### PR TITLE
refactor: update llm_ranking format to structured objects

### DIFF
--- a/lib/batches/batch1.ts
+++ b/lib/batches/batch1.ts
@@ -6,2190 +6,8195 @@ export const batch1: Question[] = [
     "qid": 1066,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ambenonium.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.8
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      }
+    ]
   },
   {
     "question_number": 2,
     "qid": 1067,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Galantamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.57
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 3,
     "qid": 1068,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Triazolam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.67
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.9
+      }
+    ]
   },
   {
     "question_number": 4,
     "qid": 1072,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Botulinum Toxin Type B.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 15.43
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.33
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.07
+      }
+    ]
   },
   {
     "question_number": 5,
     "qid": 1073,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pimavanserin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Trospium, (4) Alprazolam, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.66
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 6,
     "qid": 1074,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Trichloroethylene.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Oxybutynin, (4) Buspirone, (5) Alprazolam, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.77
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.77
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.5
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.19
+      }
+    ]
   },
   {
     "question_number": 7,
     "qid": 1076,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Afelimomab.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.21
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 8,
     "qid": 1077,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Colchicine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.86
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.71
+      }
+    ]
   },
   {
     "question_number": 9,
     "qid": 1079,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Sulthiame.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 10,
     "qid": 1080,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Brentuximab vedotin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Oxybutynin, (2) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 11,
     "qid": 1081,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tamoxifen.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.84
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.4
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.06
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 12,
     "qid": 1082,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Butaperazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.04
+      }
+    ]
   },
   {
     "question_number": 13,
     "qid": 1083,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Clonazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.96
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 14,
     "qid": 1084,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lonafarnib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      }
+    ]
   },
   {
     "question_number": 15,
     "qid": 1087,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Idelalisib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Oxybutynin, (2) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 16,
     "qid": 1089,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dichloralphenazone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.04
+      }
+    ]
   },
   {
     "question_number": 17,
     "qid": 1091,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Amantadine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.59
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 18,
     "qid": 1092,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Meperidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.89
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 19,
     "qid": 1093,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ticlopidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Oxybutynin, (5) Trospium, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.65
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.77
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.66
+      }
+    ]
   },
   {
     "question_number": 20,
     "qid": 1094,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mosapride.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.21
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.78
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 21,
     "qid": 1095,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Indalpine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.78
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 22,
     "qid": 1096,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Emapalumab.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.21
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 23,
     "qid": 1098,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Thiotepa.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 24,
     "qid": 1102,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Naltrexone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 25,
     "qid": 1105,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 15.26
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.57
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 26,
     "qid": 1106,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Salvinorin A.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Darifenacin, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 15.66
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.64
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 27,
     "qid": 1109,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pentazocine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.41
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 28,
     "qid": 1110,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Armodafinil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      }
+    ]
   },
   {
     "question_number": 29,
     "qid": 1112,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chlorthalidone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.62
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 30,
     "qid": 1113,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ethyl loflazepate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.38
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.06
+      }
+    ]
   },
   {
     "question_number": 31,
     "qid": 1114,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mefenorex.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 32,
     "qid": 1116,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Fenyramidol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.14
+      }
+    ]
   },
   {
     "question_number": 33,
     "qid": 1117,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Hydrocortisone cypionate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 34,
     "qid": 1118,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Bezitramide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 35,
     "qid": 1119,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Metreleptin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.11
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.94
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      }
+    ]
   },
   {
     "question_number": 36,
     "qid": 1121,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Idarubicin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Trospium, (2) Buspirone, (3) Darifenacin, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 37,
     "qid": 1122,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Prucalopride.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.22
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 38,
     "qid": 1123,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Deutetrabenazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 39,
     "qid": 1124,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Botulinum toxin type A.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 15.43
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.33
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.12
+      }
+    ]
   },
   {
     "question_number": 40,
     "qid": 1126,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Carbinoxamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.04
+      }
+    ]
   },
   {
     "question_number": 41,
     "qid": 1128,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pheniprazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.51
+      }
+    ]
   },
   {
     "question_number": 42,
     "qid": 1129,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Frangula purshiana bark.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 9.11
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.74
+      }
+    ]
   },
   {
     "question_number": 43,
     "qid": 1131,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Estradiol dienanthate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.36
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.81
+      }
+    ]
   },
   {
     "question_number": 44,
     "qid": 1132,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Eplerenone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.81
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 45,
     "qid": 1133,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Thalidomide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.59
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.19
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 46,
     "qid": 1135,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Beclomethasone dipropionate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.74
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.21
+      }
+    ]
   },
   {
     "question_number": 47,
     "qid": 1136,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ruxolitinib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.81
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 48,
     "qid": 1137,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Propofol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.01
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 49,
     "qid": 1139,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pegvisomant.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.45
+      }
+    ]
   },
   {
     "question_number": 50,
     "qid": 1145,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Curcumin sulfate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 51,
     "qid": 1146,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lortalamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 52,
     "qid": 1149,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Castor oil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.73
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      }
+    ]
   },
   {
     "question_number": 53,
     "qid": 1150,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lapatinib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 54,
     "qid": 1151,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Estradiol valerate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.81
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 55,
     "qid": 1152,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Doxazosin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.65
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 56,
     "qid": 1153,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Melitracen.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.9
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 57,
     "qid": 1154,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Rasagiline.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.04
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 58,
     "qid": 1155,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Indenolol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.78
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 59,
     "qid": 1160,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxyphenisatin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.8
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      }
+    ]
   },
   {
     "question_number": 60,
     "qid": 1162,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dexchlorpheniramine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.44
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 61,
     "qid": 1163,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Crizotinib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      }
+    ]
   },
   {
     "question_number": 62,
     "qid": 1165,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Aprepitant.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Oxybutynin, (2) Buspirone, (3) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.86
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.81
+      }
+    ]
   },
   {
     "question_number": 63,
     "qid": 1167,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Deflazacort.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Oxybutynin, (3) Buspirone"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 64,
     "qid": 1168,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Quazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.04
+      }
+    ]
   },
   {
     "question_number": 65,
     "qid": 1169,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cisatracurium.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 66,
     "qid": 1170,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dapagliflozin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.27
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.29
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 9.11
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.19
+      }
+    ]
   },
   {
     "question_number": 67,
     "qid": 1171,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Etanercept.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 68,
     "qid": 1172,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Levorphanol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.78
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 69,
     "qid": 1173,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Acetaminophen.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.14
+      }
+    ]
   },
   {
     "question_number": 70,
     "qid": 1175,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tizanidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.14
+      }
+    ]
   },
   {
     "question_number": 71,
     "qid": 1176,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lactulose.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Oxybutynin, (3) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.11
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.62
+      }
+    ]
   },
   {
     "question_number": 72,
     "qid": 1178,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pirbuterol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.53
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.45
+      }
+    ]
   },
   {
     "question_number": 73,
     "qid": 1179,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Deanol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.14
+      }
+    ]
   },
   {
     "question_number": 74,
     "qid": 1180,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dihydroergocristine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.45
+      }
+    ]
   },
   {
     "question_number": 75,
     "qid": 1181,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Fluoxetine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.9
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 76,
     "qid": 1182,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Thiopental.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.46
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.19
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.56
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 77,
     "qid": 1183,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pitolisant.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 78,
     "qid": 1184,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mebeverine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 79,
     "qid": 1185,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Metamfetamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.65
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 80,
     "qid": 1186,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Carbamazepine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.67
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.9
+      }
+    ]
   },
   {
     "question_number": 81,
     "qid": 1188,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Procyclidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.04
+      }
+    ]
   },
   {
     "question_number": 82,
     "qid": 1189,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Felodipine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Alprazolam, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.24
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.71
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.3
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.47
+      }
+    ]
   },
   {
     "question_number": 83,
     "qid": 1190,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Arbutamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 84,
     "qid": 1191,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tetrazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.61
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 85,
     "qid": 1193,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Distigmine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.11
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 86,
     "qid": 1194,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Hypericin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 87,
     "qid": 1195,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Betamethasone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Oxybutynin, (3) Buspirone"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 88,
     "qid": 1196,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Valbenazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 89,
     "qid": 1198,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tropisetron.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Alprazolam, (4) Desmopressin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 8.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 5.05
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 90,
     "qid": 1199,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Flunitrazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 91,
     "qid": 1200,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Orphenadrine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.21
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.78
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 92,
     "qid": 1202,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cerivastatin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 6.64
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.43
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 93,
     "qid": 1204,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pheneturide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 94,
     "qid": 1209,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Buclizine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 95,
     "qid": 1210,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Paramethasone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      }
+    ]
   },
   {
     "question_number": 96,
     "qid": 1211,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Capsaicin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.04
+      }
+    ]
   },
   {
     "question_number": 97,
     "qid": 1212,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Estazolam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Buspirone, (4) Desmopressin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.96
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.27
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 8.26
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.0
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 98,
     "qid": 1215,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lorcaserin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 99,
     "qid": 1216,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Levamlodipine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.83
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.26
+      }
+    ]
   },
   {
     "question_number": 100,
     "qid": 1217,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Bromisoval.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.64
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 101,
     "qid": 1219,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Periciazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Oxybutynin, (5) Trospium, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.4
+      }
+    ]
   },
   {
     "question_number": 102,
     "qid": 1220,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Alimemazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.14
+      }
+    ]
   },
   {
     "question_number": 103,
     "qid": 1221,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Fludiazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 104,
     "qid": 1222,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Elbasvir.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 9.11
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.74
+      }
+    ]
   },
   {
     "question_number": 105,
     "qid": 1223,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Eltoprazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Trospium, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.97
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.81
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.91
+      }
+    ]
   },
   {
     "question_number": 106,
     "qid": 1224,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pinazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.04
+      }
+    ]
   },
   {
     "question_number": 107,
     "qid": 1225,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Solabegron.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 9.16
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.76
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 5.55
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 108,
     "qid": 1227,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mephentermine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.53
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 109,
     "qid": 1228,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cilostazol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 110,
     "qid": 1230,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chlorpromazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 111,
     "qid": 1233,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Meptazinol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 112,
     "qid": 1234,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Medical Cannabis.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.21
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.78
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 113,
     "qid": 1235,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Benzilone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.04
+      }
+    ]
   },
   {
     "question_number": 114,
     "qid": 1236,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Zolazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 115,
     "qid": 1237,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Frovatriptan.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.47
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 116,
     "qid": 1238,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ritodrine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Oxybutynin, (5) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 117,
     "qid": 1239,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxcarbazepine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.76
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 118,
     "qid": 1240,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Isoflurane.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 119,
     "qid": 1242,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ixazomib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 120,
     "qid": 1244,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ifenprodil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 121,
     "qid": 1247,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Vinylbital.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.04
+      }
+    ]
   },
   {
     "question_number": 122,
     "qid": 1248,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dopamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 16.31
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.8
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 123,
     "qid": 1249,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chlormezanone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 124,
     "qid": 1250,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Prothipendyl.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.86
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 125,
     "qid": 1251,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Troleandomycin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Oxybutynin, (3) Buspirone"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 126,
     "qid": 1252,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cariprazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 127,
     "qid": 1254,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Salmeterol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 128,
     "qid": 1255,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Nelfinavir.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.21
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 129,
     "qid": 1256,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Reserpine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.84
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.17
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 130,
     "qid": 1257,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Clonidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 16.31
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.04
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 131,
     "qid": 1258,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Procaine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.47
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.78
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 132,
     "qid": 1260,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Panobinostat.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 133,
     "qid": 1261,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Diethylstilbestrol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Oxybutynin, (2) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.24
+      }
+    ]
   },
   {
     "question_number": 134,
     "qid": 1262,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Alaproclate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.78
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 135,
     "qid": 1263,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Metaxalone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 136,
     "qid": 1264,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxymorphone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.78
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 137,
     "qid": 1266,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Atomoxetine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 17.44
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.3
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.46
+      }
+    ]
   },
   {
     "question_number": 138,
     "qid": 1268,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dapsone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      }
+    ]
   },
   {
     "question_number": 139,
     "qid": 1269,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Certolizumab pegol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 8.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.08
+      }
+    ]
   },
   {
     "question_number": 140,
     "qid": 1271,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Molindone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 141,
     "qid": 1273,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Bisacodyl.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 142,
     "qid": 1274,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tubocurarine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 143,
     "qid": 1278,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Triprolidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.04
+      }
+    ]
   },
   {
     "question_number": 144,
     "qid": 1280,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Profenamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 145,
     "qid": 1281,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cyclobarbital.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.41
+      }
+    ]
   },
   {
     "question_number": 146,
     "qid": 1283,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pyrithyldione.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 147,
     "qid": 1284,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Methylcellulose.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 148,
     "qid": 1285,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Brompheniramine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 149,
     "qid": 1287,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cenobamate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.83
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 150,
     "qid": 1289,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Medifoxamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   },
   {
     "question_number": 151,
     "qid": 1290,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Atenolol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Oxybutynin, (5) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 152,
     "qid": 1292,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Fenozolone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 153,
     "qid": 1293,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Arbaclofen Placarbil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.45
+      }
+    ]
   },
   {
     "question_number": 154,
     "qid": 1294,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Romifidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 155,
     "qid": 1295,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Brexpiprazole.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 16.31
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.79
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 156,
     "qid": 1296,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Vilanterol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.65
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 157,
     "qid": 1297,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Emodin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Oxybutynin, (3) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.11
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.62
+      }
+    ]
   },
   {
     "question_number": 158,
     "qid": 1302,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Piperidolate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 159,
     "qid": 1303,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Timolol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 160,
     "qid": 1304,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dihydroergotamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 161,
     "qid": 1307,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with 2,5-Dimethoxy-4-ethylthioamphetamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.65
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 5.74
+      }
+    ]
   },
   {
     "question_number": 162,
     "qid": 1308,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chlorzoxazone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.65
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 5.74
+      }
+    ]
   },
   {
     "question_number": 163,
     "qid": 1309,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Esreboxetine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.35
+      }
+    ]
   },
   {
     "question_number": 164,
     "qid": 1311,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Clevidipine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.59
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 165,
     "qid": 1312,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Safrazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.65
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 166,
     "qid": 1314,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dichlorvos.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 167,
     "qid": 1316,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with WIN 55212-2.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 168,
     "qid": 1318,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Polycarbophil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 169,
     "qid": 1319,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Clarithromycin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.26
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 170,
     "qid": 1320,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Penthienate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.35
+      }
+    ]
   },
   {
     "question_number": 171,
     "qid": 1321,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Delavirdine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Trospium, (2) Darifenacin, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.36
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.27
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.39
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.94
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.05
+      }
+    ]
   },
   {
     "question_number": 172,
     "qid": 1322,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Hydrocortisone phosphate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 9.11
+      }
+    ]
   },
   {
     "question_number": 173,
     "qid": 1324,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Piclozotan.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 174,
     "qid": 1325,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Epinephrine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.72
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 175,
     "qid": 1327,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Halazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   },
   {
     "question_number": 176,
     "qid": 1328,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mepyramine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 17.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 12.26
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      }
+    ]
   },
   {
     "question_number": 177,
     "qid": 1329,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Thiopropazate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.69
+      }
+    ]
   },
   {
     "question_number": 178,
     "qid": 1330,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ipidacrine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 179,
     "qid": 1331,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chlorphentermine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.33
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.08
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 180,
     "qid": 1332,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Etizolam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.83
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.06
+      }
+    ]
   },
   {
     "question_number": 181,
     "qid": 1333,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Aceprometazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.41
+      }
+    ]
   },
   {
     "question_number": 182,
     "qid": 1334,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lumateperone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.38
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.06
+      }
+    ]
   },
   {
     "question_number": 183,
     "qid": 1335,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Magnesium.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.11
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 184,
     "qid": 1336,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxitriptan.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.69
+      }
+    ]
   },
   {
     "question_number": 185,
     "qid": 1337,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Levetiracetam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.64
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 186,
     "qid": 1338,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Paramethadione.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.41
+      }
+    ]
   },
   {
     "question_number": 187,
     "qid": 1341,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Neocitrullamon.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.72
+      }
+    ]
   },
   {
     "question_number": 188,
     "qid": 1342,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tiagabine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.41
+      }
+    ]
   },
   {
     "question_number": 189,
     "qid": 1345,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Isavuconazole.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.83
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 190,
     "qid": 1346,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lofexidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Alprazolam, (4) Desmopressin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 191,
     "qid": 1347,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Warfarin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.61
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 192,
     "qid": 1348,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Loratadine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 17.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      }
+    ]
   },
   {
     "question_number": 193,
     "qid": 1350,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tramazoline.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.08
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 194,
     "qid": 1351,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pentolinium.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.78
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 195,
     "qid": 1352,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tapentadol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.28
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.83
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 196,
     "qid": 1353,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Conivaptan.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.81
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 197,
     "qid": 1354,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Acetazolamide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.6
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 198,
     "qid": 1355,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxprenolol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.35
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 199,
     "qid": 1356,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Phenserine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 200,
     "qid": 1357,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxyphenonium.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.73
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.25
+      }
+    ]
   },
   {
     "question_number": 201,
     "qid": 1358,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Darifenacin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Trospium, (2) Buspirone, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.81
+      }
+    ]
   },
   {
     "question_number": 202,
     "qid": 1360,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cloxazolam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.13
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   },
   {
     "question_number": 203,
     "qid": 1361,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Iproclozide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 204,
     "qid": 1363,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Quetiapine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 205,
     "qid": 1364,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pipenzolate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 206,
     "qid": 1365,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mivacurium.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.64
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 207,
     "qid": 1366,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Amitraz.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.53
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.45
+      }
+    ]
   },
   {
     "question_number": 208,
     "qid": 1370,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Eluxadoline.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 209,
     "qid": 1371,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Phenobarbital.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Alprazolam, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.84
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.16
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.81
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.78
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 210,
     "qid": 1376,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Delorazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.38
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.06
+      }
+    ]
   },
   {
     "question_number": 211,
     "qid": 1378,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Apremilast.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.0
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 6.19
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.7
+      }
+    ]
   },
   {
     "question_number": 212,
     "qid": 1379,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Bambuterol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Oxybutynin, (5) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.07
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 213,
     "qid": 1380,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Bortezomib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Trospium, (2) Buspirone, (3) Darifenacin, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.06
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 214,
     "qid": 1381,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Alloin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 215,
     "qid": 1382,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chlorhexadol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.04
+      }
+    ]
   },
   {
     "question_number": 216,
     "qid": 1383,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lactitol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 217,
     "qid": 1384,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Sildenafil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Alprazolam, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.37
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 218,
     "qid": 1385,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Magnesium cation.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.11
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 219,
     "qid": 1386,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxazepam acetate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 220,
     "qid": 1387,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tolbutamide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.45
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.91
+      }
+    ]
   },
   {
     "question_number": 221,
     "qid": 1388,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Fluticasone furoate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      }
+    ]
   },
   {
     "question_number": 222,
     "qid": 1389,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Levocetirizine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Desmopressin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 223,
     "qid": 1391,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Trazodone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.65
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 224,
     "qid": 1392,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chloroquine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.59
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 225,
     "qid": 1393,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pyridostigmine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.49
+      }
+    ]
   },
   {
     "question_number": 226,
     "qid": 1394,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Amobarbital.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.81
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   },
   {
     "question_number": 227,
     "qid": 1395,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Trimethobenzamide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 17.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   },
   {
     "question_number": 228,
     "qid": 1396,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Eltanolone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   },
   {
     "question_number": 229,
     "qid": 1397,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Rilmenidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 230,
     "qid": 1398,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Osimertinib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 231,
     "qid": 1400,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Anisodamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.78
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 232,
     "qid": 1402,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lorpiprazole.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Oxybutynin, (5) Trospium, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.4
+      }
+    ]
   },
   {
     "question_number": 233,
     "qid": 1403,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Zonisamide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 234,
     "qid": 1405,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Propafenone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Oxybutynin, (5) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 235,
     "qid": 1406,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Methadone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 236,
     "qid": 1407,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Palmidrol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 237,
     "qid": 1410,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Almotriptan.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 8.59
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 238,
     "qid": 1411,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Propacetamol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.72
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 239,
     "qid": 1412,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Flunarizine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Trospium, (4) Alprazolam, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.52
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.7
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 240,
     "qid": 1413,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Buprenorphine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.9
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 241,
     "qid": 1414,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Safinamide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 242,
     "qid": 1415,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Trimethaphan.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.33
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.08
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 243,
     "qid": 1416,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Riociguat.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.51
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.45
+      }
+    ]
   },
   {
     "question_number": 244,
     "qid": 1417,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Fospropofol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   },
   {
     "question_number": 245,
     "qid": 1418,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dolasetron.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.75
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.7
+      }
+    ]
   },
   {
     "question_number": 246,
     "qid": 1420,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ibrutinib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Buspirone, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 15.64
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.76
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 247,
     "qid": 1422,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cevimeline.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Alprazolam, (4) Desmopressin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 248,
     "qid": 1425,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cerlapirdine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.04
+      }
+    ]
   },
   {
     "question_number": 249,
     "qid": 1426,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Terbutaline.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 250,
     "qid": 1427,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Loxapine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.47
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.78
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 251,
     "qid": 1428,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Indinavir.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 252,
     "qid": 1429,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Wortmannin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.25
+      }
+    ]
   },
   {
     "question_number": 253,
     "qid": 1431,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Isopropamide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 254,
     "qid": 1432,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Levobetaxolol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.57
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 255,
     "qid": 1433,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Doxepin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.96
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 256,
     "qid": 1434,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Theophylline.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Buspirone, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.78
+      }
+    ]
   },
   {
     "question_number": 257,
     "qid": 1435,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Sotalol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.1
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 258,
     "qid": 1436,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tetrahydrocannabivarin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 8.81
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.65
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 5.05
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 259,
     "qid": 1437,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mosapramine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.86
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 260,
     "qid": 1440,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dexfenfluramine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Trospium, (3) Darifenacin, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 261,
     "qid": 1441,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Topiramate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 262,
     "qid": 1442,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Bisoxatin.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.6
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 263,
     "qid": 1443,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tridihexethyl.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.64
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.61
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 264,
     "qid": 1444,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ergoloid mesylate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 3.63
+      }
+    ]
   },
   {
     "question_number": 265,
     "qid": 1447,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and have the curated target cholinergic receptor muscarinic 3.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 266,
     "qid": 1450,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Iproniazid.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 267,
     "qid": 1452,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ezogabine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Buspirone, (3) Darifenacin, (4) Alprazolam, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 268,
     "qid": 1453,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with SLV319.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Alprazolam, (3) Trospium, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 269,
     "qid": 1455,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Vemurafenib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 270,
     "qid": 1456,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Benzthiazide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.22
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 271,
     "qid": 1457,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dimethyltryptamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Trospium, (4) Darifenacin, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.43
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 272,
     "qid": 1458,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Fenfluramine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Trospium, (4) Alprazolam, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.27
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.08
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 273,
     "qid": 1459,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Huperzine A.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Oxybutynin, (3) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.11
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.62
+      }
+    ]
   },
   {
     "question_number": 274,
     "qid": 1461,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Iloperidone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Desmopressin, (3) Buspirone, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 8.62
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 275,
     "qid": 1462,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cinazepam.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.35
+      }
+    ]
   },
   {
     "question_number": 276,
     "qid": 1463,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Osanetant.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 277,
     "qid": 1464,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mebutamate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 278,
     "qid": 1465,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Chlorothiazide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Alprazolam, (4) Desmopressin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 279,
     "qid": 1466,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Emetonium iodide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.04
+      }
+    ]
   },
   {
     "question_number": 280,
     "qid": 1471,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Naronapride.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 5.86
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 281,
     "qid": 1473,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Medetomidine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.03
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 282,
     "qid": 1474,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Methylphosphinic Acid.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 9.11
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 8.74
+      }
+    ]
   },
   {
     "question_number": 283,
     "qid": 1475,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Rilonacept.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.53
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 284,
     "qid": 1476,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Methsuximide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.74
+      }
+    ]
   },
   {
     "question_number": 285,
     "qid": 1478,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Etoperidone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.89
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 286,
     "qid": 1480,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mesoridazine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Trospium, (4) Alprazolam, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.77
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.18
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 287,
     "qid": 1481,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Remifentanil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.89
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 288,
     "qid": 1482,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mibefradil.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Oxybutynin, (5) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 8.81
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 1.83
+      }
+    ]
   },
   {
     "question_number": 289,
     "qid": 1483,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Methscopolamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 16.73
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.25
+      }
+    ]
   },
   {
     "question_number": 290,
     "qid": 1484,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Dehydrocholic acid.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.11
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 291,
     "qid": 1486,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tacrolimus.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 4.81
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 292,
     "qid": 1487,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Phenacemide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.69
+      }
+    ]
   },
   {
     "question_number": 293,
     "qid": 1494,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Lansoprazole.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Buspirone, (3) Alprazolam, (4) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.21
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 294,
     "qid": 1495,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Etilefrine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.91
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 295,
     "qid": 1496,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Prednisolone hemisuccinate.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 296,
     "qid": 1498,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Tenamfetamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Alprazolam, (4) Darifenacin, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.52
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 5.74
+      }
+    ]
   },
   {
     "question_number": 297,
     "qid": 1499,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Mometasone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.74
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.21
+      }
+    ]
   },
   {
     "question_number": 298,
     "qid": 1500,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Oxyphencyclimine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 0.69
+      }
+    ]
   },
   {
     "question_number": 299,
     "qid": 1501,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Telaprevir.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 300,
     "qid": 1502,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Cortivazol.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 17.18
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 301,
     "qid": 1503,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Escitalopram.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Alprazolam, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 16.09
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.03
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 302,
     "qid": 1504,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Levomilnacipran.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Oxybutynin, (6) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.52
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 5.74
+      }
+    ]
   },
   {
     "question_number": 303,
     "qid": 1506,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Anagrelide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Oxybutynin, (3) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.21
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.09
+      }
+    ]
   },
   {
     "question_number": 304,
     "qid": 1507,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Ractopamine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Desmopressin, (3) Darifenacin, (4) Trospium, (5) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 16.09
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.53
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.45
+      }
+    ]
   },
   {
     "question_number": 305,
     "qid": 1508,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Palbociclib.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Oxybutynin, (2) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 306,
     "qid": 1509,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Carfentanil, C-11.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Alprazolam, (4) Oxybutynin, (5) Trospium"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 13.3
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 11.69
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 307,
     "qid": 1511,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Nitrous oxide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Desmopressin, (4) Darifenacin, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 308,
     "qid": 1512,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Quinupramine.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Desmopressin, (2) Darifenacin, (3) Buspirone, (4) Trospium, (5) Oxybutynin, (6) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.6
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 309,
     "qid": 1513,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Etoposide.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Alprazolam, (2) Buspirone, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.89
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 310,
     "qid": 1514,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Aminophenazone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 10.62
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 8.26
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 6.51
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 6.0
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 311,
     "qid": 1516,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Hydrocortisone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Alprazolam, (3) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 312,
     "qid": 1518,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Metolazone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Buspirone, (2) Darifenacin, (3) Desmopressin, (4) Alprazolam, (5) Trospium, (6) Oxybutynin"
+    "llm_ranking": [
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 7.72
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 313,
     "qid": 1519,
     "text": "List the drugs that have the side effect Syncope, are indicated for Pollakisuria, and interact with Pagoclone.",
     "category": "Abnormality of the cardiovascular system:Syncope",
-    "llm_ranking": "(1) Darifenacin, (2) Trospium, (3) Oxybutynin, (4) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Darifenacin",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Trospium",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "Oxybutynin",
+        "llm-average": 4.1
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 2.94
+      }
+    ]
   }
 ]

--- a/lib/batches/batch2.ts
+++ b/lib/batches/batch2.ts
@@ -6,2029 +6,7143 @@ export const batch2: Question[] = [
     "qid": 603,
     "text": "Which drugs interact with Colforsin, which acts on PRSS42P and has AQP9 as a compiled target?",
     "category": "Abnormality of the cardiovascular system:Acute coronary syndrome",
-    "llm_ranking": "(1) Isosorbide mononitrate, (2) Patent Blue"
+    "llm_ranking": [
+      {
+        "entity_name": "Isosorbide mononitrate",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Patent Blue",
+        "llm-average": 9.02
+      }
+    ]
   },
   {
     "question_number": 2,
     "qid": 621,
     "text": "Which drugs are curated as targeting dipeptidase 1, which is transcribed into dipeptidase 1, transcript variant 5 and is translated into DPEP1?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Cilastatin, (2) Dexamethasone"
+    "llm_ranking": [
+      {
+        "entity_name": "Cilastatin",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "Dexamethasone",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 3,
     "qid": 675,
     "text": "Which drugs are curated as targeting egl-9 family hypoxia inducible factor 1, which is transcribed into egl nine homolog 1 isoform 3 and is translated into EGLN1?",
     "category": "others:None",
-    "llm_ranking": "(1) Daprodustat, (2) Roxadustat, (3) Vadadustat"
+    "llm_ranking": [
+      {
+        "entity_name": "Daprodustat",
+        "llm-average": 15.16
+      },
+      {
+        "entity_name": "Roxadustat",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "Vadadustat",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 4,
     "qid": 727,
     "text": "Which drugs interact with Dipivefrin, which has side effect Arrhythmia and is indicated for Cataract?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Formoterol, (2) Mianserin, (3) Magnesium"
+    "llm_ranking": [
+      {
+        "entity_name": "Formoterol",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Mianserin",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Magnesium",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 5,
     "qid": 1522,
     "text": "Find all drugs that are indicated for Refractory anemia and interact with Varicella Zoster Vaccine (Recombinant), and also find the drugs that have the side effect Refractory anemia and interact with Varicella Zoster Vaccine (Recombinant).",
     "category": "Abnormality of blood and blood-forming tissues:Anemia",
-    "llm_ranking": "(1) Lenalidomide, (2) Decitabine, (3) Azacitidine, (4) Lomustine"
+    "llm_ranking": [
+      {
+        "entity_name": "Lenalidomide",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "Decitabine",
+        "llm-average": 14.58
+      },
+      {
+        "entity_name": "Azacitidine",
+        "llm-average": 13.23
+      },
+      {
+        "entity_name": "Lomustine",
+        "llm-average": 9.92
+      }
+    ]
   },
   {
     "question_number": 6,
     "qid": 1524,
     "text": "Find all drugs that interact with Pirfenidone and are indicated for Neoplasm of the pancreas, and also find the drugs that interact with Pirfenidone and have the side effect Neoplasm of the pancreas.",
     "category": "Abnormality of the digestive system:Abnormality of the pancreas",
-    "llm_ranking": "(1) Erlotinib, (2) Tamoxifen, (3) Gemcitabine, (4) Irinotecan, (5) Topotecan, (6) Paclitaxel"
+    "llm_ranking": [
+      {
+        "entity_name": "Erlotinib",
+        "llm-average": 13.23
+      },
+      {
+        "entity_name": "Tamoxifen",
+        "llm-average": 11.8
+      },
+      {
+        "entity_name": "Gemcitabine",
+        "llm-average": 10.83
+      },
+      {
+        "entity_name": "Irinotecan",
+        "llm-average": 10.07
+      },
+      {
+        "entity_name": "Paclitaxel",
+        "llm-average": 9.14
+      },
+      {
+        "entity_name": "Topotecan",
+        "llm-average": 9.08
+      }
+    ]
   },
   {
     "question_number": 7,
     "qid": 1526,
     "text": "Find all drugs that have the side effect Diabetes mellitus and interact with VTP-27999, and also find the drugs that are indicated for Diabetes mellitus and interact with VTP-27999.",
     "category": "Abnormality of metabolism/homeostasis:Abnormal glucose homeostasis",
-    "llm_ranking": "(1) Telmisartan, (2) Eprosartan, (3) Valsartan, (4) Irbesartan, (5) Losartan"
+    "llm_ranking": [
+      {
+        "entity_name": "Eprosartan",
+        "llm-average": 5.89
+      },
+      {
+        "entity_name": "Telmisartan",
+        "llm-average": 5.52
+      },
+      {
+        "entity_name": "Valsartan",
+        "llm-average": 3.76
+      },
+      {
+        "entity_name": "Irbesartan",
+        "llm-average": 3.43
+      },
+      {
+        "entity_name": "Losartan",
+        "llm-average": 1.67
+      }
+    ]
   },
   {
     "question_number": 8,
     "qid": 1527,
     "text": "Find all drugs that are indicated for Neoplasm of the liver and interact with Darifenacin, and also find the drugs that have the side effect Neoplasm of the liver and interact with Darifenacin.",
     "category": "Abnormality of the digestive system:Abnormality of the liver",
-    "llm_ranking": "(1) Zolmitriptan, (2) Cisplatin"
+    "llm_ranking": [
+      {
+        "entity_name": "Zolmitriptan",
+        "llm-average": 12.09
+      },
+      {
+        "entity_name": "Cisplatin",
+        "llm-average": 10.45
+      }
+    ]
   },
   {
     "question_number": 9,
     "qid": 455,
     "text": "Which drugs act on GPCPD1, which is associated with SAS acetyltransferase complex, and are compiled as targeting FTMT?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Iron, (2) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "Iron",
+        "llm-average": 6.45
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 2.8
+      }
+    ]
   },
   {
     "question_number": 10,
     "qid": 458,
     "text": "Which drugs act on CHRM5, which is associated with gastric acid secretion, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Rosiglitazone, (2) Pentamidine, (3) Verapamil, (4) Quinine"
+    "llm_ranking": [
+      {
+        "entity_name": "Rosiglitazone",
+        "llm-average": 16.98
+      },
+      {
+        "entity_name": "Pentamidine",
+        "llm-average": 14.07
+      },
+      {
+        "entity_name": "Verapamil",
+        "llm-average": 12.83
+      },
+      {
+        "entity_name": "Quinine",
+        "llm-average": 8.04
+      }
+    ]
   },
   {
     "question_number": 11,
     "qid": 463,
     "text": "Which drugs act on STRIP2, which is associated with sarcolemma, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.2
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 7.34
+      }
+    ]
   },
   {
     "question_number": 12,
     "qid": 467,
     "text": "Which drugs are curated as targeting potassium voltage-gated channel subfamily Q member 1, which is translated into KCNQ1, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Mefenamic acid, (2) Indomethacin"
+    "llm_ranking": [
+      {
+        "entity_name": "Mefenamic acid",
+        "llm-average": 13.27
+      },
+      {
+        "entity_name": "Indomethacin",
+        "llm-average": 9.85
+      }
+    ]
   },
   {
     "question_number": 13,
     "qid": 474,
     "text": "Which drugs are compiled as targeting ORM2, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Disopyramide, (2) Mifepristone, (3) (R)-warfarin, (4) Warfarin"
+    "llm_ranking": [
+      {
+        "entity_name": "Mifepristone",
+        "llm-average": 11.66
+      },
+      {
+        "entity_name": "Disopyramide",
+        "llm-average": 11.41
+      },
+      {
+        "entity_name": "(R)-warfarin",
+        "llm-average": 10.97
+      },
+      {
+        "entity_name": "Warfarin",
+        "llm-average": 7.37
+      }
+    ]
   },
   {
     "question_number": 14,
     "qid": 476,
     "text": "Which drugs are compiled as targeting DNAJA4, which is associated with collagen-containing extracellular matrix, and act on PRDX4?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Codeine, (2) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Codeine",
+        "llm-average": 6.91
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 6.45
+      }
+    ]
   },
   {
     "question_number": 15,
     "qid": 480,
     "text": "Which drugs act on FAR1, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Methotrexate, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Methotrexate",
+        "llm-average": 10.31
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 9.85
+      }
+    ]
   },
   {
     "question_number": 16,
     "qid": 483,
     "text": "Which drugs act on EMC10, which is associated with blood, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Methotrexate, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Methotrexate",
+        "llm-average": 12.82
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 17,
     "qid": 489,
     "text": "Which drugs act on KCTD14, which is associated with neural stem cell, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 15.6
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 8.34
+      }
+    ]
   },
   {
     "question_number": 18,
     "qid": 491,
     "text": "Which drugs are compiled as targeting SLC5A11, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Dapagliflozin, (2) Canagliflozin, (3) Balsalazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Dapagliflozin",
+        "llm-average": 12.28
+      },
+      {
+        "entity_name": "Canagliflozin",
+        "llm-average": 12.07
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 11.68
+      }
+    ]
   },
   {
     "question_number": 19,
     "qid": 494,
     "text": "Which drugs act on ALCAM, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.08
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 8.19
+      }
+    ]
   },
   {
     "question_number": 20,
     "qid": 499,
     "text": "Which drugs are compiled as targeting CYP2D6, which is associated with fruit, and act on ARMC7?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Epitestosterone, (2) Testosterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Epitestosterone",
+        "llm-average": 10.08
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 8.95
+      }
+    ]
   },
   {
     "question_number": 21,
     "qid": 502,
     "text": "Which drugs act on TRIM21, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Acetylsalicylic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 6.45
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 5.78
+      }
+    ]
   },
   {
     "question_number": 22,
     "qid": 506,
     "text": "Which drugs are compiled as targeting RHBDL2, which is associated with sarcolemma, and act on PRDX4?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Codeine, (2) Acetic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Codeine",
+        "llm-average": 6.91
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 6.45
+      }
+    ]
   },
   {
     "question_number": 23,
     "qid": 519,
     "text": "Which drugs act on SIRT4, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Resveratrol, (2) Balsalazide, (3) Valproic acid, (4) Cilostazol"
+    "llm_ranking": [
+      {
+        "entity_name": "Resveratrol",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 13.11
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 9.77
+      },
+      {
+        "entity_name": "Cilostazol",
+        "llm-average": 7.95
+      }
+    ]
   },
   {
     "question_number": 24,
     "qid": 524,
     "text": "Which drugs act on AGBL1, which is associated with sarcolemma, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Valproic acid, (2) Balsalazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.82
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 25,
     "qid": 525,
     "text": "Which drugs act on MCEE, which is associated with fruit, and are compiled as targeting FTMT?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Magnesium cation, (2) Iron"
+    "llm_ranking": [
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 8.48
+      },
+      {
+        "entity_name": "Iron",
+        "llm-average": 4.03
+      }
+    ]
   },
   {
     "question_number": 26,
     "qid": 529,
     "text": "Which drugs act on ACAT1, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Valproic acid, (2) Sulfasalazine, (3) Balsalazide, (4) Rosiglitazone, (5) Pioglitazone"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 11.54
+      },
+      {
+        "entity_name": "Sulfasalazine",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "Rosiglitazone",
+        "llm-average": 8.26
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 8.2
+      },
+      {
+        "entity_name": "Pioglitazone",
+        "llm-average": 7.63
+      }
+    ]
   },
   {
     "question_number": 27,
     "qid": 531,
     "text": "Which drugs act on DYNLRB1, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.2
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 9.05
+      }
+    ]
   },
   {
     "question_number": 28,
     "qid": 534,
     "text": "Which drugs act on DAZL, which is associated with collagen-containing extracellular matrix, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Balsalazide, (2) Valproic acid, (3) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 13.11
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 8.26
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 3.93
+      }
+    ]
   },
   {
     "question_number": 29,
     "qid": 535,
     "text": "Which drugs are compiled as targeting SLC2A2, which is associated with fruit, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Balsalazide, (2) Troglitazone, (3) Metformin, (4) Rosiglitazone"
+    "llm_ranking": [
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 17.02
+      },
+      {
+        "entity_name": "Troglitazone",
+        "llm-average": 13.88
+      },
+      {
+        "entity_name": "Metformin",
+        "llm-average": 12.82
+      },
+      {
+        "entity_name": "Rosiglitazone",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 30,
     "qid": 536,
     "text": "Which drugs are curated as targeting peroxisome proliferator activated receptor alpha, which is transcribed into peroxisome proliferator-activated receptor alpha isoform X3, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Netoglitazone, (2) Pioglitazone, (3) Iloprost"
+    "llm_ranking": [
+      {
+        "entity_name": "Netoglitazone",
+        "llm-average": 16.06
+      },
+      {
+        "entity_name": "Pioglitazone",
+        "llm-average": 12.82
+      },
+      {
+        "entity_name": "Iloprost",
+        "llm-average": 9.85
+      }
+    ]
   },
   {
     "question_number": 31,
     "qid": 544,
     "text": "Which drugs are compiled as targeting TCEA3, which is associated with fruit, and act on PRDX4?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal blood ion concentration",
-    "llm_ranking": "(1) Triethylene glycol, (2) Acetic acid, (3) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Triethylene glycol",
+        "llm-average": 11.14
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 9.79
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 6.45
+      }
+    ]
   },
   {
     "question_number": 32,
     "qid": 545,
     "text": "Which drugs act on TPD52L1, which is associated with blood, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Troglitazone, (2) Valproic acid, (3) Indomethacin, (4) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Troglitazone",
+        "llm-average": 14.57
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "Indomethacin",
+        "llm-average": 8.57
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 5.21
+      }
+    ]
   },
   {
     "question_number": 33,
     "qid": 547,
     "text": "Which drugs interact with Sumatriptan, which is curated as targeting 5-hydroxytryptamine receptor 6, and are compiled as targeting FTMT?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Lacosamide, (2) Doxycycline"
+    "llm_ranking": [
+      {
+        "entity_name": "Lacosamide",
+        "llm-average": 11.14
+      },
+      {
+        "entity_name": "Doxycycline",
+        "llm-average": 6.45
+      }
+    ]
   },
   {
     "question_number": 34,
     "qid": 552,
     "text": "Which drugs interact with Imiquimod, which has the side effect Palpitations, and have the side effect Sensory impairment?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Tacrolimus, (2) Ritonavir"
+    "llm_ranking": [
+      {
+        "entity_name": "Tacrolimus",
+        "llm-average": 15.4
+      },
+      {
+        "entity_name": "Ritonavir",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 35,
     "qid": 557,
     "text": "Which drugs are compiled as targeting CLDN11, which are compiled as interacting with DYNLT2, and act on ARMC7?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Epitestosterone, (2) Testosterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Epitestosterone",
+        "llm-average": 10.08
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 36,
     "qid": 561,
     "text": "Which drugs act on RNF144A, which is associated with sarcolemma, and interact with Phenyl aminosalicylate?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Resveratrol, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Resveratrol",
+        "llm-average": 14.09
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.83
+      }
+    ]
   },
   {
     "question_number": 37,
     "qid": 809,
     "text": "List the drugs that act on ABHD2 and interact with Oxetacaine.",
     "category": "Abnormality of the cardiovascular system:Abnormal heart valve physiology",
-    "llm_ranking": "(1) Bortezomib, (2) Cyclosporine"
+    "llm_ranking": [
+      {
+        "entity_name": "Bortezomib",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 38,
     "qid": 810,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(20:0/20:1(11Z)/20:3(5Z,8Z,11Z)) and are associated with carbohydrate metabolism disease.",
     "category": "disease of metabolism:carbohydrate metabolism disease",
-    "llm_ranking": "(1) DGAT1, (2) LPIN1, (3) GPD1, (4) GPAM, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 16.36
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 39,
     "qid": 819,
     "text": "List the drugs that interact with Quinine and have the curated target adenosine A2a receptor.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Istradefylline, (2) Grapiprant, (3) Theophylline, (4) Pentoxifylline, (5) Caffeine, (6) Oxtriphylline, (7) Aminophylline"
+    "llm_ranking": [
+      {
+        "entity_name": "Istradefylline",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "Grapiprant",
+        "llm-average": 12.95
+      },
+      {
+        "entity_name": "Theophylline",
+        "llm-average": 7.76
+      },
+      {
+        "entity_name": "Pentoxifylline",
+        "llm-average": 7.55
+      },
+      {
+        "entity_name": "Caffeine",
+        "llm-average": 6.53
+      },
+      {
+        "entity_name": "Oxtriphylline",
+        "llm-average": 6.33
+      },
+      {
+        "entity_name": "Aminophylline",
+        "llm-average": 5.87
+      }
+    ]
   },
   {
     "question_number": 40,
     "qid": 822,
     "text": "List the drugs that interact with Moricizine and have the compiled target SOCS3.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Vorinostat, (2) Tacrolimus"
+    "llm_ranking": [
+      {
+        "entity_name": "Vorinostat",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "Tacrolimus",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 41,
     "qid": 823,
     "text": "List the drugs that act on POFUT2 and interact with Phenglutarimide.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Valproic acid, (2) Magnesium cation, (3) Codeine"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 7.37
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 7.0
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 6.22
+      }
+    ]
   },
   {
     "question_number": 42,
     "qid": 824,
     "text": "List the drugs that act on SFPQ and interact with Nitroaspirin.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Carmustine, (2) Estradiol, (3) Valproic acid, (4) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Carmustine",
+        "llm-average": 13.54
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 13.02
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.12
+      }
+    ]
   },
   {
     "question_number": 43,
     "qid": 826,
     "text": "List the drugs that interact with Pegaptanib and act on SOCS6.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Estradiol, (2) Cyclosporine, (3) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.45
+      }
+    ]
   },
   {
     "question_number": 44,
     "qid": 827,
     "text": "List the drugs that act on NCOA3 and interact with Niaprazine.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Dronabinol, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Dronabinol",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.77
+      }
+    ]
   },
   {
     "question_number": 45,
     "qid": 833,
     "text": "List the proteins that are associated with VACTERL association and are compiled as interacting with IRS4.",
     "category": "VACTERL association:None",
-    "llm_ranking": "(1) PTPN11, (2) IKBKG, (3) CRKL, (4) PIK3CA, (5) PTPN18, (6) AKT1, (7) MAPK8, (8) IGF2"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPN11",
+        "llm-average": 15.76
+      },
+      {
+        "entity_name": "IKBKG",
+        "llm-average": 15.43
+      },
+      {
+        "entity_name": "PTPN18",
+        "llm-average": 13.06
+      },
+      {
+        "entity_name": "PIK3CA",
+        "llm-average": 12.82
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 10.99
+      },
+      {
+        "entity_name": "MAPK8",
+        "llm-average": 9.48
+      },
+      {
+        "entity_name": "IGF2",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 46,
     "qid": 834,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:1(13Z)/18:3(9Z,12Z,15Z)/22:1(13Z)) and are associated with kidney failure.",
     "category": "urinary system disease:kidney failure",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 10.01
+      }
+    ]
   },
   {
     "question_number": 47,
     "qid": 835,
     "text": "List the drugs that are indicated for Cerebral hemorrhage and interact with Dotarizine.",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) Phenobarbital, (2) Dihydroergotamine, (3) Citalopram, (4) Escitalopram"
+    "llm_ranking": [
+      {
+        "entity_name": "Phenobarbital",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "Dihydroergotamine",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Citalopram",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "Escitalopram",
+        "llm-average": 7.77
+      }
+    ]
   },
   {
     "question_number": 48,
     "qid": 843,
     "text": "List the drugs that interact with Sucralfate and act on RSL24D1.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Puromycin, (2) Gemcitabine, (3) Cyclosporine, (4) Balsalazide, (5) Codeine, (6) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Puromycin",
+        "llm-average": 15.24
+      },
+      {
+        "entity_name": "Gemcitabine",
+        "llm-average": 14.08
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 11.86
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 5.99
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 1.98
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 49,
     "qid": 855,
     "text": "List the drugs that interact with Typhoid vaccine and have the curated target TNF receptor superfamily member 1B.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) Dactinomycin, (2) Carbamazepine"
+    "llm_ranking": [
+      {
+        "entity_name": "Dactinomycin",
+        "llm-average": 16.09
+      },
+      {
+        "entity_name": "Carbamazepine",
+        "llm-average": 8.15
+      }
+    ]
   },
   {
     "question_number": 50,
     "qid": 869,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-18:0/i-21:0/i-17:0) and are associated with carbohydrate metabolism disease.",
     "category": "disease of metabolism:carbohydrate metabolism disease",
-    "llm_ranking": "(1) PTPMT1, (2) GPAM, (3) CRLS1, (4) AGPAT5, (5) GPD1, (6) PGS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 16.83
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 14.58
+      },
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 14.4
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 51,
     "qid": 887,
     "text": "List the drugs that act on HMGCL and interact with Dihydroetorphine.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Codeine, (2) Valproic acid, (3) Zinc, (4) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "Codeine",
+        "llm-average": 15.62
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 8.15
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 52,
     "qid": 889,
     "text": "List the proteins that act on SLC25A27 and are associated with acute cystitis.",
     "category": "urinary system disease:cystitis",
-    "llm_ranking": "(1) LEP, (2) REL"
+    "llm_ranking": [
+      {
+        "entity_name": "LEP",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "REL",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 53,
     "qid": 896,
     "text": "List the drugs that have the curated target cadherin 1 and interact with Pefloxacin.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Lapatinib, (2) Erlotinib, (3) Selumetinib"
+    "llm_ranking": [
+      {
+        "entity_name": "Lapatinib",
+        "llm-average": 14.18
+      },
+      {
+        "entity_name": "Erlotinib",
+        "llm-average": 7.0
+      },
+      {
+        "entity_name": "Selumetinib",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 54,
     "qid": 897,
     "text": "List the proteins that act on JUND and are associated with glomerulosclerosis.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) HMOX1, (2) BATF3, (3) MAPK14, (4) MAPK1, (5) CCND1"
+    "llm_ranking": [
+      {
+        "entity_name": "HMOX1",
+        "llm-average": 15.76
+      },
+      {
+        "entity_name": "BATF3",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "MAPK14",
+        "llm-average": 12.05
+      },
+      {
+        "entity_name": "MAPK1",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "CCND1",
+        "llm-average": 8.95
+      }
+    ]
   },
   {
     "question_number": 55,
     "qid": 906,
     "text": "List the proteins that are annotated in the pathway Regulation of PTEN stability and activity and are associated with sleeping sickness.",
     "category": "disease by infectious agent:parasitic protozoa infectious disease",
-    "llm_ranking": "(1) FRK, (2) CSNK2B, (3) PSMD5, (4) AKT1"
+    "llm_ranking": [
+      {
+        "entity_name": "FRK",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "CSNK2B",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "PSMD5",
+        "llm-average": 11.55
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 9.29
+      }
+    ]
   },
   {
     "question_number": 56,
     "qid": 910,
     "text": "List the drugs that have the curated target thyroid stimulating hormone subunit beta and interact with Manidipine.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Mestranol, (2) Baclofen, (3) Digoxin, (4) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Mestranol",
+        "llm-average": 14.18
+      },
+      {
+        "entity_name": "Baclofen",
+        "llm-average": 12.32
+      },
+      {
+        "entity_name": "Digoxin",
+        "llm-average": 9.16
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 57,
     "qid": 925,
     "text": "List the drugs that act on CHP2 and interact with Terfenadine.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Bepridil, (2) Tacrolimus, (3) Valproic acid, (4) Chlorothiazide, (5) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Bepridil",
+        "llm-average": 18.85
+      },
+      {
+        "entity_name": "Tacrolimus",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.3
+      },
+      {
+        "entity_name": "Chlorothiazide",
+        "llm-average": 5.95
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 1.98
+      }
+    ]
   },
   {
     "question_number": 58,
     "qid": 926,
     "text": "List the proteins that are associated with cystic kidney disease and are compiled as interacting with SMAP2.",
     "category": "urinary system disease:cystic kidney disease",
-    "llm_ranking": "(1) ARL13B, (2) AXL, (3) TMCO2, (4) SMAD9, (5) CLTC, (6) SLC2A4"
+    "llm_ranking": [
+      {
+        "entity_name": "ARL13B",
+        "llm-average": 13.54
+      },
+      {
+        "entity_name": "AXL",
+        "llm-average": 12.61
+      },
+      {
+        "entity_name": "SMAD9",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "TMCO2",
+        "llm-average": 11.46
+      },
+      {
+        "entity_name": "CLTC",
+        "llm-average": 5.72
+      },
+      {
+        "entity_name": "SLC2A4",
+        "llm-average": 5.5
+      }
+    ]
   },
   {
     "question_number": 59,
     "qid": 928,
     "text": "List the proteins that are subunits of NFAT-JUN-FOS DNA-protein complex and are associated with obstructive nephropathy.",
     "category": "urinary system disease:obstructive nephropathy",
-    "llm_ranking": "(1) FOS, (2) JUN"
+    "llm_ranking": [
+      {
+        "entity_name": "FOS",
+        "llm-average": 9.55
+      },
+      {
+        "entity_name": "JUN",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 60,
     "qid": 930,
     "text": "List the drugs that interact with Dovitinib and have the curated target MPL proto-oncogene, thrombopoietin receptor.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Eltrombopag, (2) Ruxolitinib, (3) Everolimus"
+    "llm_ranking": [
+      {
+        "entity_name": "Eltrombopag",
+        "llm-average": 17.71
+      },
+      {
+        "entity_name": "Ruxolitinib",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "Everolimus",
+        "llm-average": 8.15
+      }
+    ]
   },
   {
     "question_number": 61,
     "qid": 937,
     "text": "List the proteins that are associated with disease of cellular proliferation and are subunits of ITGA6-ITGB4-FYN complex.",
     "category": "disease:disease of cellular proliferation",
-    "llm_ranking": "(1) ITGB4, (2) ITGA6, (3) FYN"
+    "llm_ranking": [
+      {
+        "entity_name": "ITGB4",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "ITGA6",
+        "llm-average": 10.79
+      },
+      {
+        "entity_name": "FYN",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 62,
     "qid": 943,
     "text": "List the drugs that interact with Dusigitumab and act on JUN.",
     "category": "Abnormality of the cardiovascular system:None",
-    "llm_ranking": "(1) Diethylstilbestrol, (2) Estradiol, (3) Ethinylestradiol"
+    "llm_ranking": [
+      {
+        "entity_name": "Diethylstilbestrol",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "Ethinylestradiol",
+        "llm-average": 7.39
+      }
+    ]
   },
   {
     "question_number": 63,
     "qid": 946,
     "text": "List the drugs that interact with Barbexaclone and act on IL12RB2.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Cyclosporine, (2) Dronabinol"
+    "llm_ranking": [
+      {
+        "entity_name": "Dronabinol",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 64,
     "qid": 949,
     "text": "List the drugs that interact with Tolbutamide and have the curated target adrenoceptor alpha 1D.",
     "category": "Abnormality of metabolism/homeostasis:Abnormal glucose homeostasis",
-    "llm_ranking": "(1) Doxazosin, (2) Tamsulosin, (3) Epinephrine, (4) Periciazine, (5) Methotrimeprazine, (6) Cyproterone acetate, (7) Promazine"
+    "llm_ranking": [
+      {
+        "entity_name": "Doxazosin",
+        "llm-average": 16.8
+      },
+      {
+        "entity_name": "Tamsulosin",
+        "llm-average": 14.97
+      },
+      {
+        "entity_name": "Epinephrine",
+        "llm-average": 12.25
+      },
+      {
+        "entity_name": "Methotrimeprazine",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Periciazine",
+        "llm-average": 9.94
+      },
+      {
+        "entity_name": "Cyproterone acetate",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "Promazine",
+        "llm-average": 7.64
+      }
+    ]
   },
   {
     "question_number": 65,
     "qid": 964,
     "text": "List the drugs that interact with Carbenicillin and are indicated for Hypertension.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Captopril, (2) Probenecid, (3) Dinoprostone, (4) Progesterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Captopril",
+        "llm-average": 14.61
+      },
+      {
+        "entity_name": "Probenecid",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "Dinoprostone",
+        "llm-average": 8.99
+      },
+      {
+        "entity_name": "Progesterone",
+        "llm-average": 4.93
+      }
+    ]
   },
   {
     "question_number": 66,
     "qid": 965,
     "text": "List the drugs that have the side effect Stroke and interact with Formocortal.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Sunitinib, (2) Pentamidine, (3) Bromocriptine, (4) Dapagliflozin, (5) Glimepiride, (6) Rosiglitazone, (7) Pioglitazone"
+    "llm_ranking": [
+      {
+        "entity_name": "Sunitinib",
+        "llm-average": 14.63
+      },
+      {
+        "entity_name": "Pentamidine",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Bromocriptine",
+        "llm-average": 10.43
+      },
+      {
+        "entity_name": "Dapagliflozin",
+        "llm-average": 8.95
+      },
+      {
+        "entity_name": "Glimepiride",
+        "llm-average": 8.83
+      },
+      {
+        "entity_name": "Rosiglitazone",
+        "llm-average": 7.99
+      },
+      {
+        "entity_name": "Pioglitazone",
+        "llm-average": 7.09
+      }
+    ]
   },
   {
     "question_number": 67,
     "qid": 967,
     "text": "List the drugs that have the compiled target PDE3A and interact with Alogliptin.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Roflumilast, (2) Theophylline, (3) Cilostazol, (4) Milrinone, (5) Amrinone"
+    "llm_ranking": [
+      {
+        "entity_name": "Roflumilast",
+        "llm-average": 14.68
+      },
+      {
+        "entity_name": "Theophylline",
+        "llm-average": 12.89
+      },
+      {
+        "entity_name": "Cilostazol",
+        "llm-average": 12.39
+      },
+      {
+        "entity_name": "Milrinone",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Amrinone",
+        "llm-average": 8.15
+      }
+    ]
   },
   {
     "question_number": 68,
     "qid": 968,
     "text": "List the drugs that interact with Tenofovir alafenamide and have the compiled target CD69.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Sorafenib, (2) Cyclosporine, (3) Naringenin, (4) Progesterone, (5) Balsalazide, (6) Codeine"
+    "llm_ranking": [
+      {
+        "entity_name": "Sorafenib",
+        "llm-average": 17.66
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 16.29
+      },
+      {
+        "entity_name": "Naringenin",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "Progesterone",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 8.95
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 7.09
+      }
+    ]
   },
   {
     "question_number": 69,
     "qid": 974,
     "text": "List the drugs that have the compiled target ATP4A and interact with Nitrous oxide.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Lidocaine, (2) Balsalazide, (3) Nebivolol, (4) Codeine, (5) Acetylsalicylic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Lidocaine",
+        "llm-average": 8.4
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 7.81
+      },
+      {
+        "entity_name": "Nebivolol",
+        "llm-average": 7.37
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 5.95
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 5.43
+      }
+    ]
   },
   {
     "question_number": 70,
     "qid": 976,
     "text": "List the drugs that have the compiled target CREM and interact with Thyrotropin alfa.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Dextroamphetamine, (2) Norepinephrine"
+    "llm_ranking": [
+      {
+        "entity_name": "Dextroamphetamine",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "Norepinephrine",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 71,
     "qid": 984,
     "text": "List the drugs that have the curated target receptor activity modifying protein 3 and interact with Protriptyline.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Pramlintide, (2) Ethanol"
+    "llm_ranking": [
+      {
+        "entity_name": "Pramlintide",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "Ethanol",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 72,
     "qid": 986,
     "text": "List the proteins that are associated with urethral stricture and are annotated in the pathway Signaling by FGFR1 in disease.",
     "category": "urinary system disease:urethral obstruction",
-    "llm_ranking": "(1) FGF1, (2) FGF2"
+    "llm_ranking": [
+      {
+        "entity_name": "FGF1",
+        "llm-average": 13.65
+      },
+      {
+        "entity_name": "FGF2",
+        "llm-average": 13.45
+      }
+    ]
   },
   {
     "question_number": 73,
     "qid": 987,
     "text": "List the drugs that have the curated target polo like kinase 1 and interact with Parecoxib.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Inositol, (2) Safinamide"
+    "llm_ranking": [
+      {
+        "entity_name": "Inositol",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "Safinamide",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 74,
     "qid": 992,
     "text": "List the drugs that interact with Capravirine and have the curated target glyceraldehyde-3-phosphate dehydrogenase.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Tamoxifen, (2) Estradiol"
+    "llm_ranking": [
+      {
+        "entity_name": "Tamoxifen",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 75,
     "qid": 998,
     "text": "List the proteins that are associated with viral infectious disease and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:1(13Z)/20:2(11Z,14Z)/24:1(15Z)).",
     "category": "disease by infectious agent:viral infectious disease",
-    "llm_ranking": "(1) DGAT1, (2) LPIN1, (3) GPAM, (4) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 17.36
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 14.28
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.39
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 10.81
+      }
+    ]
   },
   {
     "question_number": 76,
     "qid": 1018,
     "text": "List the drugs that interact with Atracurium and act on SNX18.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Amiodarone, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Amiodarone",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 77,
     "qid": 1021,
     "text": "List the drugs that interact with Oxolinic acid and have the compiled target MYLK.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Genistein, (2) Trifluoperazine, (3) Sunitinib, (4) Guanine, (5) Calcium, (6) Ethanol"
+    "llm_ranking": [
+      {
+        "entity_name": "Genistein",
+        "llm-average": 17.84
+      },
+      {
+        "entity_name": "Trifluoperazine",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "Sunitinib",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "Guanine",
+        "llm-average": 10.89
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 6.78
+      },
+      {
+        "entity_name": "Ethanol",
+        "llm-average": 3.3
+      }
+    ]
   },
   {
     "question_number": 78,
     "qid": 1027,
     "text": "List the proteins that are associated with nephrotic syndrome and are annotated in the pathway Oxomemazine H1-Antihistamine Action.",
     "category": "urinary system disease:proteinuria",
-    "llm_ranking": "(1) NFKB1, (2) PLCB1"
+    "llm_ranking": [
+      {
+        "entity_name": "NFKB1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "PLCB1",
+        "llm-average": 15.07
+      }
+    ]
   },
   {
     "question_number": 79,
     "qid": 1028,
     "text": "List the drugs that are indicated for Thrombophlebitis and interact with Perphenazine.",
     "category": "Abnormality of blood and blood-forming tissues:Venous thrombosis",
-    "llm_ranking": "(1) (R)-warfarin, (2) Estradiol, (3) Warfarin, (4) Carbamazepine"
+    "llm_ranking": [
+      {
+        "entity_name": "(R)-warfarin",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "Warfarin",
+        "llm-average": 11.18
+      },
+      {
+        "entity_name": "Carbamazepine",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 80,
     "qid": 1029,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:2(13Z,16Z)/20:1(11Z)/22:2(13Z,16Z)) and are associated with disease of metabolism.",
     "category": "disease of metabolism:None",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPD1, (4) GPAM, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 15.3
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 14.15
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 81,
     "qid": 1036,
     "text": "List the drugs that interact with Naratriptan and have the side effect Achalasia.",
     "category": "Abnormality of the digestive system:Abnormality of digestive system physiology",
-    "llm_ranking": "(1) Trazodone, (2) Pregabalin, (3) Zaleplon, (4) Paroxetine, (5) Etodolac, (6) Naproxen"
+    "llm_ranking": [
+      {
+        "entity_name": "Trazodone",
+        "llm-average": 13.61
+      },
+      {
+        "entity_name": "Pregabalin",
+        "llm-average": 12.95
+      },
+      {
+        "entity_name": "Zaleplon",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Paroxetine",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "Etodolac",
+        "llm-average": 6.29
+      },
+      {
+        "entity_name": "Naproxen",
+        "llm-average": 3.3
+      }
+    ]
   },
   {
     "question_number": 82,
     "qid": 1038,
     "text": "List the drugs that interact with Indocyanine green acid form and act on ATP8B2.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Cyclosporine, (2) Digoxin"
+    "llm_ranking": [
+      {
+        "entity_name": "Digoxin",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 83,
     "qid": 1039,
     "text": "List the drugs that interact with Carbutamide and act on IL1RL1.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Progesterone, (2) Estradiol"
+    "llm_ranking": [
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 7.85
+      },
+      {
+        "entity_name": "Progesterone",
+        "llm-average": 7.66
+      }
+    ]
   },
   {
     "question_number": 84,
     "qid": 1040,
     "text": "List the drugs that interact with Influenza A virus A/California/7/2009 X-181 (H1N1) hemagglutinin antigen (propiolactone inactivated) and act on FLII.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) Cyclosporine, (2) Decitabine, (3) Balsalazide, (4) Acetylsalicylic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 11.54
+      },
+      {
+        "entity_name": "Decitabine",
+        "llm-average": 8.99
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 8.1
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 3.74
+      }
+    ]
   },
   {
     "question_number": 85,
     "qid": 1041,
     "text": "List the drugs that interact with Crizotinib and act on PLEKHA6.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Calcitriol, (2) Estradiol, (3) Testosterone, (4) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Calcitriol",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 2.82
+      }
+    ]
   },
   {
     "question_number": 86,
     "qid": 1042,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(14:1(9Z)/16:0/18:2(9Z,12Z)) and are associated with disease of anatomical entity.",
     "category": "disease:disease of anatomical entity",
-    "llm_ranking": "(1) DGAT1, (2) LPIN1, (3) GPD1, (4) GPAM, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 14.68
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 6.25
+      }
+    ]
   },
   {
     "question_number": 87,
     "qid": 1051,
     "text": "List the drugs that act on HIPK3 and interact with Uracil.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Sorafenib, (2) Sunitinib"
+    "llm_ranking": [
+      {
+        "entity_name": "Sorafenib",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "Sunitinib",
+        "llm-average": 11.11
+      }
+    ]
   },
   {
     "question_number": 88,
     "qid": 1057,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-14:0/i-12:0/i-16:0) and are associated with disease by infectious agent.",
     "category": "disease by infectious agent:None",
-    "llm_ranking": "(1) PTPMT1, (2) GPD1, (3) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 9.25
+      }
+    ]
   },
   {
     "question_number": 89,
     "qid": 1088,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and act on MAPK10.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) TP53, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 90,
     "qid": 1207,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are compiled as interacting with IRS4.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) MTOR, (2) CRK, (3) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 17.18
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 91,
     "qid": 1229,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are compiled as interacting with GOLPH3.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) MYC, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 14.7
+      }
+    ]
   },
   {
     "question_number": 92,
     "qid": 1245,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are compiled as interacting with FGFR3.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) JAK2, (2) TP53, (3) MYC, (4) CRK, (5) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.87
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.12
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      }
+    ]
   },
   {
     "question_number": 93,
     "qid": 1288,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are curated as interacting with HTT.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) TP53, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 94,
     "qid": 1298,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are compiled as interacting with PEAK1.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) GRB2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "GRB2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      }
+    ]
   },
   {
     "question_number": 95,
     "qid": 1305,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are compiled as interacting with TGFB1I1.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) CRK, (2) MYC"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 96,
     "qid": 1310,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are curated as interacting with CNTNAP1.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) GRB2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "GRB2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      }
+    ]
   },
   {
     "question_number": 97,
     "qid": 1373,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and act on BMX.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) TP53, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 9.86
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 98,
     "qid": 1375,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are curated as interacting with WASL.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 99,
     "qid": 1408,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are compiled as interacting with BCAR1.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) RPS6KB1, (2) GRB2, (3) JAK2, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 14.16
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.18
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 11.73
+      }
+    ]
   },
   {
     "question_number": 100,
     "qid": 1438,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and act on SHC1.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) MTOR, (2) JAK2, (3) RPS6KB1, (4) CRK, (5) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 15.56
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.29
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 101,
     "qid": 1505,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are curated as interacting with PRAG1.",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 14.33
+      }
+    ]
   },
   {
     "question_number": 102,
     "qid": 241,
     "text": "List the proteins that are acted on by Diphenoxylate, which Remifentanil interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) KCNA3, (2) OPRM1, (3) OPRD1"
+    "llm_ranking": [
+      {
+        "entity_name": "KCNA3",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "OPRM1",
+        "llm-average": 13.29
+      },
+      {
+        "entity_name": "OPRD1",
+        "llm-average": 5.65
+      }
+    ]
   },
   {
     "question_number": 103,
     "qid": 242,
     "text": "Which proteins are curated as targets of Cefdinir, which Furosemide interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) HTRA3, (2) SLC22A8, (3) SLC22A6, (4) MPO"
+    "llm_ranking": [
+      {
+        "entity_name": "HTRA3",
+        "llm-average": 14.42
+      },
+      {
+        "entity_name": "SLC22A6",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "SLC22A8",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "MPO",
+        "llm-average": 5.89
+      }
+    ]
   },
   {
     "question_number": 104,
     "qid": 243,
     "text": "List the pathways that are annotated with ADORA2B, which Vidarabine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system morphology",
-    "llm_ranking": "(1) Intracellular Signalling Through Adenosine Receptor A2b and Adenosine, (2) ADORA2B mediated anti-inflammatory cytokines production, (3) Surfactant metabolism, (4) Adenosine P1 receptors, (5) G alpha (s) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Intracellular Signalling Through Adenosine Receptor A2b and Adenosine",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
+        "llm-average": 11.66
+      },
+      {
+        "entity_name": "Surfactant metabolism",
+        "llm-average": 8.27
+      },
+      {
+        "entity_name": "Adenosine P1 receptors",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "G alpha (s) signalling events",
+        "llm-average": 4.09
+      }
+    ]
   },
   {
     "question_number": 105,
     "qid": 246,
     "text": "List the pathways that are annotated with ADRA1D, which Quinine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) G alpha (q) signalling events, (2) G alpha (12/13) signalling events, (3) Adrenoceptors"
+    "llm_ranking": [
+      {
+        "entity_name": "G alpha (q) signalling events",
+        "llm-average": 13.78
+      },
+      {
+        "entity_name": "G alpha (12/13) signalling events",
+        "llm-average": 9.12
+      },
+      {
+        "entity_name": "Adrenoceptors",
+        "llm-average": 7.4
+      }
+    ]
   },
   {
     "question_number": 106,
     "qid": 249,
     "text": "Which pathways are annotated with PTGER4, which is compiled as a target of Beraprost?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) ADORA2B mediated anti-inflammatory cytokines production, (2) G alpha (s) signalling events, (3) Prostanoid ligand receptors"
+    "llm_ranking": [
+      {
+        "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
+        "llm-average": 18.06
+      },
+      {
+        "entity_name": "G alpha (s) signalling events",
+        "llm-average": 15.54
+      },
+      {
+        "entity_name": "Prostanoid ligand receptors",
+        "llm-average": 7.33
+      }
+    ]
   },
   {
     "question_number": 107,
     "qid": 251,
     "text": "List the biological processes that are associated with CA14, which is compiled as a target of Furosemide.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) one-carbon metabolic process, (2) bicarbonate transport"
+    "llm_ranking": [
+      {
+        "entity_name": "one-carbon metabolic process",
+        "llm-average": 12.31
+      },
+      {
+        "entity_name": "bicarbonate transport",
+        "llm-average": 5.65
+      }
+    ]
   },
   {
     "question_number": 108,
     "qid": 253,
     "text": "Which proteins are acted on by TPSD1, which Perindopril acts on?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) F2RL1, (2) F2RL2, (3) F2R, (4) F2RL3"
+    "llm_ranking": [
+      {
+        "entity_name": "F2RL1",
+        "llm-average": 11.59
+      },
+      {
+        "entity_name": "F2RL2",
+        "llm-average": 9.01
+      },
+      {
+        "entity_name": "F2RL3",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "F2R",
+        "llm-average": 7.44
+      }
+    ]
   },
   {
     "question_number": 109,
     "qid": 254,
     "text": "Which pathways are annotated with CTSD, which is compiled as a target of Dexpropranolol?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) MHC class II antigen presentation, (2) Neutrophil degranulation, (3) Estrogen-dependent gene expression, (4) Metabolism of Angiotensinogen to Angiotensins, (5) Collagen degradation"
+    "llm_ranking": [
+      {
+        "entity_name": "MHC class II antigen presentation",
+        "llm-average": 19.35
+      },
+      {
+        "entity_name": "Neutrophil degranulation",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "Estrogen-dependent gene expression",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "Metabolism of Angiotensinogen to Angiotensins",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "Collagen degradation",
+        "llm-average": 6.8
+      }
+    ]
   },
   {
     "question_number": 110,
     "qid": 256,
     "text": "List the proteins that are acted on by Salicylamide, which Remifentanil interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) CARMIL2, (2) AR, (3) CARMIL1"
+    "llm_ranking": [
+      {
+        "entity_name": "CARMIL2",
+        "llm-average": 12.75
+      },
+      {
+        "entity_name": "AR",
+        "llm-average": 12.31
+      },
+      {
+        "entity_name": "CARMIL1",
+        "llm-average": 9.0
+      }
+    ]
   },
   {
     "question_number": 111,
     "qid": 257,
     "text": "List the pathways that are annotated with PLPP2, which Cocaine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Sphingolipid de novo biosynthesis, (2) Glycerolipid Metabolism, (3) Glycerol Kinase Deficiency, (4) D-Glyceric Acidura, (5) Familial Lipoprotein Lipase Deficiency"
+    "llm_ranking": [
+      {
+        "entity_name": "Sphingolipid de novo biosynthesis",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "Glycerolipid Metabolism",
+        "llm-average": 11.2
+      },
+      {
+        "entity_name": "Glycerol Kinase Deficiency",
+        "llm-average": 4.15
+      },
+      {
+        "entity_name": "D-Glyceric Acidura",
+        "llm-average": 2.07
+      },
+      {
+        "entity_name": "Familial Lipoprotein Lipase Deficiency",
+        "llm-average": 1.55
+      }
+    ]
   },
   {
     "question_number": 112,
     "qid": 259,
     "text": "List the proteins that are curated as targets of Diethylpropion, which Atomoxetine interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) SLC6A2, (2) SLC6A3, (3) ETV6, (4) AFM, (5) CHRM3"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC6A2",
+        "llm-average": 8.25
+      },
+      {
+        "entity_name": "SLC6A3",
+        "llm-average": 7.27
+      },
+      {
+        "entity_name": "AFM",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "ETV6",
+        "llm-average": 5.16
+      },
+      {
+        "entity_name": "CHRM3",
+        "llm-average": 2.73
+      }
+    ]
   },
   {
     "question_number": 113,
     "qid": 261,
     "text": "Which pathways are annotated with MTRR, which is compiled as a target of Cyclosporine?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) Defective MTRR causes methylmalonic aciduria and homocystinuria type cblE, (2) Defective MTR causes methylmalonic aciduria and homocystinuria type cblG, (3) Cobalamin (Cbl, vitamin B12) transport and metabolism, (4) Methylation, (5) Sulfur amino acid metabolism"
+    "llm_ranking": [
+      {
+        "entity_name": "Defective MTRR causes methylmalonic aciduria and homocystinuria type cblE",
+        "llm-average": 15.87
+      },
+      {
+        "entity_name": "Defective MTR causes methylmalonic aciduria and homocystinuria type cblG",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Cobalamin (Cbl, vitamin B12) transport and metabolism",
+        "llm-average": 10.63
+      },
+      {
+        "entity_name": "Methylation",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Sulfur amino acid metabolism",
+        "llm-average": 5.76
+      }
+    ]
   },
   {
     "question_number": 114,
     "qid": 262,
     "text": "Which genes are curated as targets of Aprepitant, which Estradiol valerate interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) sepiapterin reductase, (2) tachykinin receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "sepiapterin reductase",
+        "llm-average": 13.9
+      },
+      {
+        "entity_name": "tachykinin receptor 1",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 115,
     "qid": 263,
     "text": "List the pathways that are annotated with HTR1B, which Octreotide acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Serotonin receptors, (2) G alpha (i) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Serotonin receptors",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 116,
     "qid": 269,
     "text": "Which proteins are acted on by Clofarabine, which Estradiol valerate interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) BCL2L14, (2) BCL2A1, (3) BOK, (4) MCL1, (5) BCL2L1, (6) POLA1, (7) RRM1, (8) DCK"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2L14",
+        "llm-average": 11.06
+      },
+      {
+        "entity_name": "BCL2A1",
+        "llm-average": 9.89
+      },
+      {
+        "entity_name": "MCL1",
+        "llm-average": 9.36
+      },
+      {
+        "entity_name": "BOK",
+        "llm-average": 9.3
+      },
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 8.13
+      },
+      {
+        "entity_name": "POLA1",
+        "llm-average": 6.55
+      },
+      {
+        "entity_name": "RRM1",
+        "llm-average": 5.31
+      },
+      {
+        "entity_name": "DCK",
+        "llm-average": 4.41
+      }
+    ]
   },
   {
     "question_number": 117,
     "qid": 271,
     "text": "Which pathways are annotated with GRHPR, which is compiled as a target of Pyruvaldehyde?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Primary Hyperoxaluria II, PH2, (2) Pyruvate Dehydrogenase Complex Deficiency, (3) Glyoxylate metabolism and glycine degradation, (4) Leigh Syndrome, (5) Pyruvate Decarboxylase E1 Component Deficiency (PDHE1 Deficiency), (6) Pyruvate Kinase Deficiency, (7) Pyruvate Metabolism"
+    "llm_ranking": [
+      {
+        "entity_name": "Primary Hyperoxaluria II, PH2",
+        "llm-average": 18.63
+      },
+      {
+        "entity_name": "Pyruvate Dehydrogenase Complex Deficiency",
+        "llm-average": 15.98
+      },
+      {
+        "entity_name": "Glyoxylate metabolism and glycine degradation",
+        "llm-average": 12.56
+      },
+      {
+        "entity_name": "Leigh Syndrome",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Pyruvate Decarboxylase E1 Component Deficiency (PDHE1 Deficiency)",
+        "llm-average": 9.32
+      },
+      {
+        "entity_name": "Pyruvate Kinase Deficiency",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Pyruvate Metabolism",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 118,
     "qid": 274,
     "text": "List the pathways that are annotated with CASR, which is compiled as a target of Quinine.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) G alpha (q) signalling events, (2) G alpha (i) signalling events, (3) Class C/3 (Metabotropic glutamate/pheromone receptors)"
+    "llm_ranking": [
+      {
+        "entity_name": "G alpha (q) signalling events",
+        "llm-average": 14.89
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Class C/3 (Metabotropic glutamate/pheromone receptors)",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 119,
     "qid": 277,
     "text": "List the proteins that are acted on by Diethylpropion, which Nabumetone interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) SLC6A3, (2) SLC6A2"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC6A2",
+        "llm-average": 11.08
+      },
+      {
+        "entity_name": "SLC6A3",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 120,
     "qid": 278,
     "text": "List the proteins that are curated as targets of Nadolol, which Atomoxetine interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) RYR2, (2) ADRB3, (3) AKAP10, (4) ADRB1, (5) FKBP1B, (6) ADRB2, (7) REN"
+    "llm_ranking": [
+      {
+        "entity_name": "RYR2",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "ADRB1",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "ADRB3",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "ADRB2",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "FKBP1B",
+        "llm-average": 8.21
+      },
+      {
+        "entity_name": "AKAP10",
+        "llm-average": 7.3
+      },
+      {
+        "entity_name": "REN",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 121,
     "qid": 283,
     "text": "Which proteins are curated as targets of Anagrelide, which Remifentanil interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) GATA1, (2) PDE3A, (3) TLN1, (4) JAK2, (5) THPO, (6) MPL"
+    "llm_ranking": [
+      {
+        "entity_name": "GATA1",
+        "llm-average": 18.32
+      },
+      {
+        "entity_name": "PDE3A",
+        "llm-average": 17.08
+      },
+      {
+        "entity_name": "TLN1",
+        "llm-average": 11.84
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 11.47
+      },
+      {
+        "entity_name": "THPO",
+        "llm-average": 10.41
+      },
+      {
+        "entity_name": "MPL",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 122,
     "qid": 284,
     "text": "List the pathways that are annotated with TAS2R30, which is compiled as a target of Colchicine.",
     "category": "Abnormality of the digestive system:Abdominal symptom",
-    "llm_ranking": "(1) G alpha (i) signalling events, (2) Class C/3 (Metabotropic glutamate/pheromone receptors)"
+    "llm_ranking": [
+      {
+        "entity_name": "Class C/3 (Metabotropic glutamate/pheromone receptors)",
+        "llm-average": 6.84
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 4.78
+      }
+    ]
   },
   {
     "question_number": 123,
     "qid": 286,
     "text": "List the proteins that are curated as targets of Methadyl acetate, which Furosemide interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) OPRD1, (2) OPRM1, (3) CHRNA3, (4) CHRNB4, (5) CYP3A4, (6) KCNH2, (7) CYP3A5"
+    "llm_ranking": [
+      {
+        "entity_name": "OPRD1",
+        "llm-average": 15.22
+      },
+      {
+        "entity_name": "OPRM1",
+        "llm-average": 12.65
+      },
+      {
+        "entity_name": "CHRNA3",
+        "llm-average": 8.87
+      },
+      {
+        "entity_name": "CYP3A4",
+        "llm-average": 7.4
+      },
+      {
+        "entity_name": "CHRNB4",
+        "llm-average": 6.54
+      },
+      {
+        "entity_name": "CYP3A5",
+        "llm-average": 5.79
+      },
+      {
+        "entity_name": "KCNH2",
+        "llm-average": 5.65
+      }
+    ]
   },
   {
     "question_number": 124,
     "qid": 288,
     "text": "Which genes are curated as targets of Lorlatinib, which Esomeprazole interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) ALK receptor tyrosine kinase, (2) EMAP like 4, (3) ROS proto-oncogene 1, receptor tyrosine kinase, (4) tumor protein p53, (5) nucleophosmin 1, (6) RB transcriptional corepressor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "ALK receptor tyrosine kinase",
+        "llm-average": 18.45
+      },
+      {
+        "entity_name": "EMAP like 4",
+        "llm-average": 14.95
+      },
+      {
+        "entity_name": "ROS proto-oncogene 1, receptor tyrosine kinase",
+        "llm-average": 14.05
+      },
+      {
+        "entity_name": "tumor protein p53",
+        "llm-average": 7.59
+      },
+      {
+        "entity_name": "nucleophosmin 1",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "RB transcriptional corepressor 1",
+        "llm-average": 3.31
+      }
+    ]
   },
   {
     "question_number": 125,
     "qid": 289,
     "text": "List the proteins that are curated as targets of Tapentadol, which Furosemide interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) OPRK1, (2) OPRD1, (3) OPRM1, (4) SLC6A4, (5) HTR3A, (6) SLC6A2"
+    "llm_ranking": [
+      {
+        "entity_name": "OPRK1",
+        "llm-average": 13.42
+      },
+      {
+        "entity_name": "OPRD1",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "OPRM1",
+        "llm-average": 10.33
+      },
+      {
+        "entity_name": "HTR3A",
+        "llm-average": 6.29
+      },
+      {
+        "entity_name": "SLC6A4",
+        "llm-average": 5.89
+      },
+      {
+        "entity_name": "SLC6A2",
+        "llm-average": 5.13
+      }
+    ]
   },
   {
     "question_number": 126,
     "qid": 291,
     "text": "List the pathways that are annotated with PABPC1, which is compiled as a target of Genistein.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) L13a-mediated translational silencing of Ceruloplasmin expression, (2) AUF1 (hnRNP D0) binds and destabilizes mRNA, (3) Deadenylation of mRNA, (4) Nonsense Mediated Decay (NMD) independent of the Exon Junction Complex (EJC), (5) Nonsense Mediated Decay (NMD) enhanced by the Exon Junction Complex (EJC), (6) Regulation of expression of SLITs and ROBOs, (7) Translation initiation complex formation"
+    "llm_ranking": [
+      {
+        "entity_name": "L13a-mediated translational silencing of Ceruloplasmin expression",
+        "llm-average": 17.8
+      },
+      {
+        "entity_name": "Deadenylation of mRNA",
+        "llm-average": 12.77
+      },
+      {
+        "entity_name": "AUF1 (hnRNP D0) binds and destabilizes mRNA",
+        "llm-average": 12.57
+      },
+      {
+        "entity_name": "Nonsense Mediated Decay (NMD) independent of the Exon Junction Complex (EJC)",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Nonsense Mediated Decay (NMD) enhanced by the Exon Junction Complex (EJC)",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "Regulation of expression of SLITs and ROBOs",
+        "llm-average": 9.76
+      },
+      {
+        "entity_name": "Translation initiation complex formation",
+        "llm-average": 9.26
+      }
+    ]
   },
   {
     "question_number": 127,
     "qid": 294,
     "text": "Which biological processes are associated with GPR22 that Beraprost acts on?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) cell projection organization, (2) G protein-coupled receptor signaling pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "G protein-coupled receptor signaling pathway",
+        "llm-average": 8.18
+      },
+      {
+        "entity_name": "cell projection organization",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 128,
     "qid": 295,
     "text": "Which pathways are annotated with TAS2R39, which is compiled as a target of Vidarabine?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system morphology",
-    "llm_ranking": "(1) Class C/3 (Metabotropic glutamate/pheromone receptors), (2) G alpha (i) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "Class C/3 (Metabotropic glutamate/pheromone receptors)",
+        "llm-average": 4.21
+      }
+    ]
   },
   {
     "question_number": 129,
     "qid": 296,
     "text": "List the biological processes that are associated with PRSS37, which Spermine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) positive regulation of acrosome reaction, (2) positive regulation of fertilization, (3) binding of sperm to zona pellucida, (4) regulation of protein processing, (5) cell migration, (6) protein maturation, (7) proteolysis"
+    "llm_ranking": [
+      {
+        "entity_name": "positive regulation of acrosome reaction",
+        "llm-average": 19.35
+      },
+      {
+        "entity_name": "positive regulation of fertilization",
+        "llm-average": 15.54
+      },
+      {
+        "entity_name": "binding of sperm to zona pellucida",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "cell migration",
+        "llm-average": 8.34
+      },
+      {
+        "entity_name": "regulation of protein processing",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "protein maturation",
+        "llm-average": 6.35
+      },
+      {
+        "entity_name": "proteolysis",
+        "llm-average": 5.69
+      }
+    ]
   },
   {
     "question_number": 130,
     "qid": 299,
     "text": "Which pathways are annotated with CES1, which Cocaine acts on?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Metabolism of Angiotensinogen to Angiotensins, (2) Heroin Metabolism Pathway, (3) Mycophenolic Acid Metabolism Pathway, (4) Irinotecan Action Pathway, (5) Irinotecan Metabolism Pathway, (6) Capecitabine Metabolism Pathway, (7) Capecitabine Action Pathway, (8) Phase I - Functionalization of compounds"
+    "llm_ranking": [
+      {
+        "entity_name": "Metabolism of Angiotensinogen to Angiotensins",
+        "llm-average": 13.65
+      },
+      {
+        "entity_name": "Heroin Metabolism Pathway",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "Mycophenolic Acid Metabolism Pathway",
+        "llm-average": 6.72
+      },
+      {
+        "entity_name": "Irinotecan Action Pathway",
+        "llm-average": 5.89
+      },
+      {
+        "entity_name": "Irinotecan Metabolism Pathway",
+        "llm-average": 5.69
+      },
+      {
+        "entity_name": "Capecitabine Metabolism Pathway",
+        "llm-average": 4.85
+      },
+      {
+        "entity_name": "Capecitabine Action Pathway",
+        "llm-average": 4.72
+      },
+      {
+        "entity_name": "Phase I - Functionalization of compounds",
+        "llm-average": 4.52
+      }
+    ]
   },
   {
     "question_number": 131,
     "qid": 300,
     "text": "List the proteins that are acted on by Palonosetron, which Furosemide interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) HTR3B, (2) HTR3A, (3) HTR3C, (4) HTR3D"
+    "llm_ranking": [
+      {
+        "entity_name": "HTR3B",
+        "llm-average": 9.92
+      },
+      {
+        "entity_name": "HTR3A",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "HTR3C",
+        "llm-average": 8.38
+      },
+      {
+        "entity_name": "HTR3D",
+        "llm-average": 5.38
+      }
+    ]
   },
   {
     "question_number": 132,
     "qid": 308,
     "text": "Which proteins are curated as targets of Diethylpropion, which Nabumetone interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) AFM, (2) SLC6A3, (3) CHRM3, (4) ETV6, (5) SLC6A2"
+    "llm_ranking": [
+      {
+        "entity_name": "AFM",
+        "llm-average": 11.46
+      },
+      {
+        "entity_name": "SLC6A3",
+        "llm-average": 10.32
+      },
+      {
+        "entity_name": "CHRM3",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "SLC6A2",
+        "llm-average": 8.31
+      },
+      {
+        "entity_name": "ETV6",
+        "llm-average": 7.44
+      }
+    ]
   },
   {
     "question_number": 133,
     "qid": 313,
     "text": "Which pathways are annotated with MAOB, which is compiled as a target of Spermine?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Biogenic amines are oxidatively deaminated to aldehydes by MAOA and MAOB, (2) Citalopram Metabolism Pathway, (3) Citalopram Action Pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Biogenic amines are oxidatively deaminated to aldehydes by MAOA and MAOB",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "Citalopram Metabolism Pathway",
+        "llm-average": 4.14
+      },
+      {
+        "entity_name": "Citalopram Action Pathway",
+        "llm-average": 1.55
+      }
+    ]
   },
   {
     "question_number": 134,
     "qid": 314,
     "text": "List the proteins that are acted on by Anagrelide, which Remifentanil interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) PDE3A, (2) GATA1, (3) P2RY12, (4) PDGFB, (5) TGFB1"
+    "llm_ranking": [
+      {
+        "entity_name": "PDE3A",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "GATA1",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "P2RY12",
+        "llm-average": 10.68
+      },
+      {
+        "entity_name": "PDGFB",
+        "llm-average": 8.34
+      },
+      {
+        "entity_name": "TGFB1",
+        "llm-average": 4.46
+      }
+    ]
   },
   {
     "question_number": 135,
     "qid": 315,
     "text": "Which proteins are curated as targets of Cefoxitin, which Nabumetone interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal heart morphology",
-    "llm_ranking": "(1) SELP, (2) LACTB, (3) YARS2, (4) LACTBL1"
+    "llm_ranking": [
+      {
+        "entity_name": "LACTB",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "SELP",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "YARS2",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "LACTBL1",
+        "llm-average": 5.89
+      }
+    ]
   },
   {
     "question_number": 136,
     "qid": 316,
     "text": "Which pathways are annotated with NPY1R, which Octreotide acts on?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) G alpha (i) signalling events, (2) Peptide ligand-binding receptors"
+    "llm_ranking": [
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Peptide ligand-binding receptors",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 137,
     "qid": 318,
     "text": "List the pathways that are annotated with RAB6A, which is compiled as a target of Risedronic acid.",
     "category": "Abnormality of the digestive system:Abnormality of the gastrointestinal tract",
-    "llm_ranking": "(1) COPI-independent Golgi-to-ER retrograde traffic, (2) Pre-NOTCH Processing in Golgi, (3) Retrograde transport at the Trans-Golgi-Network, (4) Neutrophil degranulation, (5) RAB geranylgeranylation, (6) RAB GEFs exchange GTP for GDP on RABs, (7) TBC/RABGAPs"
+    "llm_ranking": [
+      {
+        "entity_name": "COPI-independent Golgi-to-ER retrograde traffic",
+        "llm-average": 14.56
+      },
+      {
+        "entity_name": "Retrograde transport at the Trans-Golgi-Network",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "Pre-NOTCH Processing in Golgi",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "Neutrophil degranulation",
+        "llm-average": 10.67
+      },
+      {
+        "entity_name": "RAB geranylgeranylation",
+        "llm-average": 6.74
+      },
+      {
+        "entity_name": "RAB GEFs exchange GTP for GDP on RABs",
+        "llm-average": 5.65
+      },
+      {
+        "entity_name": "TBC/RABGAPs",
+        "llm-average": 4.87
+      }
+    ]
   },
   {
     "question_number": 138,
     "qid": 326,
     "text": "Which proteins are curated as targets of Cefuroxime, which Esomeprazole interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) XRCC2, (2) IL10"
+    "llm_ranking": [
+      {
+        "entity_name": "IL10",
+        "llm-average": 15.54
+      },
+      {
+        "entity_name": "XRCC2",
+        "llm-average": 14.04
+      }
+    ]
   },
   {
     "question_number": 139,
     "qid": 330,
     "text": "Which proteins are acted on by Pipecuronium, which Furosemide interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) CHRNA2, (2) CHRM1, (3) CHRM5, (4) CHRM3, (5) CHRM4"
+    "llm_ranking": [
+      {
+        "entity_name": "CHRM1",
+        "llm-average": 6.74
+      },
+      {
+        "entity_name": "CHRM5",
+        "llm-average": 6.22
+      },
+      {
+        "entity_name": "CHRM3",
+        "llm-average": 5.69
+      },
+      {
+        "entity_name": "CHRM4",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "CHRNA2",
+        "llm-average": 5.16
+      }
+    ]
   },
   {
     "question_number": 140,
     "qid": 331,
     "text": "List the pathways that are annotated with CA4, which Spermine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Reversible hydration of carbon dioxide, (2) Erythrocytes take up carbon dioxide and release oxygen, (3) Erythrocytes take up oxygen and release carbon dioxide"
+    "llm_ranking": [
+      {
+        "entity_name": "Reversible hydration of carbon dioxide",
+        "llm-average": 12.31
+      },
+      {
+        "entity_name": "Erythrocytes take up carbon dioxide and release oxygen",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Erythrocytes take up oxygen and release carbon dioxide",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 141,
     "qid": 337,
     "text": "List the pathways that are annotated with PYY, which Vidarabine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system morphology",
-    "llm_ranking": "(1) G alpha (i) signalling events, (2) Peptide ligand-binding receptors"
+    "llm_ranking": [
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 14.17
+      },
+      {
+        "entity_name": "Peptide ligand-binding receptors",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 142,
     "qid": 338,
     "text": "List the pathways that are annotated with KLK13, which Perindopril acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Regulation of Insulin-like Growth Factor (IGF) transport and uptake by Insulin-like Growth Factor Binding Proteins (IGFBPs), (2) Formation of the cornified envelope"
+    "llm_ranking": [
+      {
+        "entity_name": "Formation of the cornified envelope",
+        "llm-average": 12.1
+      },
+      {
+        "entity_name": "Regulation of Insulin-like Growth Factor (IGF) transport and uptake by Insulin-like Growth Factor Binding Proteins (IGFBPs)",
+        "llm-average": 10.67
+      }
+    ]
   },
   {
     "question_number": 143,
     "qid": 339,
     "text": "List the pathways that are annotated with CTRB1, which Spermine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Activation of Matrix Metalloproteinases, (2) Cobalamin (Cbl, vitamin B12) transport and metabolism"
+    "llm_ranking": [
+      {
+        "entity_name": "Activation of Matrix Metalloproteinases",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Cobalamin (Cbl, vitamin B12) transport and metabolism",
+        "llm-average": 10.28
+      }
+    ]
   },
   {
     "question_number": 144,
     "qid": 344,
     "text": "List the pathways that are annotated with SSTR1, which Vidarabine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system morphology",
-    "llm_ranking": "(1) Peptide ligand-binding receptors, (2) G alpha (i) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Peptide ligand-binding receptors",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 145,
     "qid": 345,
     "text": "List the proteins that are curated as targets of Diphenoxylate, which Remifentanil interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) OPRD1, (2) OPRM1"
+    "llm_ranking": [
+      {
+        "entity_name": "OPRM1",
+        "llm-average": 6.3
+      },
+      {
+        "entity_name": "OPRD1",
+        "llm-average": 5.65
+      }
+    ]
   },
   {
     "question_number": 146,
     "qid": 349,
     "text": "List the biological processes that are associated with PPIG, which is compiled as a target of Phenobarbital.",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) protein peptidyl-prolyl isomerization, (2) protein folding, (3) RNA splicing"
+    "llm_ranking": [
+      {
+        "entity_name": "protein peptidyl-prolyl isomerization",
+        "llm-average": 18.45
+      },
+      {
+        "entity_name": "protein folding",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "RNA splicing",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 147,
     "qid": 350,
     "text": "List the proteins that are curated as targets of Gentamicin C1a, which Atomoxetine interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) SLC5A2, (2) SLC5A1"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC5A2",
+        "llm-average": 5.89
+      },
+      {
+        "entity_name": "SLC5A1",
+        "llm-average": 5.57
+      }
+    ]
   },
   {
     "question_number": 148,
     "qid": 353,
     "text": "Which pathways are annotated with CXCL9, which is compiled as a target of Quinine?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Chemokine receptors bind chemokines, (2) G alpha (i) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Chemokine receptors bind chemokines",
+        "llm-average": 14.17
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 149,
     "qid": 354,
     "text": "List the proteins that are curated as targets of Sulfaphenazole, which Estradiol valerate interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) PPIG, (2) CYP2C9, (3) CYP2C8, (4) CYP2C19, (5) CYP1A2, (6) CYP3A4"
+    "llm_ranking": [
+      {
+        "entity_name": "PPIG",
+        "llm-average": 12.9
+      },
+      {
+        "entity_name": "CYP2C9",
+        "llm-average": 11.28
+      },
+      {
+        "entity_name": "CYP2C8",
+        "llm-average": 6.73
+      },
+      {
+        "entity_name": "CYP2C19",
+        "llm-average": 6.29
+      },
+      {
+        "entity_name": "CYP1A2",
+        "llm-average": 5.43
+      },
+      {
+        "entity_name": "CYP3A4",
+        "llm-average": 4.78
+      }
+    ]
   },
   {
     "question_number": 150,
     "qid": 356,
     "text": "List the pathways that are annotated with CAT, which is compiled as a target of Cyclosporine.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) FOXO-mediated transcription of oxidative stress, metabolic and neuronal genes, (2) Detoxification of Reactive Oxygen Species, (3) Neutrophil degranulation, (4) Disulfiram Action Pathway, (5) Degradation of Superoxides, (6) Peroxisomal protein import, (7) Tryptophan Metabolism, (8) Ethanol Degradation"
+    "llm_ranking": [
+      {
+        "entity_name": "FOXO-mediated transcription of oxidative stress, metabolic and neuronal genes",
+        "llm-average": 18.06
+      },
+      {
+        "entity_name": "Detoxification of Reactive Oxygen Species",
+        "llm-average": 11.4
+      },
+      {
+        "entity_name": "Neutrophil degranulation",
+        "llm-average": 9.57
+      },
+      {
+        "entity_name": "Degradation of Superoxides",
+        "llm-average": 7.05
+      },
+      {
+        "entity_name": "Disulfiram Action Pathway",
+        "llm-average": 6.46
+      },
+      {
+        "entity_name": "Peroxisomal protein import",
+        "llm-average": 5.77
+      },
+      {
+        "entity_name": "Tryptophan Metabolism",
+        "llm-average": 5.26
+      },
+      {
+        "entity_name": "Ethanol Degradation",
+        "llm-average": 3.69
+      }
+    ]
   },
   {
     "question_number": 151,
     "qid": 357,
     "text": "List the proteins that are acted on by Salicylamide, which Estradiol valerate interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) CARMIL1, (2) CARMIL2, (3) AR"
+    "llm_ranking": [
+      {
+        "entity_name": "CARMIL1",
+        "llm-average": 10.16
+      },
+      {
+        "entity_name": "CARMIL2",
+        "llm-average": 8.99
+      },
+      {
+        "entity_name": "AR",
+        "llm-average": 8.18
+      }
+    ]
   },
   {
     "question_number": 152,
     "qid": 358,
     "text": "Which pathways are annotated with POR, which is compiled as a target of Phenobarbital?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) Cytochrome P450 - arranged by substrate type, (2) Doxorubicin Metabolism Pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Cytochrome P450 - arranged by substrate type",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "Doxorubicin Metabolism Pathway",
+        "llm-average": 4.78
+      }
+    ]
   },
   {
     "question_number": 153,
     "qid": 359,
     "text": "Which pathways are annotated with CCL2, which is compiled as a target of Cocaine?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) ATF4 activates genes in response to endoplasmic reticulum  stress, (2) Interleukin-10 signaling, (3) Chemokine receptors bind chemokines, (4) Interleukin-4 and Interleukin-13 signaling"
+    "llm_ranking": [
+      {
+        "entity_name": "ATF4 activates genes in response to endoplasmic reticulum  stress",
+        "llm-average": 13.51
+      },
+      {
+        "entity_name": "Chemokine receptors bind chemokines",
+        "llm-average": 12.44
+      },
+      {
+        "entity_name": "Interleukin-10 signaling",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Interleukin-4 and Interleukin-13 signaling",
+        "llm-average": 9.77
+      }
+    ]
   },
   {
     "question_number": 154,
     "qid": 362,
     "text": "Which pathways are annotated with UGT1A6, which is compiled as a target of Phenobarbital?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) Acetaminophen Metabolism Pathway, (2) Glucuronidation, (3) Phenytoin (Antiarrhythmic) Action Pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Acetaminophen Metabolism Pathway",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "Glucuronidation",
+        "llm-average": 11.59
+      },
+      {
+        "entity_name": "Phenytoin (Antiarrhythmic) Action Pathway",
+        "llm-average": 5.89
+      }
+    ]
   },
   {
     "question_number": 155,
     "qid": 365,
     "text": "Which proteins are curated as targets of Atracurium besylate, which Remifentanil interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) HEXB, (2) CHRNA2, (3) BCHE"
+    "llm_ranking": [
+      {
+        "entity_name": "HEXB",
+        "llm-average": 12.53
+      },
+      {
+        "entity_name": "CHRNA2",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "BCHE",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 156,
     "qid": 368,
     "text": "Which proteins are curated as targets of Benazepril, which Furosemide interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) REN, (2) ACE"
+    "llm_ranking": [
+      {
+        "entity_name": "ACE",
+        "llm-average": 10.24
+      },
+      {
+        "entity_name": "REN",
+        "llm-average": 9.26
+      }
+    ]
   },
   {
     "question_number": 157,
     "qid": 370,
     "text": "Which pathways are annotated with EGR1, which is compiled as a target of Dexpropranolol?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Regulation of PTEN gene transcription, (2) NGF-stimulated transcription, (3) Interferon alpha/beta signaling, (4) GnRH Signaling Pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Regulation of PTEN gene transcription",
+        "llm-average": 14.97
+      },
+      {
+        "entity_name": "Interferon alpha/beta signaling",
+        "llm-average": 13.9
+      },
+      {
+        "entity_name": "NGF-stimulated transcription",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "GnRH Signaling Pathway",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 158,
     "qid": 374,
     "text": "List the pathways that are annotated with NPY4R, which Beraprost acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Peptide ligand-binding receptors, (2) G alpha (i) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Peptide ligand-binding receptors",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 159,
     "qid": 375,
     "text": "Which proteins are curated as targets of Fenproporex, which Selenious acid interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) CYP2D6, (2) CYP2B6, (3) CYP3A4, (4) CYP1A2"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP2D6",
+        "llm-average": 7.97
+      },
+      {
+        "entity_name": "CYP3A4",
+        "llm-average": 7.46
+      },
+      {
+        "entity_name": "CYP2B6",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "CYP1A2",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 160,
     "qid": 379,
     "text": "List the proteins that are curated as targets of Oxacillin, which Selenious acid interacts with.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) SLC15A1, (2) SLC15A2, (3) CAT"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC15A1",
+        "llm-average": 10.75
+      },
+      {
+        "entity_name": "SLC15A2",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "CAT",
+        "llm-average": 8.31
+      }
+    ]
   },
   {
     "question_number": 161,
     "qid": 383,
     "text": "Which proteins are curated as targets of Hydromorphone, which Trametinib interacts with?",
     "category": "Abnormality of the cardiovascular system:Acute coronary syndrome",
-    "llm_ranking": "(1) VEZF1, (2) SPATA2L, (3) OPRD1, (4) OPRM1, (5) OPRK1, (6) NNT, (7) CYP2C19, (8) CYP2D6"
+    "llm_ranking": [
+      {
+        "entity_name": "OPRD1",
+        "llm-average": 9.6
+      },
+      {
+        "entity_name": "VEZF1",
+        "llm-average": 8.85
+      },
+      {
+        "entity_name": "OPRM1",
+        "llm-average": 8.77
+      },
+      {
+        "entity_name": "OPRK1",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "SPATA2L",
+        "llm-average": 7.89
+      },
+      {
+        "entity_name": "CYP2C19",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "NNT",
+        "llm-average": 5.16
+      },
+      {
+        "entity_name": "CYP2D6",
+        "llm-average": 4.48
+      }
+    ]
   },
   {
     "question_number": 162,
     "qid": 386,
     "text": "List the biological processes that are associated with GEM, which Cocaine acts on.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) negative regulation of high voltage-gated calcium channel activity, (2) metaphase plate congression, (3) chromosome organization, (4) cell surface receptor signaling pathway, (5) mitotic cell cycle, (6) signal transduction, (7) immune response"
+    "llm_ranking": [
+      {
+        "entity_name": "negative regulation of high voltage-gated calcium channel activity",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "metaphase plate congression",
+        "llm-average": 9.45
+      },
+      {
+        "entity_name": "cell surface receptor signaling pathway",
+        "llm-average": 9.13
+      },
+      {
+        "entity_name": "chromosome organization",
+        "llm-average": 7.98
+      },
+      {
+        "entity_name": "signal transduction",
+        "llm-average": 4.15
+      },
+      {
+        "entity_name": "mitotic cell cycle",
+        "llm-average": 3.45
+      },
+      {
+        "entity_name": "immune response",
+        "llm-average": 2.28
+      }
+    ]
   },
   {
     "question_number": 163,
     "qid": 387,
     "text": "Which proteins are acted on by Nadolol, which Atomoxetine interacts with?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) ADRB3, (2) REN, (3) ADRB2, (4) ADRB1"
+    "llm_ranking": [
+      {
+        "entity_name": "ADRB3",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "REN",
+        "llm-average": 8.09
+      },
+      {
+        "entity_name": "ADRB2",
+        "llm-average": 5.65
+      },
+      {
+        "entity_name": "ADRB1",
+        "llm-average": 5.13
+      }
+    ]
   },
   {
     "question_number": 164,
     "qid": 4,
     "text": "List the genes that are curated as targets of Mepyramine.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) histamine receptor H1, (2) interferon lambda receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "histamine receptor H1",
+        "llm-average": 17.33
+      },
+      {
+        "entity_name": "interferon lambda receptor 1",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 165,
     "qid": 9,
     "text": "List the genes that are curated as targets of Muromonab.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) CD3g molecule, (2) CD3e molecule, (3) CD40 ligand, (4) Fc fragment of IgG receptor IIIa, (5) CD3d molecule, (6) CD247 molecule"
+    "llm_ranking": [
+      {
+        "entity_name": "CD3g molecule",
+        "llm-average": 13.94
+      },
+      {
+        "entity_name": "CD3e molecule",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "CD40 ligand",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "Fc fragment of IgG receptor IIIa",
+        "llm-average": 11.38
+      },
+      {
+        "entity_name": "CD3d molecule",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "CD247 molecule",
+        "llm-average": 8.76
+      }
+    ]
   },
   {
     "question_number": 166,
     "qid": 10,
     "text": "What proteins does Bethanidine act on?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) KCNJ1, (2) ADRA2A, (3) ADRA2C, (4) ADRA1D, (5) ADRA1A, (6) ADRA1B, (7) ADRB1"
+    "llm_ranking": [
+      {
+        "entity_name": "KCNJ1",
+        "llm-average": 13.88
+      },
+      {
+        "entity_name": "ADRA2A",
+        "llm-average": 10.52
+      },
+      {
+        "entity_name": "ADRA2C",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "ADRA1D",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "ADRA1A",
+        "llm-average": 6.25
+      },
+      {
+        "entity_name": "ADRA1B",
+        "llm-average": 5.33
+      },
+      {
+        "entity_name": "ADRB1",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 167,
     "qid": 16,
     "text": "List the phenotypes that Ruxolitinib are indicated for.",
     "category": "Abnormality of the cardiovascular system:Abnormality of the immune system",
-    "llm_ranking": "(1) Myelofibrosis, (2) Splenomegaly"
+    "llm_ranking": [
+      {
+        "entity_name": "Myelofibrosis",
+        "llm-average": 11.06
+      },
+      {
+        "entity_name": "Splenomegaly",
+        "llm-average": 7.14
+      }
+    ]
   },
   {
     "question_number": 168,
     "qid": 18,
     "text": "List the genes that are curated as targets of Diclofenamide.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) carbonic anhydrase 12, (2) carbonic anhydrase 4, (3) carbonic anhydrase 1, (4) carbonic anhydrase 2"
+    "llm_ranking": [
+      {
+        "entity_name": "carbonic anhydrase 12",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "carbonic anhydrase 4",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "carbonic anhydrase 1",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "carbonic anhydrase 2",
+        "llm-average": 5.19
+      }
+    ]
   },
   {
     "question_number": 169,
     "qid": 20,
     "text": "Which genes are curated as targets of Ipatasertib?",
     "category": "others:None",
-    "llm_ranking": "(1) AKT serine/threonine kinase 1, (2) AKT serine/threonine kinase 2, (3) AKT serine/threonine kinase 3, (4) phosphatase and tensin homolog, (5) phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha, (6) KRAS proto-oncogene, GTPase, (7) erb-b2 receptor tyrosine kinase 2, (8) protein kinase cGMP-dependent 1"
+    "llm_ranking": [
+      {
+        "entity_name": "AKT serine/threonine kinase 1",
+        "llm-average": 15.53
+      },
+      {
+        "entity_name": "AKT serine/threonine kinase 2",
+        "llm-average": 13.03
+      },
+      {
+        "entity_name": "AKT serine/threonine kinase 3",
+        "llm-average": 12.14
+      },
+      {
+        "entity_name": "phosphatase and tensin homolog",
+        "llm-average": 9.3
+      },
+      {
+        "entity_name": "phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha",
+        "llm-average": 6.61
+      },
+      {
+        "entity_name": "KRAS proto-oncogene, GTPase",
+        "llm-average": 5.72
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 2",
+        "llm-average": 3.75
+      },
+      {
+        "entity_name": "protein kinase cGMP-dependent 1",
+        "llm-average": 2.86
+      }
+    ]
   },
   {
     "question_number": 170,
     "qid": 21,
     "text": "Which genes are curated as targets of Tandutinib?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) fms related receptor tyrosine kinase 3, (2) platelet derived growth factor receptor beta, (3) platelet derived growth factor receptor alpha, (4) KIT proto-oncogene, receptor tyrosine kinase, (5) colony stimulating factor 1 receptor, (6) MPL proto-oncogene, thrombopoietin receptor, (7) aurora kinase B"
+    "llm_ranking": [
+      {
+        "entity_name": "fms related receptor tyrosine kinase 3",
+        "llm-average": 13.02
+      },
+      {
+        "entity_name": "platelet derived growth factor receptor beta",
+        "llm-average": 10.56
+      },
+      {
+        "entity_name": "platelet derived growth factor receptor alpha",
+        "llm-average": 9.99
+      },
+      {
+        "entity_name": "KIT proto-oncogene, receptor tyrosine kinase",
+        "llm-average": 8.92
+      },
+      {
+        "entity_name": "colony stimulating factor 1 receptor",
+        "llm-average": 8.39
+      },
+      {
+        "entity_name": "MPL proto-oncogene, thrombopoietin receptor",
+        "llm-average": 6.06
+      },
+      {
+        "entity_name": "aurora kinase B",
+        "llm-average": 4.11
+      }
+    ]
   },
   {
     "question_number": 171,
     "qid": 22,
     "text": "Which genes are curated as targets of Lorlatinib?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) ALK receptor tyrosine kinase, (2) ROS proto-oncogene 1, receptor tyrosine kinase, (3) EMAP like 4, (4) tumor protein p53, (5) RB transcriptional corepressor 1, (6) nucleophosmin 1"
+    "llm_ranking": [
+      {
+        "entity_name": "ALK receptor tyrosine kinase",
+        "llm-average": 17.33
+      },
+      {
+        "entity_name": "ROS proto-oncogene 1, receptor tyrosine kinase",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "EMAP like 4",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "tumor protein p53",
+        "llm-average": 4.83
+      },
+      {
+        "entity_name": "RB transcriptional corepressor 1",
+        "llm-average": 4.48
+      },
+      {
+        "entity_name": "nucleophosmin 1",
+        "llm-average": 4.3
+      }
+    ]
   },
   {
     "question_number": 172,
     "qid": 25,
     "text": "List the genes that are curated as targets of Hydromorphone.",
     "category": "Abnormality of the cardiovascular system:Acute coronary syndrome",
-    "llm_ranking": "(1) toll like receptor 7, (2) opioid receptor mu 1, (3) opioid receptor delta 1, (4) opioid receptor kappa 1"
+    "llm_ranking": [
+      {
+        "entity_name": "toll like receptor 7",
+        "llm-average": 14.61
+      },
+      {
+        "entity_name": "opioid receptor delta 1",
+        "llm-average": 5.7
+      },
+      {
+        "entity_name": "opioid receptor kappa 1",
+        "llm-average": 5.7
+      },
+      {
+        "entity_name": "opioid receptor mu 1",
+        "llm-average": 5.55
+      }
+    ]
   },
   {
     "question_number": 173,
     "qid": 29,
     "text": "What genes is Budiodarone curated to target?",
     "category": "others:None",
-    "llm_ranking": "(1) potassium voltage-gated channel subfamily H member 2, (2) calcium voltage-gated channel auxiliary subunit alpha2delta 2, (3) adrenoceptor beta 1"
+    "llm_ranking": [
+      {
+        "entity_name": "potassium voltage-gated channel subfamily H member 2",
+        "llm-average": 14.1
+      },
+      {
+        "entity_name": "calcium voltage-gated channel auxiliary subunit alpha2delta 2",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "adrenoceptor beta 1",
+        "llm-average": 10.01
+      }
+    ]
   },
   {
     "question_number": 174,
     "qid": 30,
     "text": "Which genes are curated as targets of Astemizole?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) potassium voltage-gated channel subfamily H member 2, (2) potassium voltage-gated channel subfamily H member 1, (3) oxytocin receptor, (4) histamine receptor H1"
+    "llm_ranking": [
+      {
+        "entity_name": "potassium voltage-gated channel subfamily H member 2",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "potassium voltage-gated channel subfamily H member 1",
+        "llm-average": 14.65
+      },
+      {
+        "entity_name": "oxytocin receptor",
+        "llm-average": 13.18
+      },
+      {
+        "entity_name": "histamine receptor H1",
+        "llm-average": 6.62
+      }
+    ]
   },
   {
     "question_number": 175,
     "qid": 34,
     "text": "What phenotypes is Flucytosine indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormal heart morphology",
-    "llm_ranking": "(1) Endocarditis, (2) Recurrent pneumonia, (3) Meningitis, (4) Sepsis"
+    "llm_ranking": [
+      {
+        "entity_name": "Endocarditis",
+        "llm-average": 11.42
+      },
+      {
+        "entity_name": "Recurrent pneumonia",
+        "llm-average": 9.79
+      },
+      {
+        "entity_name": "Meningitis",
+        "llm-average": 7.86
+      },
+      {
+        "entity_name": "Sepsis",
+        "llm-average": 6.8
+      }
+    ]
   },
   {
     "question_number": 176,
     "qid": 37,
     "text": "Which genes are curated as targets of Nadolol?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) lipoprotein lipase, (2) adrenoceptor beta 1, (3) adrenoceptor beta 3, (4) adrenoceptor beta 2"
+    "llm_ranking": [
+      {
+        "entity_name": "lipoprotein lipase",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "adrenoceptor beta 1",
+        "llm-average": 12.51
+      },
+      {
+        "entity_name": "adrenoceptor beta 3",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "adrenoceptor beta 2",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 177,
     "qid": 41,
     "text": "Which genes are curated as targets of Cebranopadol?",
     "category": "others:None",
-    "llm_ranking": "(1) opioid related nociceptin receptor 1, (2) opioid receptor mu 1, (3) opioid receptor delta 1, (4) opioid receptor kappa 1"
+    "llm_ranking": [
+      {
+        "entity_name": "opioid related nociceptin receptor 1",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "opioid receptor mu 1",
+        "llm-average": 11.22
+      },
+      {
+        "entity_name": "opioid receptor delta 1",
+        "llm-average": 9.64
+      },
+      {
+        "entity_name": "opioid receptor kappa 1",
+        "llm-average": 8.55
+      }
+    ]
   },
   {
     "question_number": 178,
     "qid": 44,
     "text": "What proteins is Hydroflumethiazide compiled to target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) CA4, (2) CA12, (3) CA2, (4) CA9"
+    "llm_ranking": [
+      {
+        "entity_name": "CA4",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "CA12",
+        "llm-average": 10.72
+      },
+      {
+        "entity_name": "CA2",
+        "llm-average": 9.49
+      },
+      {
+        "entity_name": "CA9",
+        "llm-average": 8.22
+      }
+    ]
   },
   {
     "question_number": 179,
     "qid": 47,
     "text": "Which proteins are compiled as targets of Allylestrenol?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) SLC6A9, (2) PGR, (3) AR"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC6A9",
+        "llm-average": 13.02
+      },
+      {
+        "entity_name": "PGR",
+        "llm-average": 8.06
+      },
+      {
+        "entity_name": "AR",
+        "llm-average": 7.5
+      }
+    ]
   },
   {
     "question_number": 180,
     "qid": 50,
     "text": "Which genes are curated as targets of Dacomitinib?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) phosphatase and tensin homolog, (2) erb-b2 receptor tyrosine kinase 4, (3) erb-b2 receptor tyrosine kinase 3, (4) epidermal growth factor receptor, (5) erb-b2 receptor tyrosine kinase 2"
+    "llm_ranking": [
+      {
+        "entity_name": "phosphatase and tensin homolog",
+        "llm-average": 12.1
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 4",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 3",
+        "llm-average": 10.7
+      },
+      {
+        "entity_name": "epidermal growth factor receptor",
+        "llm-average": 9.14
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 2",
+        "llm-average": 8.94
+      }
+    ]
   },
   {
     "question_number": 181,
     "qid": 59,
     "text": "Which phenotypes is Sulfacetamide indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Seborrheic dermatitis, (2) Facial erythema, (3) Conjunctivitis, (4) Corneal ulceration, (5) Abnormality of the skin, (6) Pneumonia"
+    "llm_ranking": [
+      {
+        "entity_name": "Seborrheic dermatitis",
+        "llm-average": 12.65
+      },
+      {
+        "entity_name": "Facial erythema",
+        "llm-average": 11.94
+      },
+      {
+        "entity_name": "Corneal ulceration",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "Conjunctivitis",
+        "llm-average": 8.42
+      },
+      {
+        "entity_name": "Abnormality of the skin",
+        "llm-average": 6.77
+      },
+      {
+        "entity_name": "Pneumonia",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 182,
     "qid": 63,
     "text": "What phenotypes is Timolol indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Migraine, (2) Glaucoma, (3) Myocardial infarction, (4) Open angle glaucoma, (5) Angina pectoris, (6) Atrial fibrillation, (7) Hypertension"
+    "llm_ranking": [
+      {
+        "entity_name": "Migraine",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "Glaucoma",
+        "llm-average": 9.14
+      },
+      {
+        "entity_name": "Myocardial infarction",
+        "llm-average": 8.19
+      },
+      {
+        "entity_name": "Open angle glaucoma",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Angina pectoris",
+        "llm-average": 7.33
+      },
+      {
+        "entity_name": "Atrial fibrillation",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 4.65
+      }
+    ]
   },
   {
     "question_number": 183,
     "qid": 68,
     "text": "What genes is Bicuculline curated to target?",
     "category": "others:None",
-    "llm_ranking": "(1) potassium calcium-activated channel subfamily N member 1, (2) gamma-aminobutyric acid type A receptor subunit alpha4, (3) gamma-aminobutyric acid type A receptor subunit alpha5, (4) gamma-aminobutyric acid type A receptor subunit alpha6, (5) gamma-aminobutyric acid type A receptor subunit alpha2, (6) gamma-aminobutyric acid type A receptor subunit alpha1, (7) gamma-aminobutyric acid type A receptor subunit alpha3"
+    "llm_ranking": [
+      {
+        "entity_name": "potassium calcium-activated channel subfamily N member 1",
+        "llm-average": 16.41
+      },
+      {
+        "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha4",
+        "llm-average": 11.97
+      },
+      {
+        "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha5",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha6",
+        "llm-average": 11.06
+      },
+      {
+        "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha2",
+        "llm-average": 10.55
+      },
+      {
+        "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha1",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha3",
+        "llm-average": 10.36
+      }
+    ]
   },
   {
     "question_number": 184,
     "qid": 69,
     "text": "Which proteins are acted on by Remifentanil?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) GRIN3A, (2) GRIN3B, (3) GRIN2C, (4) MMP9, (5) GRIN2D, (6) OPRD1, (7) OPRM1, (8) OPRK1"
+    "llm_ranking": [
+      {
+        "entity_name": "GRIN3A",
+        "llm-average": 13.55
+      },
+      {
+        "entity_name": "GRIN3B",
+        "llm-average": 13.19
+      },
+      {
+        "entity_name": "GRIN2C",
+        "llm-average": 13.02
+      },
+      {
+        "entity_name": "MMP9",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "GRIN2D",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "OPRD1",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "OPRM1",
+        "llm-average": 8.78
+      },
+      {
+        "entity_name": "OPRK1",
+        "llm-average": 7.86
+      }
+    ]
   },
   {
     "question_number": 185,
     "qid": 71,
     "text": "What genes is Bosentan curated to target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) endothelin receptor type A, (2) endothelin receptor type B"
+    "llm_ranking": [
+      {
+        "entity_name": "endothelin receptor type A",
+        "llm-average": 8.05
+      },
+      {
+        "entity_name": "endothelin receptor type B",
+        "llm-average": 7.14
+      }
+    ]
   },
   {
     "question_number": 186,
     "qid": 72,
     "text": "Which genes are curated as targets of Macitentan?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) endothelin receptor type A, (2) endothelin receptor type B"
+    "llm_ranking": [
+      {
+        "entity_name": "endothelin receptor type A",
+        "llm-average": 9.99
+      },
+      {
+        "entity_name": "endothelin receptor type B",
+        "llm-average": 9.3
+      }
+    ]
   },
   {
     "question_number": 187,
     "qid": 73,
     "text": "What phenotypes is Cilazapril indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Elevated hepatic transaminase, (2) Renal artery stenosis, (3) Congestive heart failure, (4) Renovascular hypertension, (5) Nephropathy, (6) Renal insufficiency, (7) Hypertension"
+    "llm_ranking": [
+      {
+        "entity_name": "Elevated hepatic transaminase",
+        "llm-average": 14.43
+      },
+      {
+        "entity_name": "Renal artery stenosis",
+        "llm-average": 14.08
+      },
+      {
+        "entity_name": "Congestive heart failure",
+        "llm-average": 12.87
+      },
+      {
+        "entity_name": "Renovascular hypertension",
+        "llm-average": 10.15
+      },
+      {
+        "entity_name": "Nephropathy",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 3.75
+      }
+    ]
   },
   {
     "question_number": 188,
     "qid": 75,
     "text": "List the phenotypes that Pseudoephedrine are indicated for.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Nasal obstruction, (2) Third degree atrioventricular block, (3) Hypertension, (4) Seasonal allergy, (5) Hypotension, (6) Narcolepsy, (7) Headache, (8) Asthma"
+    "llm_ranking": [
+      {
+        "entity_name": "Third degree atrioventricular block",
+        "llm-average": 8.87
+      },
+      {
+        "entity_name": "Nasal obstruction",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 8.18
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 7.27
+      },
+      {
+        "entity_name": "Seasonal allergy",
+        "llm-average": 6.99
+      },
+      {
+        "entity_name": "Narcolepsy",
+        "llm-average": 5.68
+      },
+      {
+        "entity_name": "Headache",
+        "llm-average": 3.92
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 3.55
+      }
+    ]
   },
   {
     "question_number": 189,
     "qid": 78,
     "text": "Which genes are curated as targets of Poziotinib?",
     "category": "others:None",
-    "llm_ranking": "(1) KRAS proto-oncogene, GTPase, (2) erb-b2 receptor tyrosine kinase 4, (3) erb-b2 receptor tyrosine kinase 3, (4) erb-b2 receptor tyrosine kinase 2, (5) epidermal growth factor receptor"
+    "llm_ranking": [
+      {
+        "entity_name": "KRAS proto-oncogene, GTPase",
+        "llm-average": 16.41
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 4",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 3",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 2",
+        "llm-average": 9.84
+      },
+      {
+        "entity_name": "epidermal growth factor receptor",
+        "llm-average": 9.14
+      }
+    ]
   },
   {
     "question_number": 190,
     "qid": 79,
     "text": "Which genes are curated as targets of Sarpogrelate?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) 5-hydroxytryptamine receptor 2B, (2) 5-hydroxytryptamine receptor 2A, (3) 5-hydroxytryptamine receptor 2C"
+    "llm_ranking": [
+      {
+        "entity_name": "5-hydroxytryptamine receptor 2B",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "5-hydroxytryptamine receptor 2A",
+        "llm-average": 13.24
+      },
+      {
+        "entity_name": "5-hydroxytryptamine receptor 2C",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 191,
     "qid": 80,
     "text": "What proteins does Methscopolamine bromide act on?",
     "category": "Abnormality of the digestive system:Abnormality of digestive system physiology",
-    "llm_ranking": "(1) HRH1, (2) CHRM4, (3) CHRM5, (4) CHRM3, (5) CHRM1"
+    "llm_ranking": [
+      {
+        "entity_name": "HRH1",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "CHRM4",
+        "llm-average": 11.08
+      },
+      {
+        "entity_name": "CHRM5",
+        "llm-average": 11.06
+      },
+      {
+        "entity_name": "CHRM3",
+        "llm-average": 7.86
+      },
+      {
+        "entity_name": "CHRM1",
+        "llm-average": 4.83
+      }
+    ]
   },
   {
     "question_number": 192,
     "qid": 81,
     "text": "Which genes are curated as targets of Prexasertib?",
     "category": "others:None",
-    "llm_ranking": "(1) checkpoint kinase 1, (2) MYC proto-oncogene, bHLH transcription factor, (3) checkpoint kinase 2, (4) ribosomal protein S6 kinase A1, (5) CDP-diacylglycerol synthase 1"
+    "llm_ranking": [
+      {
+        "entity_name": "checkpoint kinase 1",
+        "llm-average": 19.99
+      },
+      {
+        "entity_name": "MYC proto-oncogene, bHLH transcription factor",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "checkpoint kinase 2",
+        "llm-average": 11.74
+      },
+      {
+        "entity_name": "ribosomal protein S6 kinase A1",
+        "llm-average": 9.99
+      },
+      {
+        "entity_name": "CDP-diacylglycerol synthase 1",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 193,
     "qid": 83,
     "text": "What phenotypes is 2-deoxy-2-fluoro-\u03b1-D-mannose indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system morphology",
-    "llm_ranking": "(1) Seizure, (2) Neoplasm, (3) Coronary artery atherosclerosis"
+    "llm_ranking": [
+      {
+        "entity_name": "Seizure",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "Coronary artery atherosclerosis",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 194,
     "qid": 85,
     "text": "List the genes that are curated as targets of Ajulemic acid.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) TNF receptor superfamily member 4, (2) tumor necrosis factor"
+    "llm_ranking": [
+      {
+        "entity_name": "TNF receptor superfamily member 4",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "tumor necrosis factor",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 195,
     "qid": 86,
     "text": "List the genes that are curated as targets of Chlorthalidone.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) C-C motif chemokine receptor 6, (2) solute carrier family 12 member 3, (3) solute carrier family 12 member 1, (4) carbonic anhydrase 12, (5) carbonic anhydrase 14, (6) carbonic anhydrase 4, (7) carbonic anhydrase 7, (8) carbonic anhydrase 1"
+    "llm_ranking": [
+      {
+        "entity_name": "C-C motif chemokine receptor 6",
+        "llm-average": 14.96
+      },
+      {
+        "entity_name": "solute carrier family 12 member 3",
+        "llm-average": 11.22
+      },
+      {
+        "entity_name": "solute carrier family 12 member 1",
+        "llm-average": 10.68
+      },
+      {
+        "entity_name": "carbonic anhydrase 12",
+        "llm-average": 10.16
+      },
+      {
+        "entity_name": "carbonic anhydrase 14",
+        "llm-average": 9.61
+      },
+      {
+        "entity_name": "carbonic anhydrase 4",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "carbonic anhydrase 7",
+        "llm-average": 6.05
+      },
+      {
+        "entity_name": "carbonic anhydrase 1",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 196,
     "qid": 88,
     "text": "Which genes are curated as targets of Diclofenamide?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) carbonic anhydrase 12, (2) carbonic anhydrase 4, (3) carbonic anhydrase 2, (4) carbonic anhydrase 1"
+    "llm_ranking": [
+      {
+        "entity_name": "carbonic anhydrase 12",
+        "llm-average": 12.3
+      },
+      {
+        "entity_name": "carbonic anhydrase 4",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "carbonic anhydrase 2",
+        "llm-average": 8.06
+      },
+      {
+        "entity_name": "carbonic anhydrase 1",
+        "llm-average": 7.5
+      }
+    ]
   },
   {
     "question_number": 197,
     "qid": 90,
     "text": "What genes is Urokinase curated to target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) plasminogen activator, tissue type, (2) serpin family E member 1, (3) plasminogen, (4) plasminogen activator, urokinase receptor, (5) serpin family B member 2, (6) plasminogen activator, urokinase"
+    "llm_ranking": [
+      {
+        "entity_name": "plasminogen activator, tissue type",
+        "llm-average": 13.02
+      },
+      {
+        "entity_name": "serpin family E member 1",
+        "llm-average": 12.82
+      },
+      {
+        "entity_name": "plasminogen",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "plasminogen activator, urokinase receptor",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "serpin family B member 2",
+        "llm-average": 6.78
+      },
+      {
+        "entity_name": "plasminogen activator, urokinase",
+        "llm-average": 6.26
+      }
+    ]
   },
   {
     "question_number": 198,
     "qid": 92,
     "text": "Which genes are curated as targets of Proscillaridin?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) lysophosphatidic acid receptor 2, (2) lysophosphatidic acid receptor 3, (3) G protein-coupled receptor 35, (4) lysophosphatidic acid receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "lysophosphatidic acid receptor 2",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "lysophosphatidic acid receptor 3",
+        "llm-average": 15.0
+      },
+      {
+        "entity_name": "G protein-coupled receptor 35",
+        "llm-average": 14.97
+      },
+      {
+        "entity_name": "lysophosphatidic acid receptor 1",
+        "llm-average": 12.14
+      }
+    ]
   },
   {
     "question_number": 199,
     "qid": 94,
     "text": "What phenotypes is Chlorothiazide indicated for?",
     "category": "Abnormality of the cardiovascular system:None",
-    "llm_ranking": "(1) Toxemia of pregnancy, (2) Nephrotic syndrome, (3) Edema, (4) Cirrhosis, (5) Hypervolemia, (6) Congestive heart failure, (7) Abnormality of the cardiovascular system, (8) Hypertension"
+    "llm_ranking": [
+      {
+        "entity_name": "Toxemia of pregnancy",
+        "llm-average": 13.54
+      },
+      {
+        "entity_name": "Nephrotic syndrome",
+        "llm-average": 11.4
+      },
+      {
+        "entity_name": "Cirrhosis",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "Edema",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "Hypervolemia",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "Congestive heart failure",
+        "llm-average": 6.61
+      },
+      {
+        "entity_name": "Abnormality of the cardiovascular system",
+        "llm-average": 4.63
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 3.75
+      }
+    ]
   },
   {
     "question_number": 200,
     "qid": 96,
     "text": "What phenotypes is Tolbutamide indicated for?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal glucose homeostasis",
-    "llm_ranking": "(1) Type II diabetes mellitus, (2) Obesity, (3) Hyperglycemia, (4) Diabetes mellitus"
+    "llm_ranking": [
+      {
+        "entity_name": "Type II diabetes mellitus",
+        "llm-average": 10.93
+      },
+      {
+        "entity_name": "Obesity",
+        "llm-average": 9.27
+      },
+      {
+        "entity_name": "Hyperglycemia",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Diabetes mellitus",
+        "llm-average": 5.56
+      }
+    ]
   },
   {
     "question_number": 201,
     "qid": 101,
     "text": "What phenotypes is Ticagrelor indicated for?",
     "category": "Abnormality of the cardiovascular system:Acute coronary syndrome",
-    "llm_ranking": "(1) Stroke, (2) Chronic pulmonary obstruction, (3) Myocardial infarction, (4) ST segment elevation, (5) Renal insufficiency, (6) Asthma, (7) Ischemic stroke"
+    "llm_ranking": [
+      {
+        "entity_name": "Chronic pulmonary obstruction",
+        "llm-average": 9.95
+      },
+      {
+        "entity_name": "Stroke",
+        "llm-average": 9.84
+      },
+      {
+        "entity_name": "Myocardial infarction",
+        "llm-average": 9.14
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 8.35
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 8.34
+      },
+      {
+        "entity_name": "ST segment elevation",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Ischemic stroke",
+        "llm-average": 7.51
+      }
+    ]
   },
   {
     "question_number": 202,
     "qid": 104,
     "text": "What phenotypes does Macitentan have as side effects?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Right ventricular failure, (2) Bronchitis, (3) Hypotension, (4) Anemia, (5) Edema, (6) Headache"
+    "llm_ranking": [
+      {
+        "entity_name": "Right ventricular failure",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Bronchitis",
+        "llm-average": 11.94
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "Anemia",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "Edema",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Headache",
+        "llm-average": 3.39
+      }
+    ]
   },
   {
     "question_number": 203,
     "qid": 105,
     "text": "What phenotypes is Bosentan indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Scleroderma, (2) Pulmonary venous occlusion, (3) Hypertension, (4) Immunodeficiency, (5) Abnormal heart morphology, (6) Abnormal lung morphology"
+    "llm_ranking": [
+      {
+        "entity_name": "Pulmonary venous occlusion",
+        "llm-average": 13.74
+      },
+      {
+        "entity_name": "Scleroderma",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 9.14
+      },
+      {
+        "entity_name": "Immunodeficiency",
+        "llm-average": 9.06
+      },
+      {
+        "entity_name": "Abnormal heart morphology",
+        "llm-average": 3.02
+      },
+      {
+        "entity_name": "Abnormal lung morphology",
+        "llm-average": 2.83
+      }
+    ]
   },
   {
     "question_number": 204,
     "qid": 108,
     "text": "List the phenotypes that Ephedrine are indicated for.",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Narcolepsy, (2) Asthma, (3) Nasal obstruction, (4) Hypotension, (5) Third degree atrioventricular block, (6) Seasonal allergy, (7) Headache, (8) Hypertension"
+    "llm_ranking": [
+      {
+        "entity_name": "Narcolepsy",
+        "llm-average": 13.19
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 12.85
+      },
+      {
+        "entity_name": "Nasal obstruction",
+        "llm-average": 11.08
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "Third degree atrioventricular block",
+        "llm-average": 9.95
+      },
+      {
+        "entity_name": "Seasonal allergy",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "Headache",
+        "llm-average": 4.63
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 1.06
+      }
+    ]
   },
   {
     "question_number": 205,
     "qid": 111,
     "text": "What genes is Alteplase curated to target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) plasminogen, (2) fibrinogen alpha chain"
+    "llm_ranking": [
+      {
+        "entity_name": "plasminogen",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "fibrinogen alpha chain",
+        "llm-average": 8.58
+      }
+    ]
   },
   {
     "question_number": 206,
     "qid": 113,
     "text": "List the proteins that are compiled as targets of Rivaroxaban.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) TSG101, (2) VPS36, (3) UEVLD, (4) F10, (5) F3"
+    "llm_ranking": [
+      {
+        "entity_name": "TSG101",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "VPS36",
+        "llm-average": 12.29
+      },
+      {
+        "entity_name": "UEVLD",
+        "llm-average": 11.74
+      },
+      {
+        "entity_name": "F10",
+        "llm-average": 6.78
+      },
+      {
+        "entity_name": "F3",
+        "llm-average": 3.03
+      }
+    ]
   },
   {
     "question_number": 207,
     "qid": 114,
     "text": "List the genes that are curated as targets of Poziotinib.",
     "category": "others:None",
-    "llm_ranking": "(1) KRAS proto-oncogene, GTPase, (2) erb-b2 receptor tyrosine kinase 4, (3) erb-b2 receptor tyrosine kinase 3, (4) erb-b2 receptor tyrosine kinase 2, (5) epidermal growth factor receptor"
+    "llm_ranking": [
+      {
+        "entity_name": "KRAS proto-oncogene, GTPase",
+        "llm-average": 16.41
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 4",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 3",
+        "llm-average": 12.86
+      },
+      {
+        "entity_name": "erb-b2 receptor tyrosine kinase 2",
+        "llm-average": 12.51
+      },
+      {
+        "entity_name": "epidermal growth factor receptor",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 208,
     "qid": 116,
     "text": "List the genes that are curated as targets of Misoprostol.",
     "category": "Abnormality of the digestive system:Abnormality of digestive system morphology",
-    "llm_ranking": "(1) prostaglandin I2 receptor, (2) prostaglandin E receptor 4, (3) prostaglandin E receptor 3, (4) prostaglandin E receptor 2"
+    "llm_ranking": [
+      {
+        "entity_name": "prostaglandin E receptor 4",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "prostaglandin I2 receptor",
+        "llm-average": 11.42
+      },
+      {
+        "entity_name": "prostaglandin E receptor 3",
+        "llm-average": 8.92
+      },
+      {
+        "entity_name": "prostaglandin E receptor 2",
+        "llm-average": 7.5
+      }
+    ]
   },
   {
     "question_number": 209,
     "qid": 119,
     "text": "List the phenotypes that Chlorothiazide are indicated for.",
     "category": "Abnormality of the cardiovascular system:None",
-    "llm_ranking": "(1) Toxemia of pregnancy, (2) Nephrotic syndrome, (3) Cirrhosis, (4) Edema, (5) Hypervolemia, (6) Congestive heart failure, (7) Abnormality of the cardiovascular system, (8) Hypertension"
+    "llm_ranking": [
+      {
+        "entity_name": "Toxemia of pregnancy",
+        "llm-average": 16.41
+      },
+      {
+        "entity_name": "Nephrotic syndrome",
+        "llm-average": 13.91
+      },
+      {
+        "entity_name": "Cirrhosis",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "Edema",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "Hypervolemia",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "Congestive heart failure",
+        "llm-average": 9.48
+      },
+      {
+        "entity_name": "Abnormality of the cardiovascular system",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 4.83
+      }
+    ]
   },
   {
     "question_number": 210,
     "qid": 122,
     "text": "List the phenotypes that Nebivolol are indicated for.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Congestive heart failure, (2) Diabetes mellitus, (3) Angina pectoris, (4) Myocardial infarction, (5) Hypertension, (6) Hyperlipidemia, (7) Abnormality of the cardiovascular system, (8) Hypotension"
+    "llm_ranking": [
+      {
+        "entity_name": "Congestive heart failure",
+        "llm-average": 11.94
+      },
+      {
+        "entity_name": "Angina pectoris",
+        "llm-average": 5.69
+      },
+      {
+        "entity_name": "Myocardial infarction",
+        "llm-average": 5.68
+      },
+      {
+        "entity_name": "Diabetes mellitus",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 3.94
+      },
+      {
+        "entity_name": "Hyperlipidemia",
+        "llm-average": 3.92
+      },
+      {
+        "entity_name": "Abnormality of the cardiovascular system",
+        "llm-average": 3.75
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 2.83
+      }
+    ]
   },
   {
     "question_number": 211,
     "qid": 124,
     "text": "List the proteins that are compiled as targets of Eltrombopag.",
     "category": "Abnormality of blood and blood-forming tissues:Abnormal platelet count",
-    "llm_ranking": "(1) MPL, (2) THPO, (3) SLCO1B1"
+    "llm_ranking": [
+      {
+        "entity_name": "MPL",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "THPO",
+        "llm-average": 9.32
+      },
+      {
+        "entity_name": "SLCO1B1",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 212,
     "qid": 127,
     "text": "List the phenotypes that Isosorbide mononitrate are indicated for.",
     "category": "Abnormality of the cardiovascular system:Angina pectoris",
-    "llm_ranking": "(1) Coronary artery atherosclerosis, (2) Angina pectoris, (3) Myocardial infarction"
+    "llm_ranking": [
+      {
+        "entity_name": "Coronary artery atherosclerosis",
+        "llm-average": 8.19
+      },
+      {
+        "entity_name": "Myocardial infarction",
+        "llm-average": 7.5
+      },
+      {
+        "entity_name": "Angina pectoris",
+        "llm-average": 7.34
+      }
+    ]
   },
   {
     "question_number": 213,
     "qid": 140,
     "text": "Which genes are curated as targets of Acarbose?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal glucose homeostasis",
-    "llm_ranking": "(1) MAX dimerization protein MGA, (2) alpha glucosidase, (3) maltase-glucoamylase, (4) sucrase-isomaltase, (5) amylase alpha 2A, (6) dopamine receptor D2, (7) solute carrier family 2 member 4, (8) lipoprotein lipase"
+    "llm_ranking": [
+      {
+        "entity_name": "MAX dimerization protein MGA",
+        "llm-average": 16.76
+      },
+      {
+        "entity_name": "alpha glucosidase",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "maltase-glucoamylase",
+        "llm-average": 14.47
+      },
+      {
+        "entity_name": "sucrase-isomaltase",
+        "llm-average": 12.5
+      },
+      {
+        "entity_name": "amylase alpha 2A",
+        "llm-average": 11.41
+      },
+      {
+        "entity_name": "dopamine receptor D2",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "solute carrier family 2 member 4",
+        "llm-average": 7.69
+      },
+      {
+        "entity_name": "lipoprotein lipase",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 214,
     "qid": 141,
     "text": "What phenotypes is Ephedrine indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Hypotension, (2) Asthma, (3) Narcolepsy, (4) Third degree atrioventricular block, (5) Nasal obstruction, (6) Seasonal allergy, (7) Headache, (8) Hypertension"
+    "llm_ranking": [
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 13.74
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 13.56
+      },
+      {
+        "entity_name": "Narcolepsy",
+        "llm-average": 12.83
+      },
+      {
+        "entity_name": "Third degree atrioventricular block",
+        "llm-average": 9.95
+      },
+      {
+        "entity_name": "Nasal obstruction",
+        "llm-average": 7.85
+      },
+      {
+        "entity_name": "Seasonal allergy",
+        "llm-average": 7.11
+      },
+      {
+        "entity_name": "Headache",
+        "llm-average": 3.55
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 1.97
+      }
+    ]
   },
   {
     "question_number": 215,
     "qid": 142,
     "text": "What diseases is PLA2G1B a biomarker of?",
     "category": "urinary system disease:kidney disease",
-    "llm_ranking": "(1) immune system disease, (2) kidney disease"
+    "llm_ranking": [
+      {
+        "entity_name": "immune system disease",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "kidney disease",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 216,
     "qid": 143,
     "text": "What genes is Latanoprostene bunod curated to target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) collagen type IV alpha 5 chain, (2) prostaglandin F receptor"
+    "llm_ranking": [
+      {
+        "entity_name": "collagen type IV alpha 5 chain",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "prostaglandin F receptor",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 217,
     "qid": 144,
     "text": "List the phenotypes that Minoxidil are indicated for.",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Encephalopathy, (2) Retinopathy, (3) Hypertension"
+    "llm_ranking": [
+      {
+        "entity_name": "Encephalopathy",
+        "llm-average": 13.9
+      },
+      {
+        "entity_name": "Retinopathy",
+        "llm-average": 10.15
+      },
+      {
+        "entity_name": "Hypertension",
+        "llm-average": 3.75
+      }
+    ]
   },
   {
     "question_number": 218,
     "qid": 145,
     "text": "Which phenotypes is Domperidone indicated for?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Gastroparesis, (2) Nausea, (3) Vomiting, (4) Orthostatic hypotension, (5) Migraine, (6) Gastritis, (7) Renal insufficiency"
+    "llm_ranking": [
+      {
+        "entity_name": "Gastroparesis",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "Nausea",
+        "llm-average": 11.77
+      },
+      {
+        "entity_name": "Orthostatic hypotension",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Vomiting",
+        "llm-average": 11.22
+      },
+      {
+        "entity_name": "Migraine",
+        "llm-average": 6.76
+      },
+      {
+        "entity_name": "Gastritis",
+        "llm-average": 6.05
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 3.19
+      }
+    ]
   },
   {
     "question_number": 219,
     "qid": 149,
     "text": "What genes is Anisotropine methylbromide curated to target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 1, (2) cholinergic receptor muscarinic 3, (3) cholinergic receptor muscarinic 2"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 3",
+        "llm-average": 5.36
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 2",
+        "llm-average": 5.35
+      }
+    ]
   },
   {
     "question_number": 220,
     "qid": 150,
     "text": "What genes is Tandutinib curated to target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) fms related receptor tyrosine kinase 3, (2) platelet derived growth factor receptor beta, (3) platelet derived growth factor receptor alpha, (4) colony stimulating factor 1 receptor, (5) KIT proto-oncogene, receptor tyrosine kinase, (6) aurora kinase B, (7) MPL proto-oncogene, thrombopoietin receptor"
+    "llm_ranking": [
+      {
+        "entity_name": "fms related receptor tyrosine kinase 3",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "platelet derived growth factor receptor beta",
+        "llm-average": 13.23
+      },
+      {
+        "entity_name": "platelet derived growth factor receptor alpha",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "KIT proto-oncogene, receptor tyrosine kinase",
+        "llm-average": 11.05
+      },
+      {
+        "entity_name": "colony stimulating factor 1 receptor",
+        "llm-average": 10.89
+      },
+      {
+        "entity_name": "aurora kinase B",
+        "llm-average": 9.11
+      },
+      {
+        "entity_name": "MPL proto-oncogene, thrombopoietin receptor",
+        "llm-average": 8.22
+      }
+    ]
   },
   {
     "question_number": 221,
     "qid": 152,
     "text": "What drugs have folate hydrolase 1 as a curated target?",
     "category": "Abnormality of the cardiovascular system:None",
-    "llm_ranking": "(1) Suramin, (2) Methotrexate, (3) Docetaxel, (4) Capromab pendetide, (5) Clavulanic acid, (6) Stanolone"
+    "llm_ranking": [
+      {
+        "entity_name": "Suramin",
+        "llm-average": 16.69
+      },
+      {
+        "entity_name": "Methotrexate",
+        "llm-average": 13.31
+      },
+      {
+        "entity_name": "Docetaxel",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Capromab pendetide",
+        "llm-average": 12.15
+      },
+      {
+        "entity_name": "Clavulanic acid",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "Stanolone",
+        "llm-average": 9.07
+      }
+    ]
   },
   {
     "question_number": 222,
     "qid": 153,
     "text": "What drugs are indicated for Bacterial endocarditis?",
     "category": "Abnormality of the cardiovascular system:Abnormal heart morphology",
-    "llm_ranking": "(1) Vancomycin, (2) Erythromycin, (3) Phenoxymethylpenicillin, (4) Benzylpenicillin, (5) Cephalexin, (6) Amoxicillin"
+    "llm_ranking": [
+      {
+        "entity_name": "Vancomycin",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "Erythromycin",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "Phenoxymethylpenicillin",
+        "llm-average": 8.62
+      },
+      {
+        "entity_name": "Benzylpenicillin",
+        "llm-average": 7.56
+      },
+      {
+        "entity_name": "Cephalexin",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Amoxicillin",
+        "llm-average": 5.35
+      }
+    ]
   },
   {
     "question_number": 223,
     "qid": 155,
     "text": "What drugs act on GCC1?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) Atrazine, (2) Cisplatin, (3) Phencyclidine, (4) Cocaine, (5) Cyclosporine"
+    "llm_ranking": [
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 12.99
+      },
+      {
+        "entity_name": "Cisplatin",
+        "llm-average": 9.3
+      },
+      {
+        "entity_name": "Phencyclidine",
+        "llm-average": 8.85
+      },
+      {
+        "entity_name": "Cocaine",
+        "llm-average": 8.46
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 7.56
+      }
+    ]
   },
   {
     "question_number": 224,
     "qid": 157,
     "text": "What drugs have potassium voltage-gated channel subfamily Q member 4 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Angina pectoris",
-    "llm_ranking": "(1) Nerispirdine, (2) Ezogabine, (3) Bepridil, (4) Dalfampridine"
+    "llm_ranking": [
+      {
+        "entity_name": "Nerispirdine",
+        "llm-average": 15.36
+      },
+      {
+        "entity_name": "Ezogabine",
+        "llm-average": 13.72
+      },
+      {
+        "entity_name": "Bepridil",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "Dalfampridine",
+        "llm-average": 8.74
+      }
+    ]
   },
   {
     "question_number": 225,
     "qid": 160,
     "text": "What drugs have cathepsin A as a curated target?",
     "category": "Abnormality of the digestive system:Abnormality of the liver",
-    "llm_ranking": "(1) Boceprevir, (2) Telaprevir"
+    "llm_ranking": [
+      {
+        "entity_name": "Boceprevir",
+        "llm-average": 9.34
+      },
+      {
+        "entity_name": "Telaprevir",
+        "llm-average": 9.2
+      }
+    ]
   },
   {
     "question_number": 226,
     "qid": 162,
     "text": "What drugs are indicated for Hepatocellular carcinoma?",
     "category": "Abnormality of the digestive system:Abnormality of the liver",
-    "llm_ranking": "(1) Sorafenib, (2) Doxorubicin, (3) Epirubicin, (4) Etoposide, (5) Mitoxantrone, (6) Gadobenic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Sorafenib",
+        "llm-average": 17.08
+      },
+      {
+        "entity_name": "Doxorubicin",
+        "llm-average": 8.58
+      },
+      {
+        "entity_name": "Epirubicin",
+        "llm-average": 7.69
+      },
+      {
+        "entity_name": "Etoposide",
+        "llm-average": 6.79
+      },
+      {
+        "entity_name": "Mitoxantrone",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Gadobenic acid",
+        "llm-average": 2.44
+      }
+    ]
   },
   {
     "question_number": 227,
     "qid": 163,
     "text": "What drugs are indicated for Sinus tachycardia?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Esmolol, (2) Pindolol, (3) Oxprenolol, (4) Salbutamol"
+    "llm_ranking": [
+      {
+        "entity_name": "Esmolol",
+        "llm-average": 17.52
+      },
+      {
+        "entity_name": "Pindolol",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Oxprenolol",
+        "llm-average": 11.48
+      },
+      {
+        "entity_name": "Salbutamol",
+        "llm-average": 4.06
+      }
+    ]
   },
   {
     "question_number": 228,
     "qid": 165,
     "text": "What drugs have solute carrier organic anion transporter family member 1A2 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Rifampicin, (2) Testosterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Rifampicin",
+        "llm-average": 15.55
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 9.18
+      }
+    ]
   },
   {
     "question_number": 229,
     "qid": 171,
     "text": "What drugs have Fc fragment of IgE receptor Ia as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Omalizumab, (2) Benzylpenicilloyl polylysine"
+    "llm_ranking": [
+      {
+        "entity_name": "Omalizumab",
+        "llm-average": 17.52
+      },
+      {
+        "entity_name": "Benzylpenicilloyl polylysine",
+        "llm-average": 7.54
+      }
+    ]
   },
   {
     "question_number": 230,
     "qid": 176,
     "text": "What drugs have discoidin domain receptor tyrosine kinase 2 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Regorafenib, (2) Imatinib, (3) Dasatinib, (4) Nilotinib, (5) Sorafenib, (6) Erlotinib"
+    "llm_ranking": [
+      {
+        "entity_name": "Regorafenib",
+        "llm-average": 12.27
+      },
+      {
+        "entity_name": "Imatinib",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Nilotinib",
+        "llm-average": 11.91
+      },
+      {
+        "entity_name": "Dasatinib",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "Sorafenib",
+        "llm-average": 9.66
+      },
+      {
+        "entity_name": "Erlotinib",
+        "llm-average": 7.72
+      }
+    ]
   },
   {
     "question_number": 231,
     "qid": 177,
     "text": "What drugs have fibroblast growth factor receptor 4 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Infigratinib, (2) Erdafitinib, (3) Orantinib, (4) Brivanib, (5) Nintedanib, (6) Brivanib alaninate, (7) Palifermin, (8) Dovitinib"
+    "llm_ranking": [
+      {
+        "entity_name": "Infigratinib",
+        "llm-average": 17.46
+      },
+      {
+        "entity_name": "Erdafitinib",
+        "llm-average": 16.84
+      },
+      {
+        "entity_name": "Orantinib",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "Brivanib",
+        "llm-average": 12.88
+      },
+      {
+        "entity_name": "Nintedanib",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Brivanib alaninate",
+        "llm-average": 11.46
+      },
+      {
+        "entity_name": "Palifermin",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "Dovitinib",
+        "llm-average": 9.18
+      }
+    ]
   },
   {
     "question_number": 232,
     "qid": 178,
     "text": "What drugs have carbonic anhydrase 9 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Ethoxzolamide, (2) Sunitinib"
+    "llm_ranking": [
+      {
+        "entity_name": "Ethoxzolamide",
+        "llm-average": 16.54
+      },
+      {
+        "entity_name": "Sunitinib",
+        "llm-average": 11.03
+      }
+    ]
   },
   {
     "question_number": 233,
     "qid": 180,
     "text": "What drugs are indicated for Metabolic alkalosis?",
     "category": "Abnormality of metabolism/homeostasis:Abnormality of acid-base homeostasis",
-    "llm_ranking": "(1) Amiloride, (2) Prednisone, (3) D-Allopyranose, (4) Balsalazide, (5) Beta-D-Glucose, (6) Codeine"
+    "llm_ranking": [
+      {
+        "entity_name": "Amiloride",
+        "llm-average": 18.9
+      },
+      {
+        "entity_name": "Prednisone",
+        "llm-average": 7.27
+      },
+      {
+        "entity_name": "D-Allopyranose",
+        "llm-average": 3.87
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 3.56
+      },
+      {
+        "entity_name": "Beta-D-Glucose",
+        "llm-average": 2.75
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 1.52
+      }
+    ]
   },
   {
     "question_number": 234,
     "qid": 182,
     "text": "What drugs are indicated for Apnea?",
     "category": "Abnormality of the respiratory system:Abnormal pattern of respiration",
-    "llm_ranking": "(1) Caffeine, (2) Doxapram, (3) Modafinil, (4) Hydroxocobalamin, (5) Desflurane, (6) Fentanyl, (7) Balsalazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Caffeine",
+        "llm-average": 17.52
+      },
+      {
+        "entity_name": "Doxapram",
+        "llm-average": 16.42
+      },
+      {
+        "entity_name": "Modafinil",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Hydroxocobalamin",
+        "llm-average": 4.91
+      },
+      {
+        "entity_name": "Desflurane",
+        "llm-average": 4.33
+      },
+      {
+        "entity_name": "Fentanyl",
+        "llm-average": 3.46
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 1.98
+      }
+    ]
   },
   {
     "question_number": 235,
     "qid": 184,
     "text": "What drugs act on PDHA2?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) alpha-Ketoisocaproic acid, (2) Cocarboxylase, (3) NADH, (4) Coenzyme A, (5) Isocaproic acid, (6) Pyruvic acid, (7) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "alpha-Ketoisocaproic acid",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "Cocarboxylase",
+        "llm-average": 11.03
+      },
+      {
+        "entity_name": "NADH",
+        "llm-average": 10.74
+      },
+      {
+        "entity_name": "Coenzyme A",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "Isocaproic acid",
+        "llm-average": 10.62
+      },
+      {
+        "entity_name": "Pyruvic acid",
+        "llm-average": 8.28
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 6.37
+      }
+    ]
   },
   {
     "question_number": 236,
     "qid": 185,
     "text": "What drugs are indicated for Cor pulmonale?",
     "category": "Abnormality of the cardiovascular system:Abnormal heart morphology",
-    "llm_ranking": "(1) Aminophylline, (2) Amantadine, (3) Ribavirin"
+    "llm_ranking": [
+      {
+        "entity_name": "Aminophylline",
+        "llm-average": 10.68
+      },
+      {
+        "entity_name": "Amantadine",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "Ribavirin",
+        "llm-average": 8.94
+      }
+    ]
   },
   {
     "question_number": 237,
     "qid": 191,
     "text": "What drugs have signal transducer and activator of transcription 5B as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Dasatinib, (2) Erythropoietin"
+    "llm_ranking": [
+      {
+        "entity_name": "Dasatinib",
+        "llm-average": 17.52
+      },
+      {
+        "entity_name": "Erythropoietin",
+        "llm-average": 10.49
+      }
+    ]
   },
   {
     "question_number": 238,
     "qid": 192,
     "text": "What drugs act on UBE2O?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) Cyclosporine, (2) Atrazine, (3) ATP, (4) Adenosine phosphate, (5) Pyrophosphoric acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 10.25
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 7.48
+      },
+      {
+        "entity_name": "Adenosine phosphate",
+        "llm-average": 6.6
+      },
+      {
+        "entity_name": "Pyrophosphoric acid",
+        "llm-average": 4.62
+      }
+    ]
   },
   {
     "question_number": 239,
     "qid": 193,
     "text": "What drugs have peptidylprolyl isomerase A as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) SCY-635, (2) Cyclosporine, (3) Proline"
+    "llm_ranking": [
+      {
+        "entity_name": "SCY-635",
+        "llm-average": 15.7
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 13.31
+      },
+      {
+        "entity_name": "Proline",
+        "llm-average": 3.43
+      }
+    ]
   },
   {
     "question_number": 240,
     "qid": 195,
     "text": "What drugs are indicated for Varicose veins?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system morphology",
-    "llm_ranking": "(1) Sodium tetradecyl sulfate, (2) Estradiol, (3) Beta-D-Glucose, (4) D-Allopyranose"
+    "llm_ranking": [
+      {
+        "entity_name": "Sodium tetradecyl sulfate",
+        "llm-average": 18.9
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 6.57
+      },
+      {
+        "entity_name": "Beta-D-Glucose",
+        "llm-average": 2.9
+      },
+      {
+        "entity_name": "D-Allopyranose",
+        "llm-average": 2.48
+      }
+    ]
   },
   {
     "question_number": 241,
     "qid": 196,
     "text": "What drugs have FSCN1 as a compiled target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Paclitaxel, (2) Mitomycin, (3) Codeine, (4) 1,4-Dithiothreitol, (5) Butyric Acid, (6) Dithioerythritol, (7) D-1,4-dithiothreitol, (8) Beta-D-Fructopyranose"
+    "llm_ranking": [
+      {
+        "entity_name": "Paclitaxel",
+        "llm-average": 15.04
+      },
+      {
+        "entity_name": "Mitomycin",
+        "llm-average": 13.88
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "1,4-Dithiothreitol",
+        "llm-average": 7.95
+      },
+      {
+        "entity_name": "Butyric Acid",
+        "llm-average": 7.54
+      },
+      {
+        "entity_name": "Dithioerythritol",
+        "llm-average": 6.79
+      },
+      {
+        "entity_name": "D-1,4-dithiothreitol",
+        "llm-average": 4.85
+      },
+      {
+        "entity_name": "Beta-D-Fructopyranose",
+        "llm-average": 4.83
+      }
+    ]
   },
   {
     "question_number": 242,
     "qid": 198,
     "text": "What drugs have potassium inwardly rectifying channel subfamily J member 8 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Diazoxide, (2) Thiamylal"
+    "llm_ranking": [
+      {
+        "entity_name": "Diazoxide",
+        "llm-average": 16.54
+      },
+      {
+        "entity_name": "Thiamylal",
+        "llm-average": 9.18
+      }
+    ]
   },
   {
     "question_number": 243,
     "qid": 199,
     "text": "What drugs are indicated for Retinal vein occlusion?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) Dexamethasone, (2) Betamethasone"
+    "llm_ranking": [
+      {
+        "entity_name": "Dexamethasone",
+        "llm-average": 8.67
+      },
+      {
+        "entity_name": "Betamethasone",
+        "llm-average": 7.32
+      }
+    ]
   },
   {
     "question_number": 244,
     "qid": 200,
     "text": "What drugs have haptoglobin as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Pyridoxine, (2) Estradiol"
+    "llm_ranking": [
+      {
+        "entity_name": "Pyridoxine",
+        "llm-average": 13.25
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 12.15
+      }
+    ]
   },
   {
     "question_number": 245,
     "qid": 202,
     "text": "What drugs are indicated for Hyponatremia?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal blood ion concentration",
-    "llm_ranking": "(1) Tolvaptan, (2) Conivaptan, (3) D-Allopyranose, (4) Acetic acid, (5) Beta-D-Glucose, (6) Balsalazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Tolvaptan",
+        "llm-average": 18.9
+      },
+      {
+        "entity_name": "Conivaptan",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "D-Allopyranose",
+        "llm-average": 1.12
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 0.79
+      },
+      {
+        "entity_name": "Beta-D-Glucose",
+        "llm-average": 0.59
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 246,
     "qid": 203,
     "text": "What drugs are indicated for Ventricular extrasystoles?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Pindolol, (2) Dexpropranolol, (3) Propranolol, (4) Oxprenolol, (5) Metoprolol, (6) Acebutolol, (7) Nitroglycerin"
+    "llm_ranking": [
+      {
+        "entity_name": "Dexpropranolol",
+        "llm-average": 11.67
+      },
+      {
+        "entity_name": "Pindolol",
+        "llm-average": 11.61
+      },
+      {
+        "entity_name": "Oxprenolol",
+        "llm-average": 11.51
+      },
+      {
+        "entity_name": "Propranolol",
+        "llm-average": 11.48
+      },
+      {
+        "entity_name": "Metoprolol",
+        "llm-average": 10.96
+      },
+      {
+        "entity_name": "Acebutolol",
+        "llm-average": 9.74
+      },
+      {
+        "entity_name": "Nitroglycerin",
+        "llm-average": 8.94
+      }
+    ]
   },
   {
     "question_number": 247,
     "qid": 205,
     "text": "What drugs are indicated for Renovascular hypertension?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Trandolapril, (2) Cilazapril, (3) Fosinopril, (4) Enalapril, (5) Ramipril, (6) Quinapril, (7) Lisinopril"
+    "llm_ranking": [
+      {
+        "entity_name": "Trandolapril",
+        "llm-average": 14.24
+      },
+      {
+        "entity_name": "Cilazapril",
+        "llm-average": 11.28
+      },
+      {
+        "entity_name": "Fosinopril",
+        "llm-average": 10.19
+      },
+      {
+        "entity_name": "Enalapril",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "Ramipril",
+        "llm-average": 7.3
+      },
+      {
+        "entity_name": "Quinapril",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Lisinopril",
+        "llm-average": 5.35
+      }
+    ]
   },
   {
     "question_number": 248,
     "qid": 206,
     "text": "What drugs have coagulation factor II, thrombin as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Ximelagatran, (2) Bivalirudin, (3) Argatroban, (4) Lepirudin, (5) Menadione, (6) Tamoxifen, (7) Enoxaparin, (8) Heparin"
+    "llm_ranking": [
+      {
+        "entity_name": "Bivalirudin",
+        "llm-average": 15.46
+      },
+      {
+        "entity_name": "Ximelagatran",
+        "llm-average": 15.44
+      },
+      {
+        "entity_name": "Argatroban",
+        "llm-average": 15.21
+      },
+      {
+        "entity_name": "Lepirudin",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "Menadione",
+        "llm-average": 9.33
+      },
+      {
+        "entity_name": "Tamoxifen",
+        "llm-average": 9.23
+      },
+      {
+        "entity_name": "Heparin",
+        "llm-average": 7.36
+      },
+      {
+        "entity_name": "Enoxaparin",
+        "llm-average": 7.35
+      }
+    ]
   },
   {
     "question_number": 249,
     "qid": 209,
     "text": "What drugs act on UBE4A?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) Resveratrol, (2) Acetylsalicylic acid, (3) ATP, (4) Pyrophosphoric acid, (5) Adenosine phosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Resveratrol",
+        "llm-average": 14.71
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 8.87
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 5.8
+      },
+      {
+        "entity_name": "Pyrophosphoric acid",
+        "llm-average": 4.72
+      },
+      {
+        "entity_name": "Adenosine phosphate",
+        "llm-average": 4.62
+      }
+    ]
   },
   {
     "question_number": 250,
     "qid": 212,
     "text": "What drugs have phosphodiesterase 1A as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal cardiovascular system physiology",
-    "llm_ranking": "(1) Crisaborole, (2) Vinpocetine, (3) Bepridil, (4) Dipyridamole, (5) Pentoxifylline"
+    "llm_ranking": [
+      {
+        "entity_name": "Crisaborole",
+        "llm-average": 13.26
+      },
+      {
+        "entity_name": "Bepridil",
+        "llm-average": 12.26
+      },
+      {
+        "entity_name": "Vinpocetine",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Dipyridamole",
+        "llm-average": 11.71
+      },
+      {
+        "entity_name": "Pentoxifylline",
+        "llm-average": 7.35
+      }
+    ]
   },
   {
     "question_number": 251,
     "qid": 216,
     "text": "What drugs have interleukin 2 receptor subunit beta as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Denileukin diftitox, (2) Daclizumab, (3) Basiliximab, (4) Aldesleukin"
+    "llm_ranking": [
+      {
+        "entity_name": "Denileukin diftitox",
+        "llm-average": 17.92
+      },
+      {
+        "entity_name": "Daclizumab",
+        "llm-average": 13.07
+      },
+      {
+        "entity_name": "Basiliximab",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Aldesleukin",
+        "llm-average": 9.18
+      }
+    ]
   },
   {
     "question_number": 252,
     "qid": 219,
     "text": "What proteins are biomarkers of the disease glomerulonephritis?",
     "category": "urinary system disease:nephritis",
-    "llm_ranking": "(1) C4A, (2) C3"
+    "llm_ranking": [
+      {
+        "entity_name": "C4A",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "C3",
+        "llm-average": 8.67
+      }
+    ]
   },
   {
     "question_number": 253,
     "qid": 221,
     "text": "What drugs have GA binding protein transcription factor subunit alpha as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) Quercetin, (2) Cyclosporine"
+    "llm_ranking": [
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 12.32
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 11.03
+      }
+    ]
   },
   {
     "question_number": 254,
     "qid": 223,
     "text": "What drugs act on NEURL1B?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) Trichostatin A, (2) Vincristine, (3) Valproic acid, (4) Adenosine phosphate, (5) ATP, (6) Magnesium cation, (7) Pyrophosphoric acid, (8) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 15.63
+      },
+      {
+        "entity_name": "Vincristine",
+        "llm-average": 12.24
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 11.35
+      },
+      {
+        "entity_name": "Adenosine phosphate",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 5.35
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 5.12
+      },
+      {
+        "entity_name": "Pyrophosphoric acid",
+        "llm-average": 3.83
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 3.73
+      }
+    ]
   },
   {
     "question_number": 255,
     "qid": 224,
     "text": "What drugs are indicated for Abnormality of the coagulation cascade?",
     "category": "Abnormality of blood and blood-forming tissues:Abnormality of the coagulation cascade",
-    "llm_ranking": "(1) Tranexamic acid, (2) Phylloquinone"
+    "llm_ranking": [
+      {
+        "entity_name": "Tranexamic acid",
+        "llm-average": 14.17
+      },
+      {
+        "entity_name": "Phylloquinone",
+        "llm-average": 9.18
+      }
+    ]
   },
   {
     "question_number": 256,
     "qid": 225,
     "text": "What drugs have Prolonged PR interval as a side effect?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Lacosamide, (2) Fingolimod, (3) Regadenoson, (4) Gadobenic acid, (5) Aripiprazole, (6) Digoxin, (7) Naratriptan, (8) Trazodone"
+    "llm_ranking": [
+      {
+        "entity_name": "Lacosamide",
+        "llm-average": 14.65
+      },
+      {
+        "entity_name": "Fingolimod",
+        "llm-average": 13.72
+      },
+      {
+        "entity_name": "Regadenoson",
+        "llm-average": 12.99
+      },
+      {
+        "entity_name": "Gadobenic acid",
+        "llm-average": 12.2
+      },
+      {
+        "entity_name": "Aripiprazole",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Digoxin",
+        "llm-average": 11.0
+      },
+      {
+        "entity_name": "Naratriptan",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "Trazodone",
+        "llm-average": 9.99
+      }
+    ]
   },
   {
     "question_number": 257,
     "qid": 227,
     "text": "What drugs have calcium voltage-gated channel auxiliary subunit alpha2delta 3 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Imagabalin, (2) Atagabalin, (3) Pregabalin, (4) Gabapentin enacarbil, (5) Gabapentin"
+    "llm_ranking": [
+      {
+        "entity_name": "Imagabalin",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "Atagabalin",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "Pregabalin",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "Gabapentin enacarbil",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Gabapentin",
+        "llm-average": 9.18
+      }
+    ]
   },
   {
     "question_number": 258,
     "qid": 228,
     "text": "What drugs have cytochrome P450 family 3 subfamily A member 43 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) Cobicistat, (2) Melatonin, (3) Chlorzoxazone"
+    "llm_ranking": [
+      {
+        "entity_name": "Cobicistat",
+        "llm-average": 15.11
+      },
+      {
+        "entity_name": "Melatonin",
+        "llm-average": 13.31
+      },
+      {
+        "entity_name": "Chlorzoxazone",
+        "llm-average": 11.76
+      }
+    ]
   },
   {
     "question_number": 259,
     "qid": 231,
     "text": "What drugs act on FBXL6?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature of the eye",
-    "llm_ranking": "(1) Cyclosporine, (2) Quercetin, (3) (2S)-8-[(tert-butoxycarbonyl)amino]-2-(1H-indol-3-yl)octanoic acid, (4) (2S)-2-(1H-indol-3-yl)pentanoic acid, (5) 1-naphthaleneacetic acid, (6) (2S)-2-(1H-indol-3-yl)hexanoic acid, (7) Indoleacetic acid, (8) Dihydrogenphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 14.6
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "(2S)-8-[(tert-butoxycarbonyl)amino]-2-(1H-indol-3-yl)octanoic acid",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "(2S)-2-(1H-indol-3-yl)pentanoic acid",
+        "llm-average": 11.71
+      },
+      {
+        "entity_name": "1-naphthaleneacetic acid",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "(2S)-2-(1H-indol-3-yl)hexanoic acid",
+        "llm-average": 10.55
+      },
+      {
+        "entity_name": "Indoleacetic acid",
+        "llm-average": 8.74
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 4.62
+      }
+    ]
   },
   {
     "question_number": 260,
     "qid": 232,
     "text": "What drugs have BRAP as a compiled target?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) ATP, (2) Pyrophosphoric acid, (3) Adenosine phosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "Pyrophosphoric acid",
+        "llm-average": 9.52
+      },
+      {
+        "entity_name": "Adenosine phosphate",
+        "llm-average": 5.71
+      }
+    ]
   },
   {
     "question_number": 261,
     "qid": 235,
     "text": "What drugs have poly(ADP-ribose) polymerase 2 as a curated target?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) Veliparib, (2) Niraparib, (3) Talazoparib, (4) Olaparib, (5) Rucaparib"
+    "llm_ranking": [
+      {
+        "entity_name": "Veliparib",
+        "llm-average": 14.96
+      },
+      {
+        "entity_name": "Niraparib",
+        "llm-average": 11.64
+      },
+      {
+        "entity_name": "Talazoparib",
+        "llm-average": 11.54
+      },
+      {
+        "entity_name": "Olaparib",
+        "llm-average": 11.38
+      },
+      {
+        "entity_name": "Rucaparib",
+        "llm-average": 8.67
+      }
+    ]
   },
   {
     "question_number": 262,
     "qid": 391,
     "text": "Which phenotypes are side effects caused by Magnesium cation, which acts on ACADS that is compiled as interacting with ALDH9A1?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Diaphragmatic paralysis, (2) Decreased pulmonary function, (3) Hypocalcemia, (4) Hyperhidrosis, (5) Erythema, (6) Hypothermia, (7) Hypotension"
+    "llm_ranking": [
+      {
+        "entity_name": "Diaphragmatic paralysis",
+        "llm-average": 12.28
+      },
+      {
+        "entity_name": "Decreased pulmonary function",
+        "llm-average": 11.85
+      },
+      {
+        "entity_name": "Hypocalcemia",
+        "llm-average": 9.57
+      },
+      {
+        "entity_name": "Hyperhidrosis",
+        "llm-average": 6.93
+      },
+      {
+        "entity_name": "Erythema",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "Hypothermia",
+        "llm-average": 5.28
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 5.05
+      }
+    ]
   },
   {
     "question_number": 263,
     "qid": 395,
     "text": "Which genes are curated as targets of Calcitriol, which acts on AIG1 that is curated as interacting with RCHY1?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal blood ion concentration",
-    "llm_ranking": "(1) growth differentiation factor 15, (2) interleukin 2, (3) vitamin D receptor, (4) plasminogen activator, urokinase, (5) thyroglobulin, (6) MYC proto-oncogene, bHLH transcription factor, (7) phosphate regulating endopeptidase homolog X-linked, (8) basic transcription factor 3 pseudogene 11"
+    "llm_ranking": [
+      {
+        "entity_name": "growth differentiation factor 15",
+        "llm-average": 16.17
+      },
+      {
+        "entity_name": "interleukin 2",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "vitamin D receptor",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "plasminogen activator, urokinase",
+        "llm-average": 9.5
+      },
+      {
+        "entity_name": "thyroglobulin",
+        "llm-average": 8.38
+      },
+      {
+        "entity_name": "MYC proto-oncogene, bHLH transcription factor",
+        "llm-average": 8.15
+      },
+      {
+        "entity_name": "phosphate regulating endopeptidase homolog X-linked",
+        "llm-average": 5.58
+      },
+      {
+        "entity_name": "basic transcription factor 3 pseudogene 11",
+        "llm-average": 1.12
+      }
+    ]
   },
   {
     "question_number": 264,
     "qid": 399,
     "text": "Which genes are curated as targets of Quinine, which acts on CHRM5 that is curated as interacting with CHRM5?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) solute carrier family 29 member 4, (2) cytochrome P450 family 3 subfamily A member 7, (3) potassium voltage-gated channel subfamily B member 2, (4) interleukin 2"
+    "llm_ranking": [
+      {
+        "entity_name": "solute carrier family 29 member 4",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "cytochrome P450 family 3 subfamily A member 7",
+        "llm-average": 9.64
+      },
+      {
+        "entity_name": "potassium voltage-gated channel subfamily B member 2",
+        "llm-average": 7.92
+      },
+      {
+        "entity_name": "interleukin 2",
+        "llm-average": 7.59
+      }
+    ]
   },
   {
     "question_number": 265,
     "qid": 402,
     "text": "Which genes are curated as targets of Nitric Oxide, which acts on AKR1B1 that is annotated in pathway Fructose Intolerance, Hereditary?",
     "category": "Abnormality of the cardiovascular system:Abnormal cardiovascular system physiology",
-    "llm_ranking": "(1) guanylate cyclase 1 soluble subunit alpha 2, (2) natriuretic peptide receptor 1, (3) dopamine receptor D1, (4) guanylate cyclase 1 soluble subunit beta 2 (pseudogene)"
+    "llm_ranking": [
+      {
+        "entity_name": "guanylate cyclase 1 soluble subunit alpha 2",
+        "llm-average": 10.17
+      },
+      {
+        "entity_name": "natriuretic peptide receptor 1",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "dopamine receptor D1",
+        "llm-average": 7.39
+      },
+      {
+        "entity_name": "guanylate cyclase 1 soluble subunit beta 2 (pseudogene)",
+        "llm-average": 6.83
+      }
+    ]
   },
   {
     "question_number": 266,
     "qid": 404,
     "text": "Which phenotypes are side effects caused by Tromethamine, which acts on NIF3L1 that is the QC marker in tissue blood plasma?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) Hepatic necrosis, (2) Venous thrombosis, (3) Hypervolemia, (4) Decreased pulmonary function, (5) Hypoventilation, (6) Fever"
+    "llm_ranking": [
+      {
+        "entity_name": "Hepatic necrosis",
+        "llm-average": 11.29
+      },
+      {
+        "entity_name": "Venous thrombosis",
+        "llm-average": 10.83
+      },
+      {
+        "entity_name": "Hypervolemia",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Decreased pulmonary function",
+        "llm-average": 8.15
+      },
+      {
+        "entity_name": "Hypoventilation",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "Fever",
+        "llm-average": 1.72
+      }
+    ]
   },
   {
     "question_number": 267,
     "qid": 406,
     "text": "Which genes are curated as targets of Calcitriol, which acts on RPLP2 that is the subunit of 60S ribosomal subunit, cytoplasmic?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal blood ion concentration",
-    "llm_ranking": "(1) vitamin D receptor, (2) growth differentiation factor 15, (3) phosphate regulating endopeptidase homolog X-linked, (4) MYC proto-oncogene, bHLH transcription factor, (5) interleukin 2, (6) thyroglobulin, (7) basic transcription factor 3 pseudogene 11, (8) plasminogen activator, urokinase"
+    "llm_ranking": [
+      {
+        "entity_name": "growth differentiation factor 15",
+        "llm-average": 16.7
+      },
+      {
+        "entity_name": "phosphate regulating endopeptidase homolog X-linked",
+        "llm-average": 11.39
+      },
+      {
+        "entity_name": "MYC proto-oncogene, bHLH transcription factor",
+        "llm-average": 9.77
+      },
+      {
+        "entity_name": "interleukin 2",
+        "llm-average": 9.7
+      },
+      {
+        "entity_name": "vitamin D receptor",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "plasminogen activator, urokinase",
+        "llm-average": 6.86
+      },
+      {
+        "entity_name": "thyroglobulin",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "basic transcription factor 3 pseudogene 11",
+        "llm-average": 3.89
+      }
+    ]
   },
   {
     "question_number": 268,
     "qid": 408,
     "text": "Which genes are curated as targets of Codeine, which acts on C5 that is the biomarker of disease kidney disease?",
     "category": "urinary system disease:kidney disease",
-    "llm_ranking": "(1) cytochrome P450 family 2 subfamily D member 6, (2) opioid receptor delta 1, (3) opioid receptor mu 1, (4) opioid receptor kappa 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily D member 6",
+        "llm-average": 15.84
+      },
+      {
+        "entity_name": "opioid receptor delta 1",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "opioid receptor mu 1",
+        "llm-average": 8.38
+      },
+      {
+        "entity_name": "opioid receptor kappa 1",
+        "llm-average": 7.43
+      }
+    ]
   },
   {
     "question_number": 269,
     "qid": 409,
     "text": "Which genes are curated as targets of Codeine, which acts on AP2A1 that is annotated in pathway WNT5A-dependent internalization of FZD4?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) cytochrome P450 family 2 subfamily D member 6, (2) opioid receptor delta 1, (3) opioid receptor mu 1, (4) opioid receptor kappa 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily D member 6",
+        "llm-average": 12.38
+      },
+      {
+        "entity_name": "opioid receptor delta 1",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "opioid receptor mu 1",
+        "llm-average": 8.38
+      },
+      {
+        "entity_name": "opioid receptor kappa 1",
+        "llm-average": 7.43
+      }
+    ]
   },
   {
     "question_number": 270,
     "qid": 411,
     "text": "Which genes are curated as targets of Acetic acid, which acts on ACTC1 that is curated as interacting with SCYL2?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal blood ion concentration",
-    "llm_ranking": "(1) free fatty acid receptor 2, (2) 5-hydroxytryptamine receptor 2C, (3) 5-hydroxytryptamine receptor 2A, (4) 5-hydroxytryptamine receptor 2B, (5) adenosine deaminase RNA specific B2 (inactive)"
+    "llm_ranking": [
+      {
+        "entity_name": "free fatty acid receptor 2",
+        "llm-average": 8.32
+      },
+      {
+        "entity_name": "5-hydroxytryptamine receptor 2C",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "5-hydroxytryptamine receptor 2A",
+        "llm-average": 6.44
+      },
+      {
+        "entity_name": "5-hydroxytryptamine receptor 2B",
+        "llm-average": 6.4
+      },
+      {
+        "entity_name": "adenosine deaminase RNA specific B2 (inactive)",
+        "llm-average": 4.46
+      }
+    ]
   },
   {
     "question_number": 271,
     "qid": 412,
     "text": "Which genes are curated as targets of Dronabinol, which acts on AGO1 that is curated as interacting with RPL21?",
     "category": "Abnormality of the digestive system:Abdominal symptom",
-    "llm_ranking": "(1) cytochrome P450 family 2 subfamily C member 9, (2) cannabinoid receptor 2, (3) cannabinoid receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cannabinoid receptor 2",
+        "llm-average": 10.63
+      },
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily C member 9",
+        "llm-average": 10.5
+      },
+      {
+        "entity_name": "cannabinoid receptor 1",
+        "llm-average": 9.37
+      }
+    ]
   },
   {
     "question_number": 272,
     "qid": 413,
     "text": "Which genes are curated as targets of Pyrophosphoric acid, which acts on BRAP that is annotated in pathway Signaling downstream of RAS mutants?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) formyl peptide receptor 1, (2) formyl peptide receptor 3, (3) formyl peptide receptor 2"
+    "llm_ranking": [
+      {
+        "entity_name": "formyl peptide receptor 1",
+        "llm-average": 6.9
+      },
+      {
+        "entity_name": "formyl peptide receptor 3",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "formyl peptide receptor 2",
+        "llm-average": 6.44
+      }
+    ]
   },
   {
     "question_number": 273,
     "qid": 414,
     "text": "Which genes are curated as targets of Balsalazide, which acts on ATG12 that is annotated in pathway Receptor Mediated Mitophagy?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) peroxisome proliferator activated receptor gamma, (2) arachidonate 5-lipoxygenase, (3) prostaglandin-endoperoxide synthase 1, (4) prostaglandin-endoperoxide synthase 2"
+    "llm_ranking": [
+      {
+        "entity_name": "peroxisome proliferator activated receptor gamma",
+        "llm-average": 14.85
+      },
+      {
+        "entity_name": "arachidonate 5-lipoxygenase",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 1",
+        "llm-average": 6.44
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 2",
+        "llm-average": 5.61
+      }
+    ]
   },
   {
     "question_number": 274,
     "qid": 416,
     "text": "Which genes are curated as targets of Dronabinol, which acts on AGO1 that is annotated in pathway Regulation of RUNX1 Expression and Activity?",
     "category": "Abnormality of the digestive system:Abdominal symptom",
-    "llm_ranking": "(1) cytochrome P450 family 2 subfamily C member 9, (2) cannabinoid receptor 2, (3) cannabinoid receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily C member 9",
+        "llm-average": 9.5
+      },
+      {
+        "entity_name": "cannabinoid receptor 2",
+        "llm-average": 9.5
+      },
+      {
+        "entity_name": "cannabinoid receptor 1",
+        "llm-average": 8.38
+      }
+    ]
   },
   {
     "question_number": 275,
     "qid": 420,
     "text": "Which genes are curated as targets of Phencyclidine, which acts on CCNB1 that is annotated in pathway P53 Signaling Pathway?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) glutamate ionotropic receptor NMDA type subunit 2B, (2) glutamate ionotropic receptor NMDA type subunit 2A, (3) glutamate ionotropic receptor NMDA type subunit 2C"
+    "llm_ranking": [
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
+        "llm-average": 13.07
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
+        "llm-average": 11.29
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
+        "llm-average": 6.6
+      }
+    ]
   },
   {
     "question_number": 276,
     "qid": 421,
     "text": "Which phenotypes are side effects caused by Magnesium cation, which acts on ATP5PD that is annotated in pathway Formation of ATP by chemiosmotic coupling?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Diaphragmatic paralysis, (2) Hypocalcemia, (3) Decreased pulmonary function, (4) Hyperhidrosis, (5) Hypothermia, (6) Erythema, (7) Hypotension"
+    "llm_ranking": [
+      {
+        "entity_name": "Diaphragmatic paralysis",
+        "llm-average": 15.45
+      },
+      {
+        "entity_name": "Hypocalcemia",
+        "llm-average": 13.56
+      },
+      {
+        "entity_name": "Decreased pulmonary function",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "Hyperhidrosis",
+        "llm-average": 9.7
+      },
+      {
+        "entity_name": "Hypothermia",
+        "llm-average": 9.54
+      },
+      {
+        "entity_name": "Erythema",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 5.54
+      }
+    ]
   },
   {
     "question_number": 277,
     "qid": 423,
     "text": "Which genes are curated as targets of Phencyclidine, which acts on FTH1 that is the biomarker of disease iron deficiency anemia?",
     "category": "disease of metabolism:nutrition disease",
-    "llm_ranking": "(1) glutamate ionotropic receptor NMDA type subunit 2B, (2) glutamate ionotropic receptor NMDA type subunit 2A, (3) glutamate ionotropic receptor NMDA type subunit 2C"
+    "llm_ranking": [
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
+        "llm-average": 14.26
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
+        "llm-average": 11.29
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
+        "llm-average": 7.79
+      }
+    ]
   },
   {
     "question_number": 278,
     "qid": 425,
     "text": "Which genes are curated as targets of Penbutolol, which acts on ADRB1 that is annotated in pathway Ibutilide Action Pathway?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) adrenoceptor beta 1, (2) adrenoceptor beta 2"
+    "llm_ranking": [
+      {
+        "entity_name": "adrenoceptor beta 1",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "adrenoceptor beta 2",
+        "llm-average": 4.32
+      }
+    ]
   },
   {
     "question_number": 279,
     "qid": 426,
     "text": "Which genes are curated as targets of Pyrophosphoric acid, which acts on CCNH that is annotated in pathway Cyclin E associated events during G1/S transition ?",
     "category": "Abnormality of the cardiovascular system:Abnormality of blood circulation",
-    "llm_ranking": "(1) formyl peptide receptor 1, (2) formyl peptide receptor 3, (3) formyl peptide receptor 2"
+    "llm_ranking": [
+      {
+        "entity_name": "formyl peptide receptor 1",
+        "llm-average": 6.9
+      },
+      {
+        "entity_name": "formyl peptide receptor 3",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "formyl peptide receptor 2",
+        "llm-average": 6.44
+      }
+    ]
   },
   {
     "question_number": 280,
     "qid": 427,
     "text": "Which genes are curated as targets of Disulfiram, which acts on ALDH1A3 that is annotated in pathway RA biosynthesis pathway?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) translocator protein, (2) gamma-glutamyltransferase 1, (3) aldehyde dehydrogenase 3 family member A1, (4) glial fibrillary acidic protein, (5) aldehyde dehydrogenase 2 family member"
+    "llm_ranking": [
+      {
+        "entity_name": "translocator protein",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "gamma-glutamyltransferase 1",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "aldehyde dehydrogenase 3 family member A1",
+        "llm-average": 8.78
+      },
+      {
+        "entity_name": "aldehyde dehydrogenase 2 family member",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "glial fibrillary acidic protein",
+        "llm-average": 6.44
+      }
+    ]
   },
   {
     "question_number": 281,
     "qid": 428,
     "text": "Which phenotypes are side effects caused by Magnesium cation, which acts on CARD11 that is annotated in pathway FCERI mediated NF-kB activation?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Diaphragmatic paralysis, (2) Hypocalcemia, (3) Decreased pulmonary function, (4) Hyperhidrosis, (5) Erythema, (6) Hypothermia, (7) Hypotension"
+    "llm_ranking": [
+      {
+        "entity_name": "Diaphragmatic paralysis",
+        "llm-average": 14.46
+      },
+      {
+        "entity_name": "Hypocalcemia",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "Decreased pulmonary function",
+        "llm-average": 11.62
+      },
+      {
+        "entity_name": "Hyperhidrosis",
+        "llm-average": 9.31
+      },
+      {
+        "entity_name": "Erythema",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "Hypothermia",
+        "llm-average": 5.78
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 4.52
+      }
+    ]
   },
   {
     "question_number": 282,
     "qid": 429,
     "text": "Which genes are curated as targets of Codeine, which acts on ACYP1 that is annotated in pathway Leigh Syndrome?",
     "category": "Abnormality of the cardiovascular system:Abnormality of cardiovascular system electrophysiology",
-    "llm_ranking": "(1) cytochrome P450 family 2 subfamily D member 6, (2) opioid receptor delta 1, (3) opioid receptor kappa 1, (4) opioid receptor mu 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily D member 6",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "opioid receptor kappa 1",
+        "llm-average": 10.89
+      },
+      {
+        "entity_name": "opioid receptor delta 1",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "opioid receptor mu 1",
+        "llm-average": 8.38
+      }
+    ]
   },
   {
     "question_number": 283,
     "qid": 432,
     "text": "Which genes are curated as targets of Naltrexone, which acts on HTR1A that is curated as interacting with HTR1B?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) BCL2 associated X, apoptosis regulator, (2) sigma non-opioid intracellular receptor 1, (3) tachykinin precursor 1, (4) glucagon, (5) opioid receptor kappa 1, (6) opioid receptor mu 1, (7) opioid receptor delta 1"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2 associated X, apoptosis regulator",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "sigma non-opioid intracellular receptor 1",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "tachykinin precursor 1",
+        "llm-average": 9.64
+      },
+      {
+        "entity_name": "glucagon",
+        "llm-average": 9.31
+      },
+      {
+        "entity_name": "opioid receptor mu 1",
+        "llm-average": 8.75
+      },
+      {
+        "entity_name": "opioid receptor kappa 1",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "opioid receptor delta 1",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 284,
     "qid": 434,
     "text": "Which phenotypes are side effects caused by Magnesium cation, which acts on AZIN2 that is annotated in pathway Agmatine biosynthesis?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Diaphragmatic paralysis, (2) Decreased pulmonary function, (3) Hypocalcemia, (4) Hyperhidrosis, (5) Hypothermia, (6) Erythema, (7) Hypotension"
+    "llm_ranking": [
+      {
+        "entity_name": "Diaphragmatic paralysis",
+        "llm-average": 12.67
+      },
+      {
+        "entity_name": "Decreased pulmonary function",
+        "llm-average": 11.85
+      },
+      {
+        "entity_name": "Hypocalcemia",
+        "llm-average": 7.26
+      },
+      {
+        "entity_name": "Hypothermia",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Hyperhidrosis",
+        "llm-average": 6.93
+      },
+      {
+        "entity_name": "Erythema",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 4.52
+      }
+    ]
   },
   {
     "question_number": 285,
     "qid": 436,
     "text": "Which genes are curated as targets of Dronabinol, which acts on HTR1F that is compiled as interacting with SSTR4?",
     "category": "Abnormality of the digestive system:Abdominal symptom",
-    "llm_ranking": "(1) cytochrome P450 family 2 subfamily C member 9, (2) cannabinoid receptor 2, (3) cannabinoid receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily C member 9",
+        "llm-average": 9.9
+      },
+      {
+        "entity_name": "cannabinoid receptor 1",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "cannabinoid receptor 2",
+        "llm-average": 6.6
+      }
+    ]
   },
   {
     "question_number": 286,
     "qid": 439,
     "text": "Which phenotypes are side effects caused by Magnesium cation, which acts on GNG10 that is the subunit of GNAS-L-GNB4-GNG10 complex?",
     "category": "Abnormality of the cardiovascular system:Abnormality of the vasculature",
-    "llm_ranking": "(1) Hypocalcemia, (2) Diaphragmatic paralysis, (3) Decreased pulmonary function, (4) Hypothermia, (5) Hyperhidrosis, (6) Erythema, (7) Hypotension"
+    "llm_ranking": [
+      {
+        "entity_name": "Hypocalcemia",
+        "llm-average": 16.3
+      },
+      {
+        "entity_name": "Diaphragmatic paralysis",
+        "llm-average": 13.47
+      },
+      {
+        "entity_name": "Decreased pulmonary function",
+        "llm-average": 11.32
+      },
+      {
+        "entity_name": "Hypothermia",
+        "llm-average": 8.05
+      },
+      {
+        "entity_name": "Hyperhidrosis",
+        "llm-average": 7.72
+      },
+      {
+        "entity_name": "Erythema",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "Hypotension",
+        "llm-average": 3.73
+      }
+    ]
   },
   {
     "question_number": 287,
     "qid": 442,
     "text": "Which genes are curated as targets of Ethinylestradiol, which acts on ADAMTS9 that is annotated in pathway Defective B3GALTL causes Peters-plus syndrome (PpS)?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) anti-Mullerian hormone, (2) cytochrome P450 family 2 subfamily C member 19, (3) aquaporin 8, (4) prolactin, (5) cyclin A2, (6) estrogen receptor 1, (7) gamma-glutamyltransferase 1, (8) actin beta"
+    "llm_ranking": [
+      {
+        "entity_name": "anti-Mullerian hormone",
+        "llm-average": 11.29
+      },
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily C member 19",
+        "llm-average": 10.33
+      },
+      {
+        "entity_name": "aquaporin 8",
+        "llm-average": 9.5
+      },
+      {
+        "entity_name": "prolactin",
+        "llm-average": 8.15
+      },
+      {
+        "entity_name": "cyclin A2",
+        "llm-average": 7.92
+      },
+      {
+        "entity_name": "estrogen receptor 1",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "gamma-glutamyltransferase 1",
+        "llm-average": 5.12
+      },
+      {
+        "entity_name": "actin beta",
+        "llm-average": 3.47
+      }
+    ]
   },
   {
     "question_number": 288,
     "qid": 444,
     "text": "Which genes are curated as targets of Calcitriol, which acts on ATM that is annotated in pathway HDR through Single Strand Annealing (SSA)?",
     "category": "Abnormality of metabolism/homeostasis:Abnormal blood ion concentration",
-    "llm_ranking": "(1) vitamin D receptor, (2) growth differentiation factor 15, (3) phosphate regulating endopeptidase homolog X-linked, (4) interleukin 2, (5) plasminogen activator, urokinase, (6) MYC proto-oncogene, bHLH transcription factor, (7) basic transcription factor 3 pseudogene 11, (8) thyroglobulin"
+    "llm_ranking": [
+      {
+        "entity_name": "growth differentiation factor 15",
+        "llm-average": 14.92
+      },
+      {
+        "entity_name": "vitamin D receptor",
+        "llm-average": 9.41
+      },
+      {
+        "entity_name": "MYC proto-oncogene, bHLH transcription factor",
+        "llm-average": 9.37
+      },
+      {
+        "entity_name": "interleukin 2",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "plasminogen activator, urokinase",
+        "llm-average": 8.32
+      },
+      {
+        "entity_name": "phosphate regulating endopeptidase homolog X-linked",
+        "llm-average": 7.46
+      },
+      {
+        "entity_name": "thyroglobulin",
+        "llm-average": 2.34
+      },
+      {
+        "entity_name": "basic transcription factor 3 pseudogene 11",
+        "llm-average": 1.22
+      }
+    ]
   },
   {
     "question_number": 289,
     "qid": 446,
     "text": "Which genes are curated as targets of Cholesterol, which acts on ADAM10 that is annotated in pathway NOTCH4 Activation and Transmission of Signal to the Nucleus?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) RAR related orphan receptor A, (2) coagulation factor X, (3) mitogen-activated protein kinase 10"
+    "llm_ranking": [
+      {
+        "entity_name": "RAR related orphan receptor A",
+        "llm-average": 15.74
+      },
+      {
+        "entity_name": "coagulation factor X",
+        "llm-average": 9.37
+      },
+      {
+        "entity_name": "mitogen-activated protein kinase 10",
+        "llm-average": 8.91
+      }
+    ]
   },
   {
     "question_number": 290,
     "qid": 449,
     "text": "Which genes are curated as targets of Balsalazide, which acts on ACOX2 that is compiled as interacting with DECR2?",
     "category": "Abnormality of the cardiovascular system:Abnormal systemic blood pressure",
-    "llm_ranking": "(1) peroxisome proliferator activated receptor gamma, (2) arachidonate 5-lipoxygenase, (3) prostaglandin-endoperoxide synthase 1, (4) prostaglandin-endoperoxide synthase 2"
+    "llm_ranking": [
+      {
+        "entity_name": "peroxisome proliferator activated receptor gamma",
+        "llm-average": 18.51
+      },
+      {
+        "entity_name": "arachidonate 5-lipoxygenase",
+        "llm-average": 14.26
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 1",
+        "llm-average": 10.5
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 2",
+        "llm-average": 8.09
+      }
+    ]
   }
 ]

--- a/lib/batches/batch3.ts
+++ b/lib/batches/batch3.ts
@@ -6,2456 +6,8399 @@ export const batch3: Question[] = [
     "qid": 563,
     "text": "Which drugs have ARSI as a compiled target, which is associated with hereditary spastic paraplegia 27 and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Zinc, (2) Balsalazide, (3) NADH, (4) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "Zinc",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "NADH",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 7.45
+      }
+    ]
   },
   {
     "question_number": 2,
     "qid": 565,
     "text": "Which drugs act on YIF1A, which is associated with neuronal ceroid lipofuscinosis 6 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Elacytarabine, (2) Cytarabine, (3) Atrazine, (4) Valproic acid, (5) Cytidine"
+    "llm_ranking": [
+      {
+        "entity_name": "Elacytarabine",
+        "llm-average": 13.2
+      },
+      {
+        "entity_name": "Cytarabine",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Cytidine",
+        "llm-average": 8.1
+      }
+    ]
   },
   {
     "question_number": 3,
     "qid": 567,
     "text": "Which proteins are curated as interacting with PRR11, which is associated with cataract 4 multiple types and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MYC, (2) ESR1, (3) IL4R, (4) OSBPL5"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "ESR1",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "IL4R",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "OSBPL5",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 4,
     "qid": 568,
     "text": "Which metabolites are associated with GDPD2, which is associated with sphingolipidosis and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Glycerophosphoinositol, (2) Inositol phosphate, (3) Glycerol, (4) Water"
+    "llm_ranking": [
+      {
+        "entity_name": "Glycerophosphoinositol",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "Inositol phosphate",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Glycerol",
+        "llm-average": 5.1
+      },
+      {
+        "entity_name": "Water",
+        "llm-average": 1.18
+      }
+    ]
   },
   {
     "question_number": 5,
     "qid": 569,
     "text": "Which proteins act on OR7G3, which is associated with dental caries and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RTP4, (2) RTP3, (3) GNG13, (4) GNGT1"
+    "llm_ranking": [
+      {
+        "entity_name": "RTP3",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "RTP4",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "GNG13",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "GNGT1",
+        "llm-average": 7.97
+      }
+    ]
   },
   {
     "question_number": 6,
     "qid": 570,
     "text": "Which proteins are curated as interacting with EIF4EBP2, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) EIF4E, (2) NFYA, (3) RDH12, (4) EIF4E2"
+    "llm_ranking": [
+      {
+        "entity_name": "EIF4E",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "NFYA",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "RDH12",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "EIF4E2",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 7,
     "qid": 572,
     "text": "Which proteins are curated as interacting with ARMS2, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) METTL27, (2) FBLN1, (3) HMCN1"
+    "llm_ranking": [
+      {
+        "entity_name": "METTL27",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "FBLN1",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "HMCN1",
+        "llm-average": 14.12
+      }
+    ]
   },
   {
     "question_number": 8,
     "qid": 573,
     "text": "Which drugs have NSUN5 as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Sinefungin, (2) Ademetionine, (3) N-Carboxymethionine, (4) Isopropyl alcohol, (5) Codeine"
+    "llm_ranking": [
+      {
+        "entity_name": "Sinefungin",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "Ademetionine",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "N-Carboxymethionine",
+        "llm-average": 9.41
+      },
+      {
+        "entity_name": "Isopropyl alcohol",
+        "llm-average": 4.58
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 3.01
+      }
+    ]
   },
   {
     "question_number": 9,
     "qid": 574,
     "text": "Which proteins act on L3HYPDH, which is associated with Fanconi anemia complementation group D2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) NPRL2, (2) DAO"
+    "llm_ranking": [
+      {
+        "entity_name": "NPRL2",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "DAO",
+        "llm-average": 15.69
+      }
+    ]
   },
   {
     "question_number": 10,
     "qid": 575,
     "text": "Which drugs act on ZCRB1, which is associated with episodic ataxia type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Atrazine, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 18.82
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 14.12
+      }
+    ]
   },
   {
     "question_number": 11,
     "qid": 576,
     "text": "Which drugs act on ZNF300, which is associated with transient neonatal diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Arsenous acid, (2) N-Dimethyl-Lysine, (3) S-adenosyl-L-homocysteine, (4) (4r)-2-Methylpentane-2,4-Diol, (5) Valproic acid, (6) Nicotine, (7) Acetic acid, (8) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "N-Dimethyl-Lysine",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "S-adenosyl-L-homocysteine",
+        "llm-average": 10.85
+      },
+      {
+        "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
+        "llm-average": 10.07
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Nicotine",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 2.75
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 2.09
+      }
+    ]
   },
   {
     "question_number": 12,
     "qid": 577,
     "text": "Which genes are translated into BBS5, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Bardet-Biedl syndrome 5 protein, (2) Bardet-Biedl syndrome 5"
+    "llm_ranking": [
+      {
+        "entity_name": "Bardet-Biedl syndrome 5 protein",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Bardet-Biedl syndrome 5",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 13,
     "qid": 579,
     "text": "Which drugs act on MIDN, which is associated with polyneuropathy due to drug and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Quercetin, (2) Kojic acid, (3) Valproic acid, (4) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Kojic acid",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 14,
     "qid": 581,
     "text": "Which proteins are curated as interacting with CFAP94, which is associated with autosomal recessive disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) NME7, (2) PPP1CA, (3) HADHA, (4) ABI2"
+    "llm_ranking": [
+      {
+        "entity_name": "NME7",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "PPP1CA",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "HADHA",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "ABI2",
+        "llm-average": 9.02
+      }
+    ]
   },
   {
     "question_number": 15,
     "qid": 585,
     "text": "Which proteins are curated as interacting with SEMA4G, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SHARPIN, (2) TNIP1, (3) CD81"
+    "llm_ranking": [
+      {
+        "entity_name": "SHARPIN",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "TNIP1",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "CD81",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 16,
     "qid": 586,
     "text": "Which drugs act on ZNF485, which is associated with adrenal cortex disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Zoledronic acid, (2) N-Dimethyl-Lysine, (3) S-adenosyl-L-homocysteine, (4) Nicotine, (5) (4r)-2-Methylpentane-2,4-Diol, (6) Formaldehyde, (7) Calcium, (8) Acetic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Zoledronic acid",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "N-Dimethyl-Lysine",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "S-adenosyl-L-homocysteine",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Nicotine",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
+        "llm-average": 5.75
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 3.92
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 2.88
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 0.39
+      }
+    ]
   },
   {
     "question_number": 17,
     "qid": 588,
     "text": "Which drugs act on LYG2, which is associated with severe congenital neutropenia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 2-acetylamino-2-deoxy-b-D-allopyranose, (2) alpha-N-Acetyl-D-galactosamine, (3) N-acetyl-alpha-D-glucosamine, (4) Cyanocobalamin"
+    "llm_ranking": [
+      {
+        "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
+        "llm-average": 14.77
+      },
+      {
+        "entity_name": "alpha-N-Acetyl-D-galactosamine",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "N-acetyl-alpha-D-glucosamine",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Cyanocobalamin",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 18,
     "qid": 589,
     "text": "Which drugs have WDR46 as a compiled target, which is associated with asthma, nasal polyps, and aspirin intolerance and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Uridine-5'-diphosphate-mannose, (2) Galactose-uridine-5'-diphosphate, (3) Uridine diphosphate glucose"
+    "llm_ranking": [
+      {
+        "entity_name": "Uridine-5'-diphosphate-mannose",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Galactose-uridine-5'-diphosphate",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "Uridine diphosphate glucose",
+        "llm-average": 8.24
+      }
+    ]
   },
   {
     "question_number": 19,
     "qid": 590,
     "text": "Which proteins are compiled as interacting with ZNF257, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TRIM28, (2) ZNF638, (3) SERAC1, (4) UNC80, (5) CYRIB, (6) TSPAN3, (7) CACHD1, (8) C5orf63"
+    "llm_ranking": [
+      {
+        "entity_name": "TRIM28",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "ZNF638",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "SERAC1",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "UNC80",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "CYRIB",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "TSPAN3",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "CACHD1",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "C5orf63",
+        "llm-average": 5.49
+      }
+    ]
   },
   {
     "question_number": 20,
     "qid": 591,
     "text": "Which proteins act on EVPL, which is associated with peeling skin syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TGM5, (2) TGM1, (3) PI3, (4) CSTA"
+    "llm_ranking": [
+      {
+        "entity_name": "TGM5",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "PI3",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "TGM1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "CSTA",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 21,
     "qid": 592,
     "text": "Which functional regions are found in protein BIRC6, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Inhibitor of Apoptosis domain, (2) Baculoviral IAP repeat-containing protein 6"
+    "llm_ranking": [
+      {
+        "entity_name": "Inhibitor of Apoptosis domain",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Baculoviral IAP repeat-containing protein 6",
+        "llm-average": 9.02
+      }
+    ]
   },
   {
     "question_number": 22,
     "qid": 594,
     "text": "Which proteins are curated as interacting with TMEM144, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ADRB2, (2) TIMMDC1, (3) SSMEM1, (4) TMEM237, (5) HERPUD2"
+    "llm_ranking": [
+      {
+        "entity_name": "ADRB2",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "TIMMDC1",
+        "llm-average": 14.25
+      },
+      {
+        "entity_name": "SSMEM1",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "TMEM237",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "HERPUD2",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 23,
     "qid": 595,
     "text": "Which proteins act on PLEKHM1, which is associated with non-Langerhans-cell histiocytosis and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ARL8B, (2) DEF8, (3) PAFAH1B1, (4) TRAFD1"
+    "llm_ranking": [
+      {
+        "entity_name": "ARL8B",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "DEF8",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "PAFAH1B1",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "TRAFD1",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 24,
     "qid": 596,
     "text": "Which proteins are compiled as interacting with C1orf185, which is associated with hereditary sensory neuropathy and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) FAF1, (2) SPTY2D1, (3) RNF11, (4) NUP210L, (5) NUP210, (6) HEATR5B, (7) H2BC1"
+    "llm_ranking": [
+      {
+        "entity_name": "FAF1",
+        "llm-average": 19.48
+      },
+      {
+        "entity_name": "SPTY2D1",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "RNF11",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "NUP210L",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "NUP210",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "HEATR5B",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "H2BC1",
+        "llm-average": 8.1
+      }
+    ]
   },
   {
     "question_number": 25,
     "qid": 598,
     "text": "Which proteins are curated as interacting with TBCCD1, which is associated with oculocerebrorenal syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) IFT88, (2) PPP2R1A, (3) PPP2CB, (4) KRBA1, (5) ZNRD2"
+    "llm_ranking": [
+      {
+        "entity_name": "IFT88",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "PPP2R1A",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "PPP2CB",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "KRBA1",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "ZNRD2",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 26,
     "qid": 599,
     "text": "Which drugs act on ISCA1, which is associated with familial hyperlipidemia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Vitamin E, (2) Mercuric iodide, (3) Azacitidine, (4) Bortezomib, (5) Balsalazide, (6) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Vitamin E",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Mercuric iodide",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "Azacitidine",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "Bortezomib",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.58
+      }
+    ]
   },
   {
     "question_number": 27,
     "qid": 600,
     "text": "Which proteins are curated as interacting with DAW1, which is associated with sickle cell anemia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) KMT5A, (2) SUV39H1, (3) SRPK1, (4) SRPK2"
+    "llm_ranking": [
+      {
+        "entity_name": "KMT5A",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "SUV39H1",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "SRPK1",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "SRPK2",
+        "llm-average": 10.59
+      }
+    ]
   },
   {
     "question_number": 28,
     "qid": 602,
     "text": "Which proteins act on YBX3, which is associated with hereditary hemorrhagic telangiectasia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PQBP1, (2) RALA, (3) DDX5, (4) PPIF, (5) DCN"
+    "llm_ranking": [
+      {
+        "entity_name": "PQBP1",
+        "llm-average": 17.91
+      },
+      {
+        "entity_name": "RALA",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "DDX5",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "PPIF",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "DCN",
+        "llm-average": 8.1
+      }
+    ]
   },
   {
     "question_number": 29,
     "qid": 604,
     "text": "Which proteins act on VPS13A, which is associated with motor neuritis and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ACTB, (2) VAMP8, (3) ADD2"
+    "llm_ranking": [
+      {
+        "entity_name": "ACTB",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "VAMP8",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "ADD2",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 30,
     "qid": 605,
     "text": "Which drugs have ZACN as a compiled target, which is associated with transient neonatal diabetes mellitus and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Tubocurarine, (2) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Tubocurarine",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 9.8
+      }
+    ]
   },
   {
     "question_number": 31,
     "qid": 609,
     "text": "Which proteins are curated as interacting with TIGD7, which is associated with familial Mediterranean fever and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CYP17A1, (2) RAB3IL1, (3) HSPA8"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP17A1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "RAB3IL1",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "HSPA8",
+        "llm-average": 10.33
+      }
+    ]
   },
   {
     "question_number": 32,
     "qid": 610,
     "text": "Which drugs act on CPLANE1, which is associated with severe congenital neutropenia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 5.88
+      }
+    ]
   },
   {
     "question_number": 33,
     "qid": 611,
     "text": "Which drugs act on FAM149A, which is associated with coloboma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Trichostatin A, (2) Cyclosporine, (3) Estradiol, (4) Valproic acid, (5) Vitamin E, (6) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 16.34
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Vitamin E",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 3.14
+      }
+    ]
   },
   {
     "question_number": 34,
     "qid": 612,
     "text": "Which functional regions are found in protein ZC3H12A, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Zc3h12a-like Ribonuclease NYN domain, (2) Endoribonuclease Regnase 1/ ZC3H12 C-terminal domain"
+    "llm_ranking": [
+      {
+        "entity_name": "Zc3h12a-like Ribonuclease NYN domain",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "Endoribonuclease Regnase 1/ ZC3H12 C-terminal domain",
+        "llm-average": 15.69
+      }
+    ]
   },
   {
     "question_number": 35,
     "qid": 613,
     "text": "Which drugs act on METTL4, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Zinc, (2) Cyclosporine"
+    "llm_ranking": [
+      {
+        "entity_name": "Zinc",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 36,
     "qid": 614,
     "text": "Which proteins act on UBASH3A, which is associated with transient neonatal diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ZAP70, (2) PRKX, (3) CRK, (4) PRKACA, (5) CSTF3"
+    "llm_ranking": [
+      {
+        "entity_name": "ZAP70",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "PRKX",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "PRKACA",
+        "llm-average": 9.54
+      },
+      {
+        "entity_name": "CSTF3",
+        "llm-average": 7.32
+      }
+    ]
   },
   {
     "question_number": 37,
     "qid": 616,
     "text": "Which drugs act on FAM162B, which is associated with constipation and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Trichostatin A, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 13.2
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 38,
     "qid": 617,
     "text": "Which drugs act on STXBP3, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Nicotine, (2) Valproic acid, (3) Cholic Acid, (4) ATP, (5) Formaldehyde, (6) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Nicotine",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Cholic Acid",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 5.88
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 5.1
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 3.79
+      }
+    ]
   },
   {
     "question_number": 39,
     "qid": 619,
     "text": "Which proteins are curated as interacting with TRERF1, which is associated with Mulchandani-Bhoj-Conlin syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MIDEAS, (2) HDAC1, (3) SOX2"
+    "llm_ranking": [
+      {
+        "entity_name": "MIDEAS",
+        "llm-average": 18.82
+      },
+      {
+        "entity_name": "HDAC1",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "SOX2",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 40,
     "qid": 622,
     "text": "Which drugs have CD8B as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 2-acetylamino-2-deoxy-b-D-allopyranose, (2) alpha-N-Acetyl-D-galactosamine, (3) N-acetyl-alpha-D-glucosamine, (4) Iodine"
+    "llm_ranking": [
+      {
+        "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "alpha-N-Acetyl-D-galactosamine",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "N-acetyl-alpha-D-glucosamine",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Iodine",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 41,
     "qid": 623,
     "text": "Which proteins are compiled as interacting with RPGRIP1, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MIB2, (2) MIB1, (3) DYRK1B, (4) POU4F3, (5) LDLRAP1, (6) ODF3L2, (7) SLC7A9"
+    "llm_ranking": [
+      {
+        "entity_name": "MIB2",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "MIB1",
+        "llm-average": 15.82
+      },
+      {
+        "entity_name": "DYRK1B",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "POU4F3",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "LDLRAP1",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "ODF3L2",
+        "llm-average": 10.85
+      },
+      {
+        "entity_name": "SLC7A9",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 42,
     "qid": 624,
     "text": "Which proteins act on EQTN, which is associated with heart conduction disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) REXO2, (2) PCNA"
+    "llm_ranking": [
+      {
+        "entity_name": "REXO2",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "PCNA",
+        "llm-average": 14.12
+      }
+    ]
   },
   {
     "question_number": 43,
     "qid": 625,
     "text": "Which drugs have UBE2J2 as a compiled target, which is associated with bone disease and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ATP, (2) Pyrophosphoric acid, (3) Adenosine phosphate, (4) Tetraethylammonium"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Pyrophosphoric acid",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "Adenosine phosphate",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Tetraethylammonium",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 44,
     "qid": 626,
     "text": "Which proteins act on DUSP19, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LEP, (2) HACE1, (3) CFL2, (4) DSTN"
+    "llm_ranking": [
+      {
+        "entity_name": "LEP",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "HACE1",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "CFL2",
+        "llm-average": 13.2
+      },
+      {
+        "entity_name": "DSTN",
+        "llm-average": 11.76
+      }
+    ]
   },
   {
     "question_number": 45,
     "qid": 627,
     "text": "Which drugs have B3GNT7 as a compiled target, which is associated with astigmatism and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Uridine-Diphosphate-N-Acetylglucosamine, (2) Uridine-Diphosphate-N-Acetylgalactosamine, (3) Galactose-uridine-5'-diphosphate, (4) Uridine diphosphate glucose, (5) Uridine-5'-diphosphate-mannose, (6) Uridine-5'-Diphosphate, (7) Uridine monophosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Uridine-Diphosphate-N-Acetylglucosamine",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "Uridine-Diphosphate-N-Acetylgalactosamine",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "Galactose-uridine-5'-diphosphate",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Uridine diphosphate glucose",
+        "llm-average": 7.19
+      },
+      {
+        "entity_name": "Uridine-5'-diphosphate-mannose",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Uridine-5'-Diphosphate",
+        "llm-average": 5.88
+      },
+      {
+        "entity_name": "Uridine monophosphate",
+        "llm-average": 4.18
+      }
+    ]
   },
   {
     "question_number": 46,
     "qid": 628,
     "text": "Which proteins are curated as interacting with PRRG4, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) BCL10, (2) HLA-C"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL10",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "HLA-C",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 47,
     "qid": 630,
     "text": "Which proteins are curated as interacting with ACBD5, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ESR1, (2) VAPA, (3) TOMM20, (4) TOMM22, (5) CANX, (6) COX14"
+    "llm_ranking": [
+      {
+        "entity_name": "ESR1",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "VAPA",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "TOMM20",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "CANX",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "TOMM22",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "COX14",
+        "llm-average": 7.84
+      }
+    ]
   },
   {
     "question_number": 48,
     "qid": 631,
     "text": "Which drugs act on C1orf109, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Bortezomib, (2) Cyclosporine"
+    "llm_ranking": [
+      {
+        "entity_name": "Bortezomib",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 49,
     "qid": 632,
     "text": "Which proteins are curated as interacting with ZMAT3, which is associated with central nervous system hematologic cancer and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SIAH1, (2) SAMHD1, (3) AGO2, (4) HNRNPA2B1, (5) PRKRA, (6) DHX9, (7) STAU1, (8) MMGT1"
+    "llm_ranking": [
+      {
+        "entity_name": "SIAH1",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "SAMHD1",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "AGO2",
+        "llm-average": 14.25
+      },
+      {
+        "entity_name": "HNRNPA2B1",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "PRKRA",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "DHX9",
+        "llm-average": 9.41
+      },
+      {
+        "entity_name": "STAU1",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "MMGT1",
+        "llm-average": 6.54
+      }
+    ]
   },
   {
     "question_number": 50,
     "qid": 634,
     "text": "Which functional regions are found in protein ARX, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) OAR motif, (2) Homeodomain"
+    "llm_ranking": [
+      {
+        "entity_name": "OAR motif",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "Homeodomain",
+        "llm-average": 11.63
+      }
+    ]
   },
   {
     "question_number": 51,
     "qid": 637,
     "text": "Which metabolites are associated with MAP4K4, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Magnesium, (2) Adenosine triphosphate, (3) ADP"
+    "llm_ranking": [
+      {
+        "entity_name": "Magnesium",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Adenosine triphosphate",
+        "llm-average": 3.4
+      },
+      {
+        "entity_name": "ADP",
+        "llm-average": 2.88
+      }
+    ]
   },
   {
     "question_number": 52,
     "qid": 638,
     "text": "Which drugs act on PROP1, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Ruxolitinib, (2) Estradiol"
+    "llm_ranking": [
+      {
+        "entity_name": "Ruxolitinib",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 11.76
+      }
+    ]
   },
   {
     "question_number": 53,
     "qid": 639,
     "text": "Which proteins act on IL17RC, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) IL17B, (2) FSTL1, (3) IL17C"
+    "llm_ranking": [
+      {
+        "entity_name": "IL17B",
+        "llm-average": 14.77
+      },
+      {
+        "entity_name": "FSTL1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "IL17C",
+        "llm-average": 12.42
+      }
+    ]
   },
   {
     "question_number": 54,
     "qid": 640,
     "text": "Which functional regions are found in protein CDH9, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Cadherin cytoplasmic region, (2) Cadherin domain"
+    "llm_ranking": [
+      {
+        "entity_name": "Cadherin cytoplasmic region",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Cadherin domain",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 55,
     "qid": 641,
     "text": "Which proteins are curated as interacting with RILPL1, which is associated with oculocerebrorenal syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MAPT, (2) RAB12, (3) RAB10"
+    "llm_ranking": [
+      {
+        "entity_name": "MAPT",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "RAB12",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "RAB10",
+        "llm-average": 14.9
+      }
+    ]
   },
   {
     "question_number": 56,
     "qid": 642,
     "text": "Which drugs act on PURG, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Trichostatin A, (2) Valproic acid, (3) Codeine"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 57,
     "qid": 643,
     "text": "Which proteins act on PRDM6, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LONRF2, (2) FBXL19, (3) CAMKMT, (4) PLOD2, (5) PLOD3, (6) PLOD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LONRF2",
+        "llm-average": 18.43
+      },
+      {
+        "entity_name": "FBXL19",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "CAMKMT",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "PLOD2",
+        "llm-average": 9.54
+      },
+      {
+        "entity_name": "PLOD3",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "PLOD1",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 58,
     "qid": 644,
     "text": "Which metabolites are associated with ATP2A1, which is associated with cylindrical spirals myopathy and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Calcium, (2) Magnesium"
+    "llm_ranking": [
+      {
+        "entity_name": "Calcium",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "Magnesium",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 59,
     "qid": 646,
     "text": "Which drugs have LGI1 as a compiled target, which is associated with Landau-Kleffner syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Arsenous acid, (2) Amobarbital, (3) Tetrodotoxin, (4) D-Leucine, (5) Leucine"
+    "llm_ranking": [
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "Amobarbital",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "Tetrodotoxin",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "D-Leucine",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Leucine",
+        "llm-average": 5.88
+      }
+    ]
   },
   {
     "question_number": 60,
     "qid": 647,
     "text": "Which proteins are curated as interacting with SLC7A11, which is associated with adrenal cortex disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CD44, (2) TRAF2, (3) FADD, (4) MAD2L2, (5) IFT27, (6) TMEM17, (7) TTC30B"
+    "llm_ranking": [
+      {
+        "entity_name": "CD44",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "TRAF2",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "FADD",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "MAD2L2",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "IFT27",
+        "llm-average": 7.97
+      },
+      {
+        "entity_name": "TMEM17",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "TTC30B",
+        "llm-average": 6.54
+      }
+    ]
   },
   {
     "question_number": 61,
     "qid": 648,
     "text": "Which proteins act on EGFL7, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ADAM17, (2) PSEN2, (3) PSEN1, (4) RBPJL, (5) ADAM10, (6) MAML1, (7) RBPJ, (8) ICAM1"
+    "llm_ranking": [
+      {
+        "entity_name": "ADAM17",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "PSEN2",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "PSEN1",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "RBPJL",
+        "llm-average": 10.07
+      },
+      {
+        "entity_name": "ADAM10",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "MAML1",
+        "llm-average": 9.41
+      },
+      {
+        "entity_name": "RBPJ",
+        "llm-average": 9.15
+      },
+      {
+        "entity_name": "ICAM1",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 62,
     "qid": 650,
     "text": "Which drugs have ABCA5 as a compiled target, which is associated with ovarian disease and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Estramustine, (2) Arsenous acid, (3) Balsalazide, (4) Codeine"
+    "llm_ranking": [
+      {
+        "entity_name": "Estramustine",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 5.36
+      }
+    ]
   },
   {
     "question_number": 63,
     "qid": 651,
     "text": "Which proteins are curated as interacting with TBCD, which is associated with Griscelli syndrome type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RAC1, (2) PRKCB, (3) SH2D3C, (4) POT1, (5) SMAD9, (6) H4C1"
+    "llm_ranking": [
+      {
+        "entity_name": "RAC1",
+        "llm-average": 19.61
+      },
+      {
+        "entity_name": "PRKCB",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "SH2D3C",
+        "llm-average": 13.99
+      },
+      {
+        "entity_name": "POT1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "SMAD9",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "H4C1",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 64,
     "qid": 652,
     "text": "Which proteins are curated as interacting with FAM228A, which is associated with Rett syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) IFNA21, (2) EAF1, (3) ZNF76, (4) HSF2BP, (5) ENKD1, (6) FAM90A1, (7) SCNM1"
+    "llm_ranking": [
+      {
+        "entity_name": "IFNA21",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "EAF1",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "ZNF76",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "ENKD1",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "HSF2BP",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "FAM90A1",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "SCNM1",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 65,
     "qid": 655,
     "text": "Which proteins are curated as interacting with WFIKKN2, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) BMP3, (2) BMP2"
+    "llm_ranking": [
+      {
+        "entity_name": "BMP3",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "BMP2",
+        "llm-average": 9.67
+      }
+    ]
   },
   {
     "question_number": 66,
     "qid": 656,
     "text": "Which proteins are curated as interacting with DUX4, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SFPQ, (2) IPO13, (3) HMGA2, (4) FUS, (5) DES, (6) LMCD1"
+    "llm_ranking": [
+      {
+        "entity_name": "SFPQ",
+        "llm-average": 15.42
+      },
+      {
+        "entity_name": "IPO13",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "HMGA2",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "FUS",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "DES",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "LMCD1",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 67,
     "qid": 657,
     "text": "Which proteins are curated as interacting with GNLY, which is associated with Griscelli syndrome type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) DERL3, (2) BCL2L1"
+    "llm_ranking": [
+      {
+        "entity_name": "DERL3",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 12.42
+      }
+    ]
   },
   {
     "question_number": 68,
     "qid": 658,
     "text": "Which metabolites are associated with CACNA1I, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) O-Desmethylverapamil (D-702), (2) Flunarizine, (3) Paramethadione, (4) Cinnarizine, (5) Verapamil, (6) Zonisamide, (7) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "O-Desmethylverapamil (D-702)",
+        "llm-average": 14.77
+      },
+      {
+        "entity_name": "Flunarizine",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "Paramethadione",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "Cinnarizine",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Verapamil",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Zonisamide",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 69,
     "qid": 661,
     "text": "Which drugs are curated as targeting CD55 molecule (Cromer blood group), which is transcribed into complement decay-accelerating factor isoform 1 preproprotein and is translated into CD55?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Tretinoin, (2) Ethanol"
+    "llm_ranking": [
+      {
+        "entity_name": "Tretinoin",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Ethanol",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 70,
     "qid": 663,
     "text": "Which drugs act on MRNIP, which is associated with thymus cancer and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Calcitriol, (2) Epitestosterone, (3) Testosterone, (4) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Calcitriol",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Epitestosterone",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 1.7
+      }
+    ]
   },
   {
     "question_number": 71,
     "qid": 664,
     "text": "Which drugs act on SERINC2, which is associated with astigmatism and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Cyclosporine, (2) Atrazine, (3) Quercetin, (4) Calcitriol, (5) Testosterone, (6) Epitestosterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Calcitriol",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 6.93
+      },
+      {
+        "entity_name": "Epitestosterone",
+        "llm-average": 6.67
+      }
+    ]
   },
   {
     "question_number": 72,
     "qid": 665,
     "text": "Which proteins act on ZSCAN26, which is associated with transient neonatal diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) FBXL19, (2) LONRF2"
+    "llm_ranking": [
+      {
+        "entity_name": "FBXL19",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "LONRF2",
+        "llm-average": 13.2
+      }
+    ]
   },
   {
     "question_number": 73,
     "qid": 668,
     "text": "Which proteins act on PMP22, which is associated with PCWH syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ITGB4, (2) ITGA6, (3) LAMA1, (4) LAMB1, (5) LAMC2"
+    "llm_ranking": [
+      {
+        "entity_name": "ITGB4",
+        "llm-average": 14.77
+      },
+      {
+        "entity_name": "ITGA6",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "LAMA1",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "LAMB1",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "LAMC2",
+        "llm-average": 10.98
+      }
+    ]
   },
   {
     "question_number": 74,
     "qid": 669,
     "text": "Which proteins are curated as interacting with ATL2, which is associated with thymus cancer and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ZFYVE27, (2) HSCB, (3) ATL3"
+    "llm_ranking": [
+      {
+        "entity_name": "ZFYVE27",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "HSCB",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "ATL3",
+        "llm-average": 13.59
+      }
+    ]
   },
   {
     "question_number": 75,
     "qid": 670,
     "text": "Which functional regions are found in protein ADIPOQ, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) C1q domain, (2) Collagen triple helix repeat (20 copies)"
+    "llm_ranking": [
+      {
+        "entity_name": "C1q domain",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Collagen triple helix repeat (20 copies)",
+        "llm-average": 9.67
+      }
+    ]
   },
   {
     "question_number": 76,
     "qid": 671,
     "text": "Which proteins are curated as interacting with TNP1, which is associated with cataract 4 multiple types and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) DVL3, (2) SDCBP2"
+    "llm_ranking": [
+      {
+        "entity_name": "DVL3",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "SDCBP2",
+        "llm-average": 10.98
+      }
+    ]
   },
   {
     "question_number": 77,
     "qid": 672,
     "text": "Which drugs act on C20orf27, which is associated with disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Epitestosterone, (2) Calcitriol, (3) Valproic acid, (4) Vitamin E, (5) Testosterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Epitestosterone",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "Calcitriol",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Vitamin E",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 78,
     "qid": 673,
     "text": "Which functional regions are found in protein KRT81, which is associated with Bamforth-Lazarus syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Intermediate filament protein, (2) Keratin type II head"
+    "llm_ranking": [
+      {
+        "entity_name": "Intermediate filament protein",
+        "llm-average": 10.85
+      },
+      {
+        "entity_name": "Keratin type II head",
+        "llm-average": 9.67
+      }
+    ]
   },
   {
     "question_number": 79,
     "qid": 674,
     "text": "Which proteins are curated as interacting with TRIM52, which is associated with central nervous system disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RNF114, (2) TRIM41"
+    "llm_ranking": [
+      {
+        "entity_name": "RNF114",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "TRIM41",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 80,
     "qid": 676,
     "text": "Which proteins are curated as interacting with CUSTOS, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ESR1, (2) SLC30A6, (3) AURKC, (4) YEATS4, (5) PIP4K2A, (6) FAM177A1, (7) CDK17, (8) SPC25"
+    "llm_ranking": [
+      {
+        "entity_name": "ESR1",
+        "llm-average": 15.42
+      },
+      {
+        "entity_name": "SLC30A6",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "AURKC",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "YEATS4",
+        "llm-average": 13.99
+      },
+      {
+        "entity_name": "PIP4K2A",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "FAM177A1",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "CDK17",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "SPC25",
+        "llm-average": 6.27
+      }
+    ]
   },
   {
     "question_number": 81,
     "qid": 677,
     "text": "Which drugs have PSD2 as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 1D-myo-inositol 1,3,4-trisphosphate, (2) 1D-myo-inositol 1,4,5-trisphosphate, (3) Triethylene glycol, (4) 2-(2-{2-[2-(2-{2-[2-(2-Ethoxy-Ethoxy)-Ethoxy]-Ethoxy}-Ethoxy)-Ethoxy]-Ethoxy}-Ethoxy)-Ethanol, Polyethyleneglycol Peg400, (5) Inositol 2,4,5-trisphosphate, (6) Inositol-(1,3,4,5,6)-Pentakisphosphate, (7) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "1D-myo-inositol 1,3,4-trisphosphate",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "1D-myo-inositol 1,4,5-trisphosphate",
+        "llm-average": 13.2
+      },
+      {
+        "entity_name": "Triethylene glycol",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "2-(2-{2-[2-(2-{2-[2-(2-Ethoxy-Ethoxy)-Ethoxy]-Ethoxy}-Ethoxy)-Ethoxy]-Ethoxy}-Ethoxy)-Ethanol, Polyethyleneglycol Peg400",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Inositol 2,4,5-trisphosphate",
+        "llm-average": 6.01
+      },
+      {
+        "entity_name": "Inositol-(1,3,4,5,6)-Pentakisphosphate",
+        "llm-average": 5.88
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 3.4
+      }
+    ]
   },
   {
     "question_number": 82,
     "qid": 678,
     "text": "Which drugs have VWA5B1 as a compiled target, which is associated with endogenous depression and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) N-Dimethyl-Lysine, (2) Codeine, (3) Formic acid, (4) Calcium, (5) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "N-Dimethyl-Lysine",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Formic acid",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 4.05
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 3.4
+      }
+    ]
   },
   {
     "question_number": 83,
     "qid": 679,
     "text": "Which proteins are curated as interacting with SH2B1, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MEF2A, (2) MET, (3) EGFR, (4) JAK2, (5) INSR"
+    "llm_ranking": [
+      {
+        "entity_name": "MEF2A",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "MET",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "EGFR",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "INSR",
+        "llm-average": 8.37
+      }
+    ]
   },
   {
     "question_number": 84,
     "qid": 680,
     "text": "Which drugs act on PDCD10, which is associated with hereditary hemorrhagic telangiectasia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Inositol 1,3,4,5-Tetrakisphosphate, (2) Amiodarone, (3) Acetylsalicylic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Inositol 1,3,4,5-Tetrakisphosphate",
+        "llm-average": 18.82
+      },
+      {
+        "entity_name": "Amiodarone",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 6.54
+      }
+    ]
   },
   {
     "question_number": 85,
     "qid": 681,
     "text": "Which drugs act on DCBLD1, which is associated with bile duct disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Trichostatin A, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 86,
     "qid": 682,
     "text": "Which drugs act on ZBTB4, which is associated with Mulchandani-Bhoj-Conlin syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Zoledronic acid, (2) S-adenosyl-L-homocysteine, (3) N-Dimethyl-Lysine, (4) Nicotine, (5) (4r)-2-Methylpentane-2,4-Diol, (6) Calcium, (7) Acetic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Zoledronic acid",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "S-adenosyl-L-homocysteine",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "N-Dimethyl-Lysine",
+        "llm-average": 9.41
+      },
+      {
+        "entity_name": "Nicotine",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
+        "llm-average": 4.97
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 1.7
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 87,
     "qid": 684,
     "text": "Which proteins are compiled as interacting with PAGE3, which is associated with normocytic anemia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CHRNG, (2) NPTX1, (3) NREP, (4) TNNI1, (5) TNNC2"
+    "llm_ranking": [
+      {
+        "entity_name": "CHRNG",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "NPTX1",
+        "llm-average": 15.56
+      },
+      {
+        "entity_name": "NREP",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "TNNI1",
+        "llm-average": 10.07
+      },
+      {
+        "entity_name": "TNNC2",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 88,
     "qid": 686,
     "text": "Which drugs act on ELP1, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Motexafin gadolinium, (2) Quercetin, (3) Amiodarone, (4) Coenzyme A, (5) Mercuric iodide, (6) Acetaminophen, (7) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Motexafin gadolinium",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Amiodarone",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Coenzyme A",
+        "llm-average": 8.1
+      },
+      {
+        "entity_name": "Mercuric iodide",
+        "llm-average": 6.01
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.18
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 1.96
+      }
+    ]
   },
   {
     "question_number": 89,
     "qid": 687,
     "text": "Which proteins are curated as interacting with UBE3D, which is associated with acute pericementitis and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CCM2, (2) DNAAF2, (3) MEMO1, (4) PPP5C, (5) KLHDC2, (6) FKBP6, (7) CPSF3, (8) DEFA1"
+    "llm_ranking": [
+      {
+        "entity_name": "CCM2",
+        "llm-average": 16.6
+      },
+      {
+        "entity_name": "DNAAF2",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "MEMO1",
+        "llm-average": 15.95
+      },
+      {
+        "entity_name": "PPP5C",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "KLHDC2",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "FKBP6",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "CPSF3",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "DEFA1",
+        "llm-average": 8.1
+      }
+    ]
   },
   {
     "question_number": 90,
     "qid": 688,
     "text": "Which proteins are curated as interacting with LHFPL2, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) FXYD6, (2) TMEM147, (3) GPR152"
+    "llm_ranking": [
+      {
+        "entity_name": "FXYD6",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "TMEM147",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "GPR152",
+        "llm-average": 11.24
+      }
+    ]
   },
   {
     "question_number": 91,
     "qid": 689,
     "text": "Which functional regions are found in protein MAGEB3, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MAGE family, (2) Melanoma associated antigen family N terminal"
+    "llm_ranking": [
+      {
+        "entity_name": "Melanoma associated antigen family N terminal",
+        "llm-average": 10.07
+      },
+      {
+        "entity_name": "MAGE family",
+        "llm-average": 5.49
+      }
+    ]
   },
   {
     "question_number": 92,
     "qid": 692,
     "text": "Which metabolites are associated with CHST13, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Chondroitin 4-sulfate, (2) Phosphoadenosine phosphosulfate, (3) Chondroitin, (4) Adenosine 3',5'-diphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Chondroitin 4-sulfate",
+        "llm-average": 18.43
+      },
+      {
+        "entity_name": "Phosphoadenosine phosphosulfate",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Chondroitin",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Adenosine 3',5'-diphosphate",
+        "llm-average": 9.67
+      }
+    ]
   },
   {
     "question_number": 93,
     "qid": 693,
     "text": "Which drugs act on SLAMF1, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Menadione, (2) Vincristine, (3) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Menadione",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "Vincristine",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 94,
     "qid": 694,
     "text": "Which drugs act on KCTD14, which is associated with bile duct disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Cyclosporine, (2) Quercetin, (3) Amiodarone, (4) Valproic acid, (5) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 18.3
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Amiodarone",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 95,
     "qid": 695,
     "text": "Which drugs act on ZNF346, which is associated with Griscelli syndrome type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Atrazine, (2) Zinc, (3) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 13.07
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 96,
     "qid": 696,
     "text": "Which drugs have NUPR1 as a compiled target, which is associated with type 2 diabetes mellitus and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Gemcitabine, (2) Beta-D-Glucose, (3) D-Allopyranose"
+    "llm_ranking": [
+      {
+        "entity_name": "Gemcitabine",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Beta-D-Glucose",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "D-Allopyranose",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 97,
     "qid": 697,
     "text": "Which drugs have GDPD1 as a compiled target, which is associated with Nasu-Hakola disease and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Balsalazide, (2) sn-glycerol 3-phosphate, (3) Codeine, (4) Citric acid, (5) Zinc, (6) Acetic acid, (7) Magnesium cation, (8) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "sn-glycerol 3-phosphate",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "Citric acid",
+        "llm-average": 4.58
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 2.22
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 1.83
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 1.31
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 0.39
+      }
+    ]
   },
   {
     "question_number": 98,
     "qid": 700,
     "text": "Which drugs act on BCOR, which is associated with cataract 38 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Vincristine, (2) Quercetin, (3) Valproic acid, (4) Mercuric iodide, (5) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Vincristine",
+        "llm-average": 15.56
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Mercuric iodide",
+        "llm-average": 5.49
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 5.36
+      }
+    ]
   },
   {
     "question_number": 99,
     "qid": 701,
     "text": "Which drugs act on MKRN3, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Pyrophosphoric acid, (2) ATP, (3) Adenosine phosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Pyrophosphoric acid",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 4.58
+      },
+      {
+        "entity_name": "Adenosine phosphate",
+        "llm-average": 3.79
+      }
+    ]
   },
   {
     "question_number": 100,
     "qid": 702,
     "text": "Which proteins are curated as interacting with PLCL1, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) KIN, (2) HSPA5"
+    "llm_ranking": [
+      {
+        "entity_name": "KIN",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "HSPA5",
+        "llm-average": 12.42
+      }
+    ]
   },
   {
     "question_number": 101,
     "qid": 703,
     "text": "Which drugs have SOX11 as a compiled target, which is associated with PCWH syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Azacitidine, (2) Arsenous acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Azacitidine",
+        "llm-average": 13.2
+      },
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 102,
     "qid": 704,
     "text": "Which drugs have CHAF1B as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) D-Tryptophan, (2) Tryptophan"
+    "llm_ranking": [
+      {
+        "entity_name": "D-Tryptophan",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Tryptophan",
+        "llm-average": 6.14
+      }
+    ]
   },
   {
     "question_number": 103,
     "qid": 706,
     "text": "Which functional regions are found in protein PTH2R, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 7 transmembrane receptor (Secretin family), (2) Hormone receptor domain"
+    "llm_ranking": [
+      {
+        "entity_name": "7 transmembrane receptor (Secretin family)",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Hormone receptor domain",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 104,
     "qid": 708,
     "text": "Which functional regions are found in protein GRM2, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 7 transmembrane sweet-taste receptor of 3 GCPR, (2) Nine Cysteines Domain of family 3 GPCR, (3) Receptor family ligand binding region"
+    "llm_ranking": [
+      {
+        "entity_name": "7 transmembrane sweet-taste receptor of 3 GCPR",
+        "llm-average": 18.82
+      },
+      {
+        "entity_name": "Nine Cysteines Domain of family 3 GPCR",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Receptor family ligand binding region",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 105,
     "qid": 709,
     "text": "Which proteins act on POU4F2, which is associated with retinitis pigmentosa 33 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) DLX2, (2) HSPB1, (3) IFNG, (4) TP53"
+    "llm_ranking": [
+      {
+        "entity_name": "DLX2",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "HSPB1",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "IFNG",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 106,
     "qid": 710,
     "text": "Which proteins are curated as interacting with ACTR3B, which is associated with oculocerebrorenal syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ARPC5, (2) ARPC4, (3) EXOC5"
+    "llm_ranking": [
+      {
+        "entity_name": "ARPC5",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "ARPC4",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "EXOC5",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 107,
     "qid": 711,
     "text": "Which drugs have EGLN3 as a compiled target, which is associated with type 2 diabetes mellitus and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Succinic acid, (2) Ascorbic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Succinic acid",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "Ascorbic acid",
+        "llm-average": 9.02
+      }
+    ]
   },
   {
     "question_number": 108,
     "qid": 712,
     "text": "Which drugs act on TASP1, which is associated with coloboma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) S,S-(2-Hydroxyethyl)Thiocysteine, (2) Balsalazide, (3) Valproic acid, (4) Tromethamine, (5) Codeine, (6) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "S,S-(2-Hydroxyethyl)Thiocysteine",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Tromethamine",
+        "llm-average": 4.84
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 4.18
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 1.7
+      }
+    ]
   },
   {
     "question_number": 109,
     "qid": 713,
     "text": "Which drugs have MAP1A as a compiled target, which is associated with type 2 diabetes mellitus and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Estramustine, (2) Fluorescein"
+    "llm_ranking": [
+      {
+        "entity_name": "Estramustine",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "Fluorescein",
+        "llm-average": 9.02
+      }
+    ]
   },
   {
     "question_number": 110,
     "qid": 714,
     "text": "Which drugs have NUP98 as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Bisphenol A, (2) 2-(N-morpholino)ethanesulfonic acid, (3) 2-Pyridinethiol"
+    "llm_ranking": [
+      {
+        "entity_name": "Bisphenol A",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "2-(N-morpholino)ethanesulfonic acid",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "2-Pyridinethiol",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 111,
     "qid": 715,
     "text": "Which drugs have SMAD5 as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Resveratrol, (2) ATP, (3) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Resveratrol",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 10.33
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 112,
     "qid": 716,
     "text": "Which drugs act on CNPY1, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Trichostatin A, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 113,
     "qid": 719,
     "text": "Which proteins are curated as interacting with TRIM31, which is associated with comedo carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ZSCAN1, (2) HIP2, (3) UBE2D2, (4) MNAT1, (5) MAGEA1, (6) UBE2K"
+    "llm_ranking": [
+      {
+        "entity_name": "ZSCAN1",
+        "llm-average": 13.99
+      },
+      {
+        "entity_name": "HIP2",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "UBE2D2",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "MNAT1",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "MAGEA1",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "UBE2K",
+        "llm-average": 11.63
+      }
+    ]
   },
   {
     "question_number": 114,
     "qid": 720,
     "text": "Which proteins act on GLRX2, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RRM1, (2) DLD, (3) GSR"
+    "llm_ranking": [
+      {
+        "entity_name": "RRM1",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "DLD",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "GSR",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 115,
     "qid": 722,
     "text": "Which drugs have PITPNA as a compiled target, which is associated with peripheral retinal degeneration and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) (Z,Z)-4-Hydroxy-N,N,N-Trimethyl-10-Oxo-7-[(1-Oxo-9-Octadecenyl)Oxy]-3,5,9-Trioxa-4-Phosphaheptacos-18-En-1-Aminium-4-Oxide, (2) 9,10-Deepithio-9,10-Didehydroacanthifolicin, (3) 1,2-diacyl-sn-glycero-3-phosphoinositol, (4) Aniracetam, (5) ATP"
+    "llm_ranking": [
+      {
+        "entity_name": "(Z,Z)-4-Hydroxy-N,N,N-Trimethyl-10-Oxo-7-[(1-Oxo-9-Octadecenyl)Oxy]-3,5,9-Trioxa-4-Phosphaheptacos-18-En-1-Aminium-4-Oxide",
+        "llm-average": 17.78
+      },
+      {
+        "entity_name": "9,10-Deepithio-9,10-Didehydroacanthifolicin",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "1,2-diacyl-sn-glycero-3-phosphoinositol",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "Aniracetam",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 3.66
+      }
+    ]
   },
   {
     "question_number": 116,
     "qid": 724,
     "text": "Which drugs have WDR1 as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Isoflurophate, (2) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Isoflurophate",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 117,
     "qid": 726,
     "text": "Which drugs act on TMEM270, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 5beta-dihydrotestosterone, (2) Formaldehyde, (3) Stanolone"
+    "llm_ranking": [
+      {
+        "entity_name": "5beta-dihydrotestosterone",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Stanolone",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 118,
     "qid": 728,
     "text": "Which drugs act on COMMD8, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Valproic acid, (2) Quercetin"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 13.59
+      }
+    ]
   },
   {
     "question_number": 119,
     "qid": 730,
     "text": "Which proteins are curated as interacting with PCYOX1L, which is associated with endogenous depression and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) IFNA21, (2) CD1B, (3) ITGA9, (4) LYZL2, (5) TEX101, (6) LACRT, (7) CLU, (8) CANX"
+    "llm_ranking": [
+      {
+        "entity_name": "IFNA21",
+        "llm-average": 16.34
+      },
+      {
+        "entity_name": "CD1B",
+        "llm-average": 16.21
+      },
+      {
+        "entity_name": "ITGA9",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "LYZL2",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "TEX101",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "LACRT",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "CLU",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "CANX",
+        "llm-average": 7.45
+      }
+    ]
   },
   {
     "question_number": 120,
     "qid": 731,
     "text": "Which proteins are curated as interacting with TRIM45, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MGME1, (2) GABARAPL2, (3) AARSD1"
+    "llm_ranking": [
+      {
+        "entity_name": "MGME1",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "GABARAPL2",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "AARSD1",
+        "llm-average": 11.24
+      }
+    ]
   },
   {
     "question_number": 121,
     "qid": 732,
     "text": "Which proteins are compiled as interacting with ZNF480, which is associated with transient neonatal diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TRIM28, (2) ALDH16A1, (3) PRR19, (4) FBXW12, (5) ALS2CL, (6) NGRN, (7) DDX27"
+    "llm_ranking": [
+      {
+        "entity_name": "TRIM28",
+        "llm-average": 18.04
+      },
+      {
+        "entity_name": "ALDH16A1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "PRR19",
+        "llm-average": 10.33
+      },
+      {
+        "entity_name": "FBXW12",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "ALS2CL",
+        "llm-average": 9.54
+      },
+      {
+        "entity_name": "NGRN",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "DDX27",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 122,
     "qid": 733,
     "text": "Which proteins are curated as interacting with VAT1L, which is associated with Blau syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) C11orf24, (2) PPP1CA"
+    "llm_ranking": [
+      {
+        "entity_name": "C11orf24",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "PPP1CA",
+        "llm-average": 10.98
+      }
+    ]
   },
   {
     "question_number": 123,
     "qid": 734,
     "text": "Which drugs act on TPRA1, which is associated with legume allergy and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Sulindac, (2) Atrazine"
+    "llm_ranking": [
+      {
+        "entity_name": "Sulindac",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 12.16
+      }
+    ]
   },
   {
     "question_number": 124,
     "qid": 736,
     "text": "Which drugs have SPRY4 as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Arsenous acid, (2) Guanosine-5'-Diphosphate, (3) Guanosine-5'-Triphosphate, (4) D-Tyrosine, (5) Tyrosine"
+    "llm_ranking": [
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "Guanosine-5'-Triphosphate",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "D-Tyrosine",
+        "llm-average": 4.97
+      },
+      {
+        "entity_name": "Tyrosine",
+        "llm-average": 2.61
+      }
+    ]
   },
   {
     "question_number": 125,
     "qid": 737,
     "text": "Which metabolites are associated with DYRK4, which is associated with astigmatism and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Magnesium, (2) ADP, (3) Adenosine triphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Magnesium",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "ADP",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "Adenosine triphosphate",
+        "llm-average": 5.36
+      }
+    ]
   },
   {
     "question_number": 126,
     "qid": 738,
     "text": "Which proteins are curated as interacting with NT5C1A, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ICAM1, (2) HNRNPU, (3) NPY2R, (4) NTAQ1"
+    "llm_ranking": [
+      {
+        "entity_name": "ICAM1",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "HNRNPU",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "NPY2R",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "NTAQ1",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 127,
     "qid": 739,
     "text": "Which drugs act on RILP, which is associated with Griscelli syndrome type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ATP, (2) Magnesium cation, (3) Guanosine-5'-Triphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP",
+        "llm-average": 9.41
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Guanosine-5'-Triphosphate",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 128,
     "qid": 743,
     "text": "Which drugs act on SUSD3, which is associated with familial hyperlipidemia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Quercetin, (2) Genistein, (3) Trichostatin A, (4) Cyclosporine, (5) Estradiol, (6) Valproic acid, (7) Acetaminophen, (8) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "Genistein",
+        "llm-average": 15.95
+      },
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 13.99
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 13.07
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.58
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 2.35
+      }
+    ]
   },
   {
     "question_number": 129,
     "qid": 744,
     "text": "Which functional regions are found in protein CD93, which is associated with Mulchandani-Bhoj-Conlin syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Lectin C-type domain, (2) Complement Clr-like EGF-like"
+    "llm_ranking": [
+      {
+        "entity_name": "Complement Clr-like EGF-like",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Lectin C-type domain",
+        "llm-average": 10.2
+      }
+    ]
   },
   {
     "question_number": 130,
     "qid": 746,
     "text": "Which drugs act on CASD1, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Quercetin, (2) Estradiol, (3) Trichostatin A, (4) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.98
+      }
+    ]
   },
   {
     "question_number": 131,
     "qid": 747,
     "text": "Which proteins act on ZNF74, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TRIM28, (2) FBXL19, (3) LONRF2"
+    "llm_ranking": [
+      {
+        "entity_name": "TRIM28",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "FBXL19",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "LONRF2",
+        "llm-average": 12.42
+      }
+    ]
   },
   {
     "question_number": 132,
     "qid": 749,
     "text": "Which functional regions are found in protein ATP5F1B, which is associated with Griscelli syndrome type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ATP synthase alpha/beta family, nucleotide-binding domain, (2) ATP synthase alpha/beta family, beta-barrel domain"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP synthase alpha/beta family, nucleotide-binding domain",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "ATP synthase alpha/beta family, beta-barrel domain",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 133,
     "qid": 750,
     "text": "Which drugs act on BZW1, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Valproic acid, (2) Acetylsalicylic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 134,
     "qid": 751,
     "text": "Which proteins act on NEUROG2, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PHOX2B, (2) DLL3, (3) ASCL1, (4) NEUROD1, (5) UNCX, (6) NOTCH1, (7) FGF2"
+    "llm_ranking": [
+      {
+        "entity_name": "PHOX2B",
+        "llm-average": 15.95
+      },
+      {
+        "entity_name": "DLL3",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "ASCL1",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "NEUROD1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "UNCX",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "NOTCH1",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "FGF2",
+        "llm-average": 9.93
+      }
+    ]
   },
   {
     "question_number": 135,
     "qid": 752,
     "text": "Which proteins are curated as interacting with TCF23, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TCF12, (2) HNRNPK"
+    "llm_ranking": [
+      {
+        "entity_name": "TCF12",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "HNRNPK",
+        "llm-average": 10.98
+      }
+    ]
   },
   {
     "question_number": 136,
     "qid": 753,
     "text": "Which drugs have PPTC7 as a compiled target, which is associated with neuronal ceroid lipofuscinosis 2 and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Codeine, (2) Cacodylic acid, (3) Acetic acid, (4) Dihydrogenphosphate, (5) Zinc, (6) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "Codeine",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Cacodylic acid",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 3.4
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 3.27
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 2.75
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 1.44
+      }
+    ]
   },
   {
     "question_number": 137,
     "qid": 754,
     "text": "Which proteins are curated as interacting with SGSH, which is associated with Ohdo syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) DISC1, (2) PCNA, (3) PLAUR, (4) FBXO6"
+    "llm_ranking": [
+      {
+        "entity_name": "DISC1",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "PCNA",
+        "llm-average": 13.2
+      },
+      {
+        "entity_name": "PLAUR",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "FBXO6",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 138,
     "qid": 755,
     "text": "Which proteins act on CCDC68, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) KIF2A, (2) CEP128, (3) CEP170, (4) ODF2, (5) CNTRL, (6) DCTN1, (7) NIN"
+    "llm_ranking": [
+      {
+        "entity_name": "KIF2A",
+        "llm-average": 19.08
+      },
+      {
+        "entity_name": "CEP128",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "CEP170",
+        "llm-average": 13.99
+      },
+      {
+        "entity_name": "ODF2",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "CNTRL",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "DCTN1",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "NIN",
+        "llm-average": 9.93
+      }
+    ]
   },
   {
     "question_number": 139,
     "qid": 756,
     "text": "Which proteins are curated as interacting with ZFX, which is associated with epithelioid trophoblastic tumor and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CDC23, (2) CENPQ"
+    "llm_ranking": [
+      {
+        "entity_name": "CDC23",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "CENPQ",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 140,
     "qid": 757,
     "text": "Which drugs act on LEAP2, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Cyclosporine, (2) Quercetin, (3) Clozapine, (4) Estradiol, (5) Acetaminophen, (6) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Clozapine",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 9.15
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.18
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 1.44
+      }
+    ]
   },
   {
     "question_number": 141,
     "qid": 758,
     "text": "Which proteins are curated as interacting with FAIM, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SPRY2, (2) H2BS1, (3) H2BC18, (4) H2BC9, (5) H1-1"
+    "llm_ranking": [
+      {
+        "entity_name": "SPRY2",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "H2BS1",
+        "llm-average": 7.32
+      },
+      {
+        "entity_name": "H2BC18",
+        "llm-average": 6.93
+      },
+      {
+        "entity_name": "H2BC9",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "H1-1",
+        "llm-average": 6.01
+      }
+    ]
   },
   {
     "question_number": 142,
     "qid": 759,
     "text": "Which drugs have RAB28 as a compiled target, which is associated with oculocerebrorenal syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Phosphoaminophosphonic acid guanylate ester, (2) Guanosine-3'-monophosphate-5'-diphosphate, (3) Cyanocobalamin, (4) Mercaptoethanol, (5) Dihydrogenphosphate, (6) Zinc, (7) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "Phosphoaminophosphonic acid guanylate ester",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "Guanosine-3'-monophosphate-5'-diphosphate",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "Cyanocobalamin",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Mercaptoethanol",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 4.18
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 4.05
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 2.35
+      }
+    ]
   },
   {
     "question_number": 143,
     "qid": 760,
     "text": "Which drugs act on RADX, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Trichostatin A, (2) Calcitriol, (3) Melphalan, (4) Cyclosporine, (5) Valproic acid, (6) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Calcitriol",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "Melphalan",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 9.41
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 3.01
+      }
+    ]
   },
   {
     "question_number": 144,
     "qid": 761,
     "text": "Which drugs have BCL9L as a compiled target, which is associated with Mulchandani-Bhoj-Conlin syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Ademetionine, (2) S-adenosyl-L-homocysteine"
+    "llm_ranking": [
+      {
+        "entity_name": "Ademetionine",
+        "llm-average": 10.85
+      },
+      {
+        "entity_name": "S-adenosyl-L-homocysteine",
+        "llm-average": 8.63
+      }
+    ]
   },
   {
     "question_number": 145,
     "qid": 762,
     "text": "Which drugs have STX10 as a compiled target, which is associated with salmonellosis and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Propafenone, (2) Guanosine-5'-Diphosphate-Rhamnose, (3) Brefeldin A, (4) Guanosine-5'-Diphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Propafenone",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate-Rhamnose",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "Brefeldin A",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 146,
     "qid": 763,
     "text": "Which metabolites are associated with HRH4, which is associated with legume allergy and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Histamine, (2) Cyclic AMP, (3) Chlorpheniramine"
+    "llm_ranking": [
+      {
+        "entity_name": "Histamine",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "Cyclic AMP",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Chlorpheniramine",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 147,
     "qid": 764,
     "text": "Which drugs have TDRD3 as a compiled target, which is associated with ovarian disease and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) N,N-dimethylarginine, (2) Arsenous acid, (3) Isopropyl alcohol"
+    "llm_ranking": [
+      {
+        "entity_name": "N,N-dimethylarginine",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Isopropyl alcohol",
+        "llm-average": 9.8
+      }
+    ]
   },
   {
     "question_number": 148,
     "qid": 765,
     "text": "Which drugs have SLC5A10 as a compiled target, which is associated with type 2 diabetes mellitus and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Dapagliflozin, (2) Telmisartan, (3) Balsalazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Dapagliflozin",
+        "llm-average": 19.48
+      },
+      {
+        "entity_name": "Telmisartan",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 149,
     "qid": 766,
     "text": "Which drugs act on ZNF705B, which is detected in pathology samples of kidney cancer and is associated with reproductive system?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) (4r)-2-Methylpentane-2,4-Diol, (2) N-Dimethyl-Lysine, (3) S-adenosyl-L-homocysteine, (4) Nicotine, (5) Acetic acid, (6) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "N-Dimethyl-Lysine",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "S-adenosyl-L-homocysteine",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Nicotine",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 2.88
+      }
+    ]
   },
   {
     "question_number": 150,
     "qid": 768,
     "text": "Which genes are translated into OXLD1, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) oxidoreductase-like domain-containing protein 1 isoform a, (2) oxidoreductase like domain containing 1"
+    "llm_ranking": [
+      {
+        "entity_name": "oxidoreductase-like domain-containing protein 1 isoform a",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "oxidoreductase like domain containing 1",
+        "llm-average": 9.93
+      }
+    ]
   },
   {
     "question_number": 151,
     "qid": 769,
     "text": "Which drugs have ATP6V0E2 as a compiled target, which is associated with chromosomal deletion syndrome and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Balsalazide, (2) Dihydrogenphosphate, (3) ATP, (4) Iron"
+    "llm_ranking": [
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Iron",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 152,
     "qid": 770,
     "text": "Which proteins are curated as interacting with TPTE2, which is associated with oculocerebrorenal syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) EPHA2, (2) AATK, (3) LMTK2, (4) PTK7, (5) CALD1"
+    "llm_ranking": [
+      {
+        "entity_name": "EPHA2",
+        "llm-average": 18.43
+      },
+      {
+        "entity_name": "AATK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "LMTK2",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "PTK7",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "CALD1",
+        "llm-average": 8.37
+      }
+    ]
   },
   {
     "question_number": 153,
     "qid": 772,
     "text": "Which drugs have SLC24A2 as a compiled target, which is associated with gastroesophageal junction adenocarcinoma and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ATP, (2) Balsalazide, (3) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 154,
     "qid": 773,
     "text": "Which drugs act on GLT1D1, which is associated with peroxisomal biogenesis disorder and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Trichostatin A, (2) Atrazine, (3) Progesterone, (4) Phenobarbital, (5) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 10.85
+      },
+      {
+        "entity_name": "Progesterone",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "Phenobarbital",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 3.79
+      }
+    ]
   },
   {
     "question_number": 155,
     "qid": 774,
     "text": "Which proteins are curated as interacting with HS6ST2, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) NETO2, (2) KIF20A, (3) YWHAZ, (4) CANX"
+    "llm_ranking": [
+      {
+        "entity_name": "NETO2",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "KIF20A",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "YWHAZ",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "CANX",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 156,
     "qid": 775,
     "text": "Which proteins are curated as interacting with LYPLAL1, which is associated with type 2 diabetes mellitus and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LRRK2, (2) PDK1, (3) ENG, (4) HSPD1, (5) CT55, (6) MGST3, (7) SCLT1, (8) TRMT61B"
+    "llm_ranking": [
+      {
+        "entity_name": "LRRK2",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "PDK1",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "ENG",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "HSPD1",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "CT55",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "MGST3",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "SCLT1",
+        "llm-average": 8.1
+      },
+      {
+        "entity_name": "TRMT61B",
+        "llm-average": 7.58
+      }
+    ]
   },
   {
     "question_number": 157,
     "qid": 776,
     "text": "Which proteins act on EMC7, which is associated with acanthoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) EMC2, (2) EMC3, (3) EMC8"
+    "llm_ranking": [
+      {
+        "entity_name": "EMC2",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "EMC3",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "EMC8",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 158,
     "qid": 778,
     "text": "Which functional regions are found in protein HHIPL2, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Folate receptor family, (2) Glucose / Sorbosone dehydrogenase"
+    "llm_ranking": [
+      {
+        "entity_name": "Folate receptor family",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Glucose / Sorbosone dehydrogenase",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 159,
     "qid": 780,
     "text": "Which proteins act on TSPAN4, which is associated with bone disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ADAM10, (2) CAV1, (3) SCARB1, (4) TEAD4, (5) CKAP4, (6) TEAD3"
+    "llm_ranking": [
+      {
+        "entity_name": "ADAM10",
+        "llm-average": 18.04
+      },
+      {
+        "entity_name": "CAV1",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "SCARB1",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "TEAD4",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "CKAP4",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "TEAD3",
+        "llm-average": 9.93
+      }
+    ]
   },
   {
     "question_number": 160,
     "qid": 782,
     "text": "Which drugs act on RNF39, which is associated with portal vein thrombosis and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Calcitriol, (2) Atrazine, (3) alpha-D-quinovopyranose, (4) alpha-L-fucose, (5) beta-L-fucose, (6) beta-D-fucose, (7) alpha-D-Fucopyranose"
+    "llm_ranking": [
+      {
+        "entity_name": "Calcitriol",
+        "llm-average": 19.87
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "alpha-D-quinovopyranose",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "alpha-L-fucose",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "beta-L-fucose",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "beta-D-fucose",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "alpha-D-Fucopyranose",
+        "llm-average": 6.54
+      }
+    ]
   },
   {
     "question_number": 161,
     "qid": 784,
     "text": "Which proteins act on KASH5, which is associated with severe congenital neutropenia and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SUN1, (2) SUN2, (3) SYNE3, (4) SYNE2, (5) SUN3, (6) SYNE4, (7) SYNE1"
+    "llm_ranking": [
+      {
+        "entity_name": "SUN1",
+        "llm-average": 15.82
+      },
+      {
+        "entity_name": "SUN2",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "SYNE3",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "SYNE2",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "SUN3",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "SYNE4",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "SYNE1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 162,
     "qid": 787,
     "text": "Which drugs act on ARHGAP36, which is associated with medulloblastoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Guanosine-5'-Triphosphate, (2) Guanosine-5'-Diphosphate, (3) Valproic acid, (4) Dihydrogenphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Guanosine-5'-Triphosphate",
+        "llm-average": 12.29
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 3.79
+      }
+    ]
   },
   {
     "question_number": 163,
     "qid": 789,
     "text": "Which genes are translated into BOLA2, which is associated with chromosomal deletion syndrome and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) bolA family member 2, (2) bolA family member 2B"
+    "llm_ranking": [
+      {
+        "entity_name": "bolA family member 2",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "bolA family member 2B",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 164,
     "qid": 790,
     "text": "Which drugs act on NSMAF, which is associated with olivopontocerebellar atrophy and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Irinotecan, (2) Trichostatin A, (3) Atrazine, (4) Valproic acid, (5) Cyclosporine"
+    "llm_ranking": [
+      {
+        "entity_name": "Irinotecan",
+        "llm-average": 17.12
+      },
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 165,
     "qid": 791,
     "text": "Which proteins are curated as interacting with MREG, which is associated with Griscelli syndrome type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TOR1AIP1, (2) PTPN1, (3) EIF1AD"
+    "llm_ranking": [
+      {
+        "entity_name": "TOR1AIP1",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "PTPN1",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "EIF1AD",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 166,
     "qid": 793,
     "text": "Which drugs have FGF5 as a compiled target, which is associated with type 2 diabetes mellitus and detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 3-[(3-(2-CARBOXYETHYL)-4-METHYLPYRROL-2-YL)METHYLENE]-2-INDOLINONE, (2) Suramin, (3) Genistein, (4) Sucrosofate, (5) Arsenous acid, (6) Codeine, (7) Ethanol"
+    "llm_ranking": [
+      {
+        "entity_name": "3-[(3-(2-CARBOXYETHYL)-4-METHYLPYRROL-2-YL)METHYLENE]-2-INDOLINONE",
+        "llm-average": 16.6
+      },
+      {
+        "entity_name": "Suramin",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Genistein",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Sucrosofate",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 5.23
+      },
+      {
+        "entity_name": "Ethanol",
+        "llm-average": 4.18
+      }
+    ]
   },
   {
     "question_number": 167,
     "qid": 794,
     "text": "Which proteins are curated as interacting with DMRTB1, which is associated with heart conduction disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) IL16, (2) LENG8, (3) RAMAC, (4) CSN3"
+    "llm_ranking": [
+      {
+        "entity_name": "IL16",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "LENG8",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "RAMAC",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "CSN3",
+        "llm-average": 11.24
+      }
+    ]
   },
   {
     "question_number": 168,
     "qid": 795,
     "text": "Which metabolites are associated with NDST2, which is associated with legume allergy and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Phosphoadenosine phosphosulfate, (2) Adenosine 3',5'-diphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Phosphoadenosine phosphosulfate",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Adenosine 3',5'-diphosphate",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 169,
     "qid": 798,
     "text": "Which proteins are curated as interacting with CDK10, which is associated with ovarian disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PIN1, (2) HSP90AB1, (3) PRKD2, (4) CCR4"
+    "llm_ranking": [
+      {
+        "entity_name": "PIN1",
+        "llm-average": 16.34
+      },
+      {
+        "entity_name": "HSP90AB1",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "PRKD2",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "CCR4",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 170,
     "qid": 799,
     "text": "Which proteins act on ZNF229, which is associated with monoclonal gammopathy of uncertain significance and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) FBXL19, (2) LONRF2"
+    "llm_ranking": [
+      {
+        "entity_name": "FBXL19",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "LONRF2",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 171,
     "qid": 801,
     "text": "Which proteins act on POU2F3, which is associated with Griscelli syndrome type 2 and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) HCFC2, (2) CSNK2A1"
+    "llm_ranking": [
+      {
+        "entity_name": "HCFC2",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "CSNK2A1",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 172,
     "qid": 802,
     "text": "Which proteins are curated as interacting with NAP1L2, which is associated with autosomal recessive disease and is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PPP3R1, (2) FAM81A, (3) TP53BP2, (4) MED30, (5) CUL1, (6) NAP1L5, (7) FBL, (8) NAP1L3"
+    "llm_ranking": [
+      {
+        "entity_name": "PPP3R1",
+        "llm-average": 15.56
+      },
+      {
+        "entity_name": "FAM81A",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "TP53BP2",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "MED30",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "CUL1",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "NAP1L5",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "NAP1L3",
+        "llm-average": 9.15
+      },
+      {
+        "entity_name": "FBL",
+        "llm-average": 9.15
+      }
+    ]
   },
   {
     "question_number": 173,
     "qid": 821,
     "text": "List the proteins that are associated with peripheral nerve sheath neoplasm and are subunits of AXIN1-APC-CTNNB1-GSK3B complex.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) GSK3B, (2) CTNNB1, (3) AXIN1"
+    "llm_ranking": [
+      {
+        "entity_name": "GSK3B",
+        "llm-average": 12.77
+      },
+      {
+        "entity_name": "CTNNB1",
+        "llm-average": 10.82
+      },
+      {
+        "entity_name": "AXIN1",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 174,
     "qid": 837,
     "text": "List the proteins that are associated with placenta cancer and act on DOCK5.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) KDR, (2) FLT4"
+    "llm_ranking": [
+      {
+        "entity_name": "KDR",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "FLT4",
+        "llm-average": 8.85
+      }
+    ]
   },
   {
     "question_number": 175,
     "qid": 844,
     "text": "List the proteins that are subunits of ESR1-JUN-GRIP1 complex and are associated with peripheral nerve sheath neoplasm.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JUN, (2) ESR1"
+    "llm_ranking": [
+      {
+        "entity_name": "JUN",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "ESR1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 176,
     "qid": 850,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(14:1(9Z)/22:1(13Z)/20:3(8Z,11Z,14Z)) and are associated with renal carcinoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 177,
     "qid": 853,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-12:0/18:2(9Z,11Z)/i-16:0/a-25:0) and are associated with lymphoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PTPMT1, (2) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 178,
     "qid": 859,
     "text": "List the proteins that are associated with prostate cancer and are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-19:0/i-13:0/a-15:0).",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PTPMT1, (2) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 179,
     "qid": 862,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(20:2(11Z,14Z)/22:5(4Z,7Z,10Z,13Z,16Z)/22:5(7Z,10Z,13Z,16Z,19Z)) and are associated with lymphatic system cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) AGPAT1, (3) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 10.0
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 180,
     "qid": 868,
     "text": "List the drugs that have the compiled target NUP214 and act on ARHGEF4.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Guanosine-5'-Triphosphate, (2) Guanosine-5'-Diphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Guanosine-5'-Triphosphate",
+        "llm-average": 8.78
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 181,
     "qid": 870,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(21:0/i-15:0/i-17:0) and are associated with renal carcinoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 182,
     "qid": 873,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(20:4(5Z,8Z,11Z,14Z)/18:1(9Z)/22:6(4Z,7Z,10Z,13Z,16Z,19Z)) and are detected in pathology samples of liver cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPAM, (4) AGPAT1, (5) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 14.15
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 8.93
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 183,
     "qid": 874,
     "text": "List the proteins that are associated with stomach carcinoma and are subunits of PTIP-DNA damage response complex.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TP53BP1, (2) MRE11, (3) NBN"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53BP1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "NBN",
+        "llm-average": 12.17
+      },
+      {
+        "entity_name": "MRE11",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 184,
     "qid": 881,
     "text": "List the proteins that are associated with malignant pleural mesothelioma and are compiled as interacting with PABPC1L.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CHTOP, (2) WEE1, (3) EIF4G1, (4) EIF4A2, (5) EIF4A1, (6) EIF4E, (7) EEF2"
+    "llm_ranking": [
+      {
+        "entity_name": "CHTOP",
+        "llm-average": 18.94
+      },
+      {
+        "entity_name": "WEE1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "EIF4G1",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "EIF4A2",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "EIF4E",
+        "llm-average": 8.9
+      },
+      {
+        "entity_name": "EIF4A1",
+        "llm-average": 8.83
+      },
+      {
+        "entity_name": "EEF2",
+        "llm-average": 7.63
+      }
+    ]
   },
   {
     "question_number": 185,
     "qid": 894,
     "text": "List the proteins that are subunits of ITGA9-ITGB1-SPP1 complex and are associated with invasive ductal carcinoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ITGB1, (2) SPP1"
+    "llm_ranking": [
+      {
+        "entity_name": "ITGB1",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "SPP1",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 186,
     "qid": 904,
     "text": "List the proteins that are subunits of CAMK2-delta-MASH1 promoter-coactivator complex and are associated with leiomyosarcoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PARP1, (2) CREBBP, (3) SRC"
+    "llm_ranking": [
+      {
+        "entity_name": "PARP1",
+        "llm-average": 16.8
+      },
+      {
+        "entity_name": "CREBBP",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "SRC",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 187,
     "qid": 922,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-13:0/i-12:0/i-14:0/a-13:0) and are detected in pathology samples of prostate cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRLS1, (2) AGPAT5, (3) CDS2, (4) PTPMT1, (5) PGS1, (6) GPAM, (7) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 17.57
+      },
+      {
+        "entity_name": "CDS2",
+        "llm-average": 15.2
+      },
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 15.0
+      },
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 13.55
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 11.1
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.48
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 188,
     "qid": 923,
     "text": "List the proteins that are associated with uterine cancer and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(15:0/18:1(11Z)/22:0).",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 15.07
+      }
+    ]
   },
   {
     "question_number": 189,
     "qid": 932,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-14:0/i-16:0/i-12:0/i-20:0) and are associated with B-cell lymphoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PTPMT1, (2) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 190,
     "qid": 935,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:2(13Z,16Z)/18:3(9Z,12Z,15Z)/18:4(6Z,9Z,12Z,15Z)) and are detected in pathology samples of prostate cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) GPAM, (3) DGAT1, (4) GPD1, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 8.93
+      }
+    ]
   },
   {
     "question_number": 191,
     "qid": 942,
     "text": "List the proteins that are associated with colorectal cancer and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(18:1(9Z)/20:5(5Z,8Z,11Z,14Z,17Z)/22:4(7Z,10Z,13Z,16Z)).",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPAM, (4) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 12.72
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 7.09
+      }
+    ]
   },
   {
     "question_number": 192,
     "qid": 950,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(16:1(9Z)/20:4(8Z,11Z,14Z,17Z)/20:4(8Z,11Z,14Z,17Z)) and are associated with uterine cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 193,
     "qid": 953,
     "text": "List the proteins that are subunits of BRAF-RAF1-14-3-3 complex and are associated with HCL-V.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) BRAF, (2) RAF1"
+    "llm_ranking": [
+      {
+        "entity_name": "BRAF",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "RAF1",
+        "llm-average": 10.35
+      }
+    ]
   },
   {
     "question_number": 194,
     "qid": 955,
     "text": "List the proteins that are detected in pathology samples of colorectal cancer and are associated with NIH-3T3-G185 cell.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ANXA5, (2) ABCG2, (3) ABCC1, (4) ABCB1"
+    "llm_ranking": [
+      {
+        "entity_name": "ANXA5",
+        "llm-average": 13.15
+      },
+      {
+        "entity_name": "ABCG2",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "ABCC1",
+        "llm-average": 7.55
+      },
+      {
+        "entity_name": "ABCB1",
+        "llm-average": 6.8
+      }
+    ]
   },
   {
     "question_number": 195,
     "qid": 963,
     "text": "List the proteins that are associated with lymphoma and are subunits of ING1-PCNA complex.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ING1, (2) PCNA"
+    "llm_ranking": [
+      {
+        "entity_name": "ING1",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "PCNA",
+        "llm-average": 6.27
+      }
+    ]
   },
   {
     "question_number": 196,
     "qid": 990,
     "text": "List the proteins that are subunits of TRAP-SMCC mediator complex and are associated with luminal breast carcinoma A.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MED29, (2) MED11"
+    "llm_ranking": [
+      {
+        "entity_name": "MED29",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "MED11",
+        "llm-average": 8.85
+      }
+    ]
   },
   {
     "question_number": 197,
     "qid": 996,
     "text": "List the proteins that are detected in pathology samples of liver cancer and are associated with succinate dehydrogenase (ubiquinone) activity.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SDHB, (2) SDHA"
+    "llm_ranking": [
+      {
+        "entity_name": "SDHB",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "SDHA",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 198,
     "qid": 1003,
     "text": "List the proteins that are associated with oropharynx cancer and are annotated in the pathway ESR-mediated signaling.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ESR2, (2) MAPK3, (3) MAPK1, (4) HSP90AA1, (5) ESR1"
+    "llm_ranking": [
+      {
+        "entity_name": "ESR2",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "MAPK3",
+        "llm-average": 10.57
+      },
+      {
+        "entity_name": "MAPK1",
+        "llm-average": 9.66
+      },
+      {
+        "entity_name": "HSP90AA1",
+        "llm-average": 9.25
+      },
+      {
+        "entity_name": "ESR1",
+        "llm-average": 8.06
+      }
+    ]
   },
   {
     "question_number": 199,
     "qid": 1030,
     "text": "List the proteins that are associated with pleural cancer and are subunits of IKB(alpha)-RELA-cREL complex.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) NFKBIA, (2) RELA"
+    "llm_ranking": [
+      {
+        "entity_name": "NFKBIA",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "RELA",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 200,
     "qid": 1031,
     "text": "List the proteins that are compiled as interacting with AMOTL2 and are associated with spleen cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) AMOTL1, (2) ALB"
+    "llm_ranking": [
+      {
+        "entity_name": "AMOTL1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "ALB",
+        "llm-average": 3.89
+      }
+    ]
   },
   {
     "question_number": 201,
     "qid": 1037,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:0/18:3(9Z,12Z,15Z)/22:5(4Z,7Z,10Z,13Z,16Z)) and are associated with kidney cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 202,
     "qid": 1043,
     "text": "List the proteins that are subunits of Brm-associated complex and are associated with childhood leukemia.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SMARCB1, (2) PRMT5, (3) SMARCA2"
+    "llm_ranking": [
+      {
+        "entity_name": "SMARCB1",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "PRMT5",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "SMARCA2",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 203,
     "qid": 1046,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(i-24:0/18:0/13:0) and are associated with kidney cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 204,
     "qid": 1062,
     "text": "List the proteins that are associated with hepatobiliary system cancer and are annotated in the pathway Cardiolipin Biosynthesis CL(i-12:0/18:2(9Z,11Z)/i-18:0/i-14:0).",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PTPMT1, (2) CRLS1, (3) GPAM, (4) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 17.38
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.1
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.86
+      }
+    ]
   },
   {
     "question_number": 205,
     "qid": 1063,
     "text": "List the proteins that act on TTI2 and are associated with colorectal cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RUVBL2, (2) TTI1, (3) TELO2"
+    "llm_ranking": [
+      {
+        "entity_name": "RUVBL2",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "TTI1",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "TELO2",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 206,
     "qid": 1064,
     "text": "List the proteins that are associated with glomangiosarcoma and are compiled as interacting with KBTBD13.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) GLMN, (2) TPM3"
+    "llm_ranking": [
+      {
+        "entity_name": "GLMN",
+        "llm-average": 15.07
+      },
+      {
+        "entity_name": "TPM3",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 207,
     "qid": 1065,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-24:0/i-24:0/i-17:0) and are associated with breast cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) AGPAT5, (2) PTPMT1, (3) CRLS1, (4) GPAM, (5) PGS1, (6) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 18.7
+      },
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 17.37
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 16.49
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 13.65
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 208,
     "qid": 1069,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of kidney cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MTOR, (2) MYC, (3) RPS6KB1, (4) TP53, (5) CRK, (6) GRB2, (7) JAK2, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 16.07
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 11.03
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 9.74
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.2
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 7.82
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 6.79
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 6.38
+      }
+    ]
   },
   {
     "question_number": 209,
     "qid": 1075,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of lymphoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 210,
     "qid": 1097,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are curated as interacting with WASL.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 211,
     "qid": 1100,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and act on LPXN.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRK, (2) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 8.59
+      }
+    ]
   },
   {
     "question_number": 212,
     "qid": 1104,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of prostate cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 213,
     "qid": 1107,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and act on SHC1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) RPS6KB1, (3) CBL, (4) MTOR, (5) CRK, (6) GRB2, (7) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 9.29
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 9.24
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 7.13
+      }
+    ]
   },
   {
     "question_number": 214,
     "qid": 1127,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are compiled as interacting with GOLPH3.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRK, (2) MYC"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 215,
     "qid": 1138,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and act on MAPK10.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) BCL2L1, (2) CRK, (3) CRKL, (4) TP53"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 7.99
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 6.22
+      }
+    ]
   },
   {
     "question_number": 216,
     "qid": 1140,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of stomach cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 217,
     "qid": 1141,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and act on SHC1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) CBL, (3) RPS6KB1, (4) MTOR, (5) CRK, (6) GRB2, (7) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 15.51
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 9.29
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 7.13
+      }
+    ]
   },
   {
     "question_number": 218,
     "qid": 1142,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are the subunits of CRKL-PDGFRA-CRK-RAPGEF1 complex.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.64
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 219,
     "qid": 1143,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are compiled as interacting with IRS4.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MTOR, (2) PIK3R1, (3) CRKL, (4) CRK, (5) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 14.46
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 9.52
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 220,
     "qid": 1159,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of kidney cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 221,
     "qid": 1174,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are curated as interacting with PRAG1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) CRK, (3) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 222,
     "qid": 1192,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and act on FGFR3.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CBL, (2) MDM2, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "MDM2",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 223,
     "qid": 1208,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are the subunits of CIN85 complex (CIN85, CRK, BCAR1, CBL, PIK3R1, GRB2, SOS1).",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SOS1, (2) PIK3R1, (3) CBL, (4) CRK, (5) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 11.03
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 10.56
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 10.12
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      }
+    ]
   },
   {
     "question_number": 224,
     "qid": 1214,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and act on FRS2.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) PIK3R1, (3) CBL, (4) CRK, (5) GRB2, (6) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 12.53
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 11.62
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 7.13
+      }
+    ]
   },
   {
     "question_number": 225,
     "qid": 1218,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are the subunits of CIN85 complex (CIN85, CRK, BCAR1, CBL, PIK3R1, GRB2, SOS1).",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SOS1, (2) PIK3R1, (3) CBL, (4) CRK, (5) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "SOS1",
+        "llm-average": 10.57
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 10.56
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 10.14
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.62
+      }
+    ]
   },
   {
     "question_number": 226,
     "qid": 1231,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are curated as interacting with HTT.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PIK3R1, (2) TP53, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 227,
     "qid": 1246,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are compiled as interacting with DOCK7.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 228,
     "qid": 1267,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are curated as interacting with PRAG1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) CRK, (3) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.75
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 229,
     "qid": 1276,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and act on FRS2.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) PIK3R1, (3) CRK, (4) GRB2, (5) SOS1, (6) CBL"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 13.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 9.37
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 8.4
+      }
+    ]
   },
   {
     "question_number": 230,
     "qid": 1286,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are the subunits of CRKL-PDGFRA-CRK-RAPGEF1 complex.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.64
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 231,
     "qid": 1313,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are compiled as interacting with BCAR1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) CBL, (3) GRB2, (4) PIK3R1, (5) RPS6KB1, (6) CRKL, (7) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 17.0
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 15.32
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 232,
     "qid": 1343,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of lymphoma.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MYC, (2) MTOR, (3) JAK2, (4) TP53, (5) RPS6KB1, (6) CRK, (7) GRB2, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 10.67
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 9.35
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.8
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 5.78
+      }
+    ]
   },
   {
     "question_number": 233,
     "qid": 1362,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of prostate cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MTOR, (2) MYC, (3) TP53, (4) CRK, (5) RPS6KB1, (6) GRB2, (7) CDKN1B, (8) JAK2"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 16.82
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 15.08
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.2
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.59
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 6.68
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 6.32
+      }
+    ]
   },
   {
     "question_number": 234,
     "qid": 1374,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are compiled as interacting with PEAK1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 235,
     "qid": 1390,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and act on LPXN.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRK, (2) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 236,
     "qid": 1419,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are compiled as interacting with IRS4.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MTOR, (2) PIK3R1, (3) CRK, (4) GRB2, (5) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 15.96
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 10.27
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 237,
     "qid": 1424,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are compiled as interacting with RAC3.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PIK3R1, (2) GRB2, (3) SOS1, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 12.87
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 10.99
+      }
+    ]
   },
   {
     "question_number": 238,
     "qid": 1445,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and act on FGFR3.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CBL, (2) MDM2, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 19.25
+      },
+      {
+        "entity_name": "MDM2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 239,
     "qid": 1460,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of lung cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MYC, (2) MTOR, (3) TP53, (4) CRK, (5) RPS6KB1, (6) GRB2, (7) JAK2, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 15.08
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 13.36
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.5
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 9.78
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.59
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 6.68
+      }
+    ]
   },
   {
     "question_number": 240,
     "qid": 1467,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and act on BMX.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CBL, (2) TP53, (3) CRKL, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 12.38
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 9.97
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 9.61
+      }
+    ]
   },
   {
     "question_number": 241,
     "qid": 1468,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and act on MAPK10.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) BCL2L1, (2) CRK, (3) CRKL, (4) TP53"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 7.99
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 6.22
+      }
+    ]
   },
   {
     "question_number": 242,
     "qid": 1477,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of liver cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MTOR, (2) MYC, (3) RPS6KB1, (4) JAK2, (5) CRK, (6) TP53, (7) GRB2, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 12.61
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 11.03
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 9.74
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 9.2
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 7.51
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 6.79
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 6.38
+      }
+    ]
   },
   {
     "question_number": 243,
     "qid": 1479,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are compiled as interacting with GOLPH3.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MYC, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 12.34
+      }
+    ]
   },
   {
     "question_number": 244,
     "qid": 1488,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are compiled as interacting with TGFB1I1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRKL, (2) MYC, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 10.99
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 245,
     "qid": 1490,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are compiled as interacting with SOCS6.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SKP2, (2) STAT5A, (3) JAK2, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "SKP2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "STAT5A",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 11.32
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 246,
     "qid": 1492,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are curated as interacting with HTT.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PIK3R1, (2) TP53, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.99
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 247,
     "qid": 1493,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with medulloblastoma, and are compiled as interacting with BCAR1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PIK3R1, (2) JAK2, (3) GRB2, (4) RPS6KB1, (5) CBL, (6) CRKL, (7) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 16.1
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 13.49
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 12.18
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 8.67
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 248,
     "qid": 1510,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with thymus cancer, and are compiled as interacting with PEAK1.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 249,
     "qid": 1517,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of liver cancer.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 250,
     "qid": 236,
     "text": "List the biological processes that are associated with PIGQ, which is compiled as a target of N-[(Aminooxy)Carbonyl]Aniline.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) preassembly of GPI anchor in ER membrane, (2) GPI anchor biosynthetic process, (3) carbohydrate metabolic process"
+    "llm_ranking": [
+      {
+        "entity_name": "preassembly of GPI anchor in ER membrane",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "GPI anchor biosynthetic process",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "carbohydrate metabolic process",
+        "llm-average": 9.26
+      }
+    ]
   },
   {
     "question_number": 251,
     "qid": 237,
     "text": "List the pathways that are annotated with REV3L, which is compiled as a target of 4-(5,11-DIOXO-5H-INDENO[1,2-C]ISOQUINOLIN-6(11H)-YL)BUTANOATE.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Translesion synthesis by REV1, (2) Translesion synthesis by POLK, (3) Translesion synthesis by POLI"
+    "llm_ranking": [
+      {
+        "entity_name": "Translesion synthesis by REV1",
+        "llm-average": 15.72
+      },
+      {
+        "entity_name": "Translesion synthesis by POLK",
+        "llm-average": 10.8
+      },
+      {
+        "entity_name": "Translesion synthesis by POLI",
+        "llm-average": 9.12
+      }
+    ]
   },
   {
     "question_number": 252,
     "qid": 238,
     "text": "Which biological processes are associated with KLK13 that alpha-L-fucose acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) proteolysis, (2) cornification"
+    "llm_ranking": [
+      {
+        "entity_name": "proteolysis",
+        "llm-average": 10.24
+      },
+      {
+        "entity_name": "cornification",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 253,
     "qid": 239,
     "text": "List the pathways that are annotated with RRH, which Dodecyldimethylamine N-oxide acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) G alpha (i) signalling events, (2) Opsins"
+    "llm_ranking": [
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 9.34
+      },
+      {
+        "entity_name": "Opsins",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 254,
     "qid": 240,
     "text": "List the proteins that are acted on by MMAA, which is compiled as a target of 2'-Deoxyguanosine-5'-Diphosphate.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) GLOD4, (2) GLO1"
+    "llm_ranking": [
+      {
+        "entity_name": "GLO1",
+        "llm-average": 7.85
+      },
+      {
+        "entity_name": "GLOD4",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 255,
     "qid": 244,
     "text": "List the proteins that are acted on by ELOVL2, which is compiled as a target of Coenzyme A.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ELOVL6, (2) HSD17B3, (3) ELOVL5"
+    "llm_ranking": [
+      {
+        "entity_name": "ELOVL6",
+        "llm-average": 5.69
+      },
+      {
+        "entity_name": "ELOVL5",
+        "llm-average": 4.27
+      },
+      {
+        "entity_name": "HSD17B3",
+        "llm-average": 3.61
+      }
+    ]
   },
   {
     "question_number": 256,
     "qid": 245,
     "text": "List the pathways that are annotated with RARS1, which is compiled as a target of Tamibarotene.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Cytosolic tRNA aminoacylation, (2) Selenoamino acid metabolism, (3) Protein Synthesis: Arginine"
+    "llm_ranking": [
+      {
+        "entity_name": "Cytosolic tRNA aminoacylation",
+        "llm-average": 7.4
+      },
+      {
+        "entity_name": "Protein Synthesis: Arginine",
+        "llm-average": 6.54
+      },
+      {
+        "entity_name": "Selenoamino acid metabolism",
+        "llm-average": 3.45
+      }
+    ]
   },
   {
     "question_number": 257,
     "qid": 247,
     "text": "Which proteins are acted on by SDK1, which is compiled as a target of alpha-L-fucose?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PTK7, (2) PRKCA, (3) TLN2"
+    "llm_ranking": [
+      {
+        "entity_name": "PTK7",
+        "llm-average": 14.04
+      },
+      {
+        "entity_name": "PRKCA",
+        "llm-average": 11.53
+      },
+      {
+        "entity_name": "TLN2",
+        "llm-average": 7.83
+      }
+    ]
   },
   {
     "question_number": 258,
     "qid": 250,
     "text": "Which proteins are acted on by PHGDH, which is compiled as a target of D-Glutamic Acid?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PSPH, (2) PSAT1, (3) SLC4A4, (4) PGAM4, (5) BPGM, (6) PGAM1, (7) EWSR1, (8) PFKFB1"
+    "llm_ranking": [
+      {
+        "entity_name": "PSPH",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "PSAT1",
+        "llm-average": 11.74
+      },
+      {
+        "entity_name": "SLC4A4",
+        "llm-average": 8.85
+      },
+      {
+        "entity_name": "PGAM1",
+        "llm-average": 6.01
+      },
+      {
+        "entity_name": "PGAM4",
+        "llm-average": 5.69
+      },
+      {
+        "entity_name": "BPGM",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "EWSR1",
+        "llm-average": 3.06
+      },
+      {
+        "entity_name": "PFKFB1",
+        "llm-average": 1.55
+      }
+    ]
   },
   {
     "question_number": 259,
     "qid": 252,
     "text": "Which pathways are annotated with S1PR1, which is compiled as a target of D-Glutamic Acid?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Lysosphingolipid and LPA receptors, (2) Interleukin-4 and Interleukin-13 signaling, (3) Potential therapeutics for SARS"
+    "llm_ranking": [
+      {
+        "entity_name": "Lysosphingolipid and LPA receptors",
+        "llm-average": 13.47
+      },
+      {
+        "entity_name": "Interleukin-4 and Interleukin-13 signaling",
+        "llm-average": 12.23
+      },
+      {
+        "entity_name": "Potential therapeutics for SARS",
+        "llm-average": 10.67
+      }
+    ]
   },
   {
     "question_number": 260,
     "qid": 255,
     "text": "Which pathways are annotated with COX6B1, which is compiled as a target of Flavin mononucleotide?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TP53 Regulates Metabolic Genes, (2) Respiratory electron transport, (3) Cytoprotection by HMOX1"
+    "llm_ranking": [
+      {
+        "entity_name": "Respiratory electron transport",
+        "llm-average": 14.32
+      },
+      {
+        "entity_name": "TP53 Regulates Metabolic Genes",
+        "llm-average": 13.78
+      },
+      {
+        "entity_name": "Cytoprotection by HMOX1",
+        "llm-average": 8.66
+      }
+    ]
   },
   {
     "question_number": 261,
     "qid": 258,
     "text": "List the pathways that are annotated with CHRM4, which (S)-econazole acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Muscarinic acetylcholine receptors, (2) G alpha (i) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Muscarinic acetylcholine receptors",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 262,
     "qid": 264,
     "text": "List the biological processes that are associated with PRPSAP2, which Adenosine phosphate acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) negative regulation of catalytic activity, (2) purine nucleotide biosynthetic process, (3) 5-phosphoribose 1-diphosphate biosynthetic process, (4) nucleoside metabolic process, (5) nucleobase-containing compound metabolic process"
+    "llm_ranking": [
+      {
+        "entity_name": "purine nucleotide biosynthetic process",
+        "llm-average": 12.0
+      },
+      {
+        "entity_name": "negative regulation of catalytic activity",
+        "llm-average": 11.28
+      },
+      {
+        "entity_name": "5-phosphoribose 1-diphosphate biosynthetic process",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "nucleoside metabolic process",
+        "llm-average": 5.76
+      },
+      {
+        "entity_name": "nucleobase-containing compound metabolic process",
+        "llm-average": 5.0
+      }
+    ]
   },
   {
     "question_number": 263,
     "qid": 265,
     "text": "Which pathways are annotated with HTR4, which is compiled as a target of 4-{2-[(7-amino-2-furan-2-yl[1,2,4]triazolo[1,5-a][1,3,5]triazin-5-yl)amino]ethyl}phenol?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Excitatory Neural Signalling Through 5-HTR 4 and Serotonin, (2) ADORA2B mediated anti-inflammatory cytokines production, (3) G alpha (s) signalling events, (4) Serotonin receptors"
+    "llm_ranking": [
+      {
+        "entity_name": "Excitatory Neural Signalling Through 5-HTR 4 and Serotonin",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "G alpha (s) signalling events",
+        "llm-average": 11.32
+      },
+      {
+        "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
+        "llm-average": 10.93
+      },
+      {
+        "entity_name": "Serotonin receptors",
+        "llm-average": 5.65
+      }
+    ]
   },
   {
     "question_number": 264,
     "qid": 266,
     "text": "Which pathways are annotated with CTLA4, which is compiled as a target of N-Ethyl-5'-Carboxamido Adenosine?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RUNX1 and FOXP3 control the development of regulatory T lymphocytes (Tregs), (2) CTLA4 inhibitory signaling"
+    "llm_ranking": [
+      {
+        "entity_name": "RUNX1 and FOXP3 control the development of regulatory T lymphocytes (Tregs)",
+        "llm-average": 16.75
+      },
+      {
+        "entity_name": "CTLA4 inhibitory signaling",
+        "llm-average": 12.31
+      }
+    ]
   },
   {
     "question_number": 265,
     "qid": 267,
     "text": "Which pathways are annotated with OPRK1, which 4-{2-[(7-amino-2-furan-2-yl[1,2,4]triazolo[1,5-a][1,3,5]triazin-5-yl)amino]ethyl}phenol acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MECP2 regulates neuronal receptors and channels, (2) G alpha (i) signalling events, (3) Nalbuphine Action Pathway, (4) Peptide ligand-binding receptors"
+    "llm_ranking": [
+      {
+        "entity_name": "MECP2 regulates neuronal receptors and channels",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "Nalbuphine Action Pathway",
+        "llm-average": 10.67
+      },
+      {
+        "entity_name": "Peptide ligand-binding receptors",
+        "llm-average": 8.95
+      }
+    ]
   },
   {
     "question_number": 266,
     "qid": 268,
     "text": "List the biological processes that are associated with PDF, which is compiled as a target of N-[(2R)-2-{[(2S)-2-(1,3-benzoxazol-2-yl)pyrrolidin-1-yl]carbonyl}hexyl]-N-hydroxyformamide.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) peptidyl-methionine modification, (2) N-terminal protein amino acid modification, (3) co-translational protein modification, (4) positive regulation of cell population proliferation, (5) translation"
+    "llm_ranking": [
+      {
+        "entity_name": "peptidyl-methionine modification",
+        "llm-average": 16.13
+      },
+      {
+        "entity_name": "N-terminal protein amino acid modification",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "co-translational protein modification",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "positive regulation of cell population proliferation",
+        "llm-average": 5.65
+      },
+      {
+        "entity_name": "translation",
+        "llm-average": 2.92
+      }
+    ]
   },
   {
     "question_number": 267,
     "qid": 270,
     "text": "List the pathways that are annotated with FBXL19, which is compiled as a target of (2S)-8-[(tert-butoxycarbonyl)amino]-2-(1H-indol-3-yl)octanoic acid.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Neddylation, (2) Antigen processing: Ubiquitination & Proteasome degradation"
+    "llm_ranking": [
+      {
+        "entity_name": "Neddylation",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "Antigen processing: Ubiquitination & Proteasome degradation",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 268,
     "qid": 272,
     "text": "List the biological processes that are associated with OGDHL, which Adenosine phosphate acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 2-oxoglutarate metabolic process, (2) tricarboxylic acid cycle, (3) glycolytic process"
+    "llm_ranking": [
+      {
+        "entity_name": "2-oxoglutarate metabolic process",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "tricarboxylic acid cycle",
+        "llm-average": 6.76
+      },
+      {
+        "entity_name": "glycolytic process",
+        "llm-average": 4.47
+      }
+    ]
   },
   {
     "question_number": 269,
     "qid": 282,
     "text": "List the pathways that are annotated with GLUD2, which is compiled as a target of D-Glutamic Acid.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Glutamate and glutamine metabolism, (2) Transcriptional activation of mitochondrial biogenesis"
+    "llm_ranking": [
+      {
+        "entity_name": "Glutamate and glutamine metabolism",
+        "llm-average": 14.84
+      },
+      {
+        "entity_name": "Transcriptional activation of mitochondrial biogenesis",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 270,
     "qid": 293,
     "text": "Which pathways are annotated with SLC25A17, which is compiled as a target of Adenosine phosphate?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Class I peroxisomal membrane protein import, (2) Alpha-oxidation of phytanate"
+    "llm_ranking": [
+      {
+        "entity_name": "Class I peroxisomal membrane protein import",
+        "llm-average": 13.47
+      },
+      {
+        "entity_name": "Alpha-oxidation of phytanate",
+        "llm-average": 12.23
+      }
+    ]
   },
   {
     "question_number": 271,
     "qid": 298,
     "text": "List the pathways that are annotated with TTR, which is compiled as a target of 2',6'-DIFLUOROBIPHENYL-4-CARBOXYLIC ACID.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Amyloid fiber formation, (2) The canonical retinoid cycle in rods (twilight vision), (3) Retinoid metabolism and transport, (4) Retinoid cycle disease events, (5) Neutrophil degranulation, (6) Non-integrin membrane-ECM interactions"
+    "llm_ranking": [
+      {
+        "entity_name": "Amyloid fiber formation",
+        "llm-average": 15.22
+      },
+      {
+        "entity_name": "The canonical retinoid cycle in rods (twilight vision)",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Retinoid metabolism and transport",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "Retinoid cycle disease events",
+        "llm-average": 9.13
+      },
+      {
+        "entity_name": "Neutrophil degranulation",
+        "llm-average": 6.98
+      },
+      {
+        "entity_name": "Non-integrin membrane-ECM interactions",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 272,
     "qid": 302,
     "text": "Which pathways are annotated with PRKG1, which is compiled as a target of (S)-2-METHYL-1-[(4-METHYL-5-ISOQUINOLINE)SULFONYL]-HOMOPIPERAZINE?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Ca2+ pathway, (2) Ion Channels and Their Functional Role in Vascular Endothelium"
+    "llm_ranking": [
+      {
+        "entity_name": "Ca2+ pathway",
+        "llm-average": 13.47
+      },
+      {
+        "entity_name": "Ion Channels and Their Functional Role in Vascular Endothelium",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 273,
     "qid": 303,
     "text": "Which pathways are annotated with SORD, which alpha-D-Xylopyranose acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Formation of xylulose-5-phosphate, (2) Fructose and Mannose Degradation, (3) Fructosuria, (4) Fructose biosynthesis, (5) Fructose Intolerance, Hereditary"
+    "llm_ranking": [
+      {
+        "entity_name": "Formation of xylulose-5-phosphate",
+        "llm-average": 13.29
+      },
+      {
+        "entity_name": "Fructose biosynthesis",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Fructosuria",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Fructose and Mannose Degradation",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "Fructose Intolerance, Hereditary",
+        "llm-average": 5.89
+      }
+    ]
   },
   {
     "question_number": 274,
     "qid": 304,
     "text": "List the proteins that are acted on by OLFML1, which is compiled as a target of alpha-L-fucose.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LRRK1, (2) CTNNA3"
+    "llm_ranking": [
+      {
+        "entity_name": "CTNNA3",
+        "llm-average": 11.08
+      },
+      {
+        "entity_name": "LRRK1",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 275,
     "qid": 309,
     "text": "List the pathways that are annotated with EXOSC8, which is compiled as a target of Adenosine phosphate.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Tristetraprolin (TTP, ZFP36) binds and destabilizes mRNA, (2) Butyrate Response Factor 1 (BRF1) binds and destabilizes mRNA, (3) KSRP (KHSRP) binds and destabilizes mRNA, (4) ATF4 activates genes in response to endoplasmic reticulum  stress, (5) mRNA decay by 3' to 5' exoribonuclease, (6) Major pathway of rRNA processing in the nucleolus and cytosol"
+    "llm_ranking": [
+      {
+        "entity_name": "Tristetraprolin (TTP, ZFP36) binds and destabilizes mRNA",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "Butyrate Response Factor 1 (BRF1) binds and destabilizes mRNA",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "KSRP (KHSRP) binds and destabilizes mRNA",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "mRNA decay by 3' to 5' exoribonuclease",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "ATF4 activates genes in response to endoplasmic reticulum  stress",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "Major pathway of rRNA processing in the nucleolus and cytosol",
+        "llm-average": 4.35
+      }
+    ]
   },
   {
     "question_number": 276,
     "qid": 310,
     "text": "List the pathways that are annotated with ALDH1A2, which is compiled as a target of Nicotinamide adenine dinucleotide phosphate.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RA biosynthesis pathway, (2) Retinol Metabolism, (3) Vitamin A Deficiency"
+    "llm_ranking": [
+      {
+        "entity_name": "RA biosynthesis pathway",
+        "llm-average": 15.72
+      },
+      {
+        "entity_name": "Retinol Metabolism",
+        "llm-average": 12.31
+      },
+      {
+        "entity_name": "Vitamin A Deficiency",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 277,
     "qid": 312,
     "text": "List the proteins that are acted on by PSKH1, which 4-[3-Hydroxyanilino]-6,7-Dimethoxyquinazoline acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RHOT2, (2) RHOT1, (3) TTN, (4) MYL3, (5) MYL4, (6) MYL6B, (7) MYL1, (8) MYL6"
+    "llm_ranking": [
+      {
+        "entity_name": "RHOT2",
+        "llm-average": 14.95
+      },
+      {
+        "entity_name": "RHOT1",
+        "llm-average": 14.75
+      },
+      {
+        "entity_name": "TTN",
+        "llm-average": 13.21
+      },
+      {
+        "entity_name": "MYL6B",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "MYL4",
+        "llm-average": 8.03
+      },
+      {
+        "entity_name": "MYL3",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "MYL1",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "MYL6",
+        "llm-average": 6.22
+      }
+    ]
   },
   {
     "question_number": 278,
     "qid": 317,
     "text": "Which proteins are acted on by PVR, which is compiled as a target of alpha-L-fucose?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TIGIT, (2) NECTIN3, (3) ITGB3"
+    "llm_ranking": [
+      {
+        "entity_name": "TIGIT",
+        "llm-average": 17.08
+      },
+      {
+        "entity_name": "NECTIN3",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "ITGB3",
+        "llm-average": 9.26
+      }
+    ]
   },
   {
     "question_number": 279,
     "qid": 320,
     "text": "List the proteins that are acted on by MAFF, which is compiled as a target of 1,4-Dithiothreitol.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) BACH1, (2) MAFG, (3) NFE2L2, (4) NFE2L1, (5) NFE2, (6) HBE1, (7) HBD, (8) HBG2"
+    "llm_ranking": [
+      {
+        "entity_name": "BACH1",
+        "llm-average": 12.5
+      },
+      {
+        "entity_name": "MAFG",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "NFE2L2",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "NFE2L1",
+        "llm-average": 10.8
+      },
+      {
+        "entity_name": "NFE2",
+        "llm-average": 7.51
+      },
+      {
+        "entity_name": "HBE1",
+        "llm-average": 6.54
+      },
+      {
+        "entity_name": "HBG2",
+        "llm-average": 3.37
+      },
+      {
+        "entity_name": "HBD",
+        "llm-average": 3.3
+      }
+    ]
   },
   {
     "question_number": 280,
     "qid": 321,
     "text": "List the proteins that are acted on by PCSK2, which is compiled as a target of alpha-L-fucose.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SCG5, (2) RXFP2, (3) INS, (4) RXFP1, (5) LGR5, (6) LGR4, (7) LGR6, (8) FN1"
+    "llm_ranking": [
+      {
+        "entity_name": "SCG5",
+        "llm-average": 16.18
+      },
+      {
+        "entity_name": "RXFP2",
+        "llm-average": 11.25
+      },
+      {
+        "entity_name": "INS",
+        "llm-average": 10.97
+      },
+      {
+        "entity_name": "RXFP1",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "LGR5",
+        "llm-average": 8.53
+      },
+      {
+        "entity_name": "LGR4",
+        "llm-average": 5.76
+      },
+      {
+        "entity_name": "LGR6",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "FN1",
+        "llm-average": 1.55
+      }
+    ]
   },
   {
     "question_number": 281,
     "qid": 327,
     "text": "Which proteins are acted on by HPD, which is compiled as a target of D-Glutamic Acid?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) GOT1L1, (2) DDO, (3) TAT, (4) COQ2, (5) UPB1, (6) GOT1"
+    "llm_ranking": [
+      {
+        "entity_name": "GOT1L1",
+        "llm-average": 16.7
+      },
+      {
+        "entity_name": "TAT",
+        "llm-average": 9.42
+      },
+      {
+        "entity_name": "DDO",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "COQ2",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "UPB1",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "GOT1",
+        "llm-average": 5.79
+      }
+    ]
   },
   {
     "question_number": 282,
     "qid": 328,
     "text": "Which pathways are annotated with NOX4, which is compiled as a target of Nicotinamide adenine dinucleotide phosphate?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Detoxification of Reactive Oxygen Species, (2) STAT5 activation downstream of FLT3 ITD mutants, (3) Signaling by FLT3 fusion proteins, (4) Thyroid Hormone Synthesis"
+    "llm_ranking": [
+      {
+        "entity_name": "Detoxification of Reactive Oxygen Species",
+        "llm-average": 17.08
+      },
+      {
+        "entity_name": "STAT5 activation downstream of FLT3 ITD mutants",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "Signaling by FLT3 fusion proteins",
+        "llm-average": 12.61
+      },
+      {
+        "entity_name": "Thyroid Hormone Synthesis",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 283,
     "qid": 329,
     "text": "List the pathways that are annotated with QRFPR, which 4-{2-[(7-amino-2-furan-2-yl[1,2,4]triazolo[1,5-a][1,3,5]triazin-5-yl)amino]ethyl}phenol acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Orexin and neuropeptides FF and QRFP bind to their respective receptors, (2) G alpha (q) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Orexin and neuropeptides FF and QRFP bind to their respective receptors",
+        "llm-average": 18.45
+      },
+      {
+        "entity_name": "G alpha (q) signalling events",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 284,
     "qid": 332,
     "text": "Which biological processes are associated with RNASEH2A, which is compiled as a target of 2-Methyl-3-(2-Aminothiazolo)Propanal?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RNA catabolic process, (2) mismatch repair, (3) RNA phosphodiester bond hydrolysis, endonucleolytic, (4) DNA replication, (5) DNA replication, removal of RNA primer"
+    "llm_ranking": [
+      {
+        "entity_name": "RNA catabolic process",
+        "llm-average": 15.48
+      },
+      {
+        "entity_name": "mismatch repair",
+        "llm-average": 9.73
+      },
+      {
+        "entity_name": "RNA phosphodiester bond hydrolysis, endonucleolytic",
+        "llm-average": 9.64
+      },
+      {
+        "entity_name": "DNA replication",
+        "llm-average": 9.14
+      },
+      {
+        "entity_name": "DNA replication, removal of RNA primer",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 285,
     "qid": 340,
     "text": "List the pathways that are annotated with VDR, which is compiled as a target of Ergosterol.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Vitamin D (calciferol) metabolism, (2) SUMOylation of intracellular receptors, (3) Nuclear Receptor transcription pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Vitamin D (calciferol) metabolism",
+        "llm-average": 15.54
+      },
+      {
+        "entity_name": "SUMOylation of intracellular receptors",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "Nuclear Receptor transcription pathway",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 286,
     "qid": 341,
     "text": "Which pathways are annotated with GRPR, which 4-{2-[(7-amino-2-furan-2-yl[1,2,4]triazolo[1,5-a][1,3,5]triazin-5-yl)amino]ethyl}phenol acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) G alpha (q) signalling events, (2) Peptide ligand-binding receptors"
+    "llm_ranking": [
+      {
+        "entity_name": "Peptide ligand-binding receptors",
+        "llm-average": 11.53
+      },
+      {
+        "entity_name": "G alpha (q) signalling events",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 287,
     "qid": 342,
     "text": "Which pathways are annotated with ALDH5A1, which Coenzyme A acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) 4-Hydroxybutyric Aciduria/Succinic Semialdehyde Dehydrogenase Deficiency, (2) Succinic Semialdehyde Dehydrogenase Deficiency, (3) Degradation of GABA, (4) Homocarnosinosis, (5) Hyperinsulinism-Hyperammonemia Syndrome, (6) 2-Hydroxyglutric Aciduria (D and L Form), (7) Glutamate Metabolism"
+    "llm_ranking": [
+      {
+        "entity_name": "4-Hydroxybutyric Aciduria/Succinic Semialdehyde Dehydrogenase Deficiency",
+        "llm-average": 15.22
+      },
+      {
+        "entity_name": "Degradation of GABA",
+        "llm-average": 11.1
+      },
+      {
+        "entity_name": "Succinic Semialdehyde Dehydrogenase Deficiency",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "Homocarnosinosis",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "2-Hydroxyglutric Aciduria (D and L Form)",
+        "llm-average": 8.61
+      },
+      {
+        "entity_name": "Hyperinsulinism-Hyperammonemia Syndrome",
+        "llm-average": 8.47
+      },
+      {
+        "entity_name": "Glutamate Metabolism",
+        "llm-average": 6.11
+      }
+    ]
   },
   {
     "question_number": 288,
     "qid": 343,
     "text": "Which proteins are acted on by POR, which Palmitoleic Acid acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CYP4F8, (2) CYP4F12"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP4F8",
+        "llm-average": 14.18
+      },
+      {
+        "entity_name": "CYP4F12",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 289,
     "qid": 346,
     "text": "Which pathways are annotated with SERPINE1, which alpha-D-Xylopyranose acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) BMAL1:CLOCK,NPAS2 activates circadian gene expression, (2) SMAD2/SMAD3:SMAD4 heterotrimer regulates transcription, (3) ECM proteoglycans, (4) Dissolution of Fibrin Clot, (5) Platelet degranulation "
+    "llm_ranking": [
+      {
+        "entity_name": "BMAL1:CLOCK,NPAS2 activates circadian gene expression",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "SMAD2/SMAD3:SMAD4 heterotrimer regulates transcription",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "ECM proteoglycans",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "Dissolution of Fibrin Clot",
+        "llm-average": 5.65
+      },
+      {
+        "entity_name": "Platelet degranulation ",
+        "llm-average": 4.35
+      }
+    ]
   },
   {
     "question_number": 290,
     "qid": 347,
     "text": "List the pathways that are annotated with BRS3, which 4-{2-[(7-amino-2-furan-2-yl[1,2,4]triazolo[1,5-a][1,3,5]triazin-5-yl)amino]ethyl}phenol acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Peptide ligand-binding receptors, (2) G alpha (q) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Peptide ligand-binding receptors",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "G alpha (q) signalling events",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 291,
     "qid": 348,
     "text": "Which pathways are annotated with HLA-B, which Enprofylline acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Antigen Presentation: Folding, assembly and peptide loading of class I MHC, (2) Immunoregulatory interactions between a Lymphoid and a non-Lymphoid cell, (3) ER-Phagosome pathway, (4) Endosomal/Vacuolar pathway, (5) Interferon gamma signaling, (6) Interferon alpha/beta signaling, (7) Neutrophil degranulation"
+    "llm_ranking": [
+      {
+        "entity_name": "Antigen Presentation: Folding, assembly and peptide loading of class I MHC",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "Immunoregulatory interactions between a Lymphoid and a non-Lymphoid cell",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "ER-Phagosome pathway",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Endosomal/Vacuolar pathway",
+        "llm-average": 10.34
+      },
+      {
+        "entity_name": "Interferon gamma signaling",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "Interferon alpha/beta signaling",
+        "llm-average": 4.6
+      },
+      {
+        "entity_name": "Neutrophil degranulation",
+        "llm-average": 3.49
+      }
+    ]
   },
   {
     "question_number": 292,
     "qid": 351,
     "text": "List the pathways that are annotated with UGCG, which Dodecyldimethylamine N-oxide acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Glycosphingolipid metabolism, (2) Sphingolipid Metabolism, (3) Globoid Cell Leukodystrophy, (4) Gaucher Disease, (5) Krabbe Disease, (6) Metachromatic Leukodystrophy (MLD), (7) Fabry Disease"
+    "llm_ranking": [
+      {
+        "entity_name": "Glycosphingolipid metabolism",
+        "llm-average": 16.64
+      },
+      {
+        "entity_name": "Sphingolipid Metabolism",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "Globoid Cell Leukodystrophy",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "Gaucher Disease",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "Krabbe Disease",
+        "llm-average": 8.73
+      },
+      {
+        "entity_name": "Metachromatic Leukodystrophy (MLD)",
+        "llm-average": 7.24
+      },
+      {
+        "entity_name": "Fabry Disease",
+        "llm-average": 5.37
+      }
+    ]
   },
   {
     "question_number": 293,
     "qid": 352,
     "text": "List the pathways that are annotated with MTRR, which is compiled as a target of (2S)-2-methyl-2,3-dihydrothieno[2,3-f][1,4]oxazepin-5-amine.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Defective MTRR causes methylmalonic aciduria and homocystinuria type cblE, (2) Defective MTR causes methylmalonic aciduria and homocystinuria type cblG, (3) Cobalamin (Cbl, vitamin B12) transport and metabolism, (4) Sulfur amino acid metabolism, (5) Methylation"
+    "llm_ranking": [
+      {
+        "entity_name": "Defective MTRR causes methylmalonic aciduria and homocystinuria type cblE",
+        "llm-average": 16.13
+      },
+      {
+        "entity_name": "Defective MTR causes methylmalonic aciduria and homocystinuria type cblG",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Cobalamin (Cbl, vitamin B12) transport and metabolism",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "Sulfur amino acid metabolism",
+        "llm-average": 5.76
+      },
+      {
+        "entity_name": "Methylation",
+        "llm-average": 4.35
+      }
+    ]
   },
   {
     "question_number": 294,
     "qid": 360,
     "text": "List the pathways that are annotated with BCHE, which is compiled as a target of DIMETHYL THIOPHOSPHATE.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Synthesis, secretion, and deacylation of Ghrelin, (2) Neurotransmitter clearance, (3) Heroin Metabolism Pathway, (4) Synthesis of PC, (5) Irinotecan Metabolism Pathway, (6) Irinotecan Action Pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Synthesis, secretion, and deacylation of Ghrelin",
+        "llm-average": 17.42
+      },
+      {
+        "entity_name": "Neurotransmitter clearance",
+        "llm-average": 10.63
+      },
+      {
+        "entity_name": "Heroin Metabolism Pathway",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "Irinotecan Metabolism Pathway",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Irinotecan Action Pathway",
+        "llm-average": 7.05
+      },
+      {
+        "entity_name": "Synthesis of PC",
+        "llm-average": 6.72
+      }
+    ]
   },
   {
     "question_number": 295,
     "qid": 363,
     "text": "Which pathways are annotated with CYP2F1, which Palmitoleic Acid acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CYP2E1 reactions, (2) Fatty acids, (3) Xenobiotics"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP2E1 reactions",
+        "llm-average": 9.34
+      },
+      {
+        "entity_name": "Fatty acids",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "Xenobiotics",
+        "llm-average": 2.28
+      }
+    ]
   },
   {
     "question_number": 296,
     "qid": 364,
     "text": "List the proteins that are acted on by CYP8B1, which is compiled as a target of Nicotinamide adenine dinucleotide phosphate.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MAFG, (2) TBXAS1, (3) CYP17A1, (4) CYP21A2, (5) CYP2R1, (6) INS"
+    "llm_ranking": [
+      {
+        "entity_name": "MAFG",
+        "llm-average": 15.53
+      },
+      {
+        "entity_name": "TBXAS1",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "CYP17A1",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "CYP21A2",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "CYP2R1",
+        "llm-average": 4.66
+      },
+      {
+        "entity_name": "INS",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 297,
     "qid": 366,
     "text": "List the pathways that are annotated with HCAR3, which Uridine diphosphate glucose acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Hydroxycarboxylic acid-binding receptors, (2) G alpha (i) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "Hydroxycarboxylic acid-binding receptors",
+        "llm-average": 14.17
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 7.05
+      }
+    ]
   },
   {
     "question_number": 298,
     "qid": 367,
     "text": "List the proteins that are acted on by GCAT, which 1,4-Dithiothreitol acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) KDSR, (2) ORMDL3"
+    "llm_ranking": [
+      {
+        "entity_name": "KDSR",
+        "llm-average": 13.14
+      },
+      {
+        "entity_name": "ORMDL3",
+        "llm-average": 12.49
+      }
+    ]
   },
   {
     "question_number": 299,
     "qid": 369,
     "text": "Which pathways are annotated with FASN, which 1,4-Dithiothreitol acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) NR1H2 & NR1H3 regulate gene expression linked to lipogenesis, (2) ChREBP activates metabolic gene expression, (3) Activation of gene expression by SREBF (SREBP), (4) Vitamin B5 (pantothenate) metabolism, (5) Fatty acyl-CoA biosynthesis, (6) Fatty Acid Biosynthesis"
+    "llm_ranking": [
+      {
+        "entity_name": "NR1H2 & NR1H3 regulate gene expression linked to lipogenesis",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "ChREBP activates metabolic gene expression",
+        "llm-average": 16.5
+      },
+      {
+        "entity_name": "Activation of gene expression by SREBF (SREBP)",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "Fatty Acid Biosynthesis",
+        "llm-average": 7.33
+      },
+      {
+        "entity_name": "Fatty acyl-CoA biosynthesis",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "Vitamin B5 (pantothenate) metabolism",
+        "llm-average": 6.54
+      }
+    ]
   },
   {
     "question_number": 300,
     "qid": 371,
     "text": "List the pathways that are annotated with ADORA2B, which Dodecyldimethylamine N-oxide acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ADORA2B mediated anti-inflammatory cytokines production, (2) Intracellular Signalling Through Adenosine Receptor A2b and Adenosine, (3) Adenosine P1 receptors, (4) Surfactant metabolism, (5) G alpha (s) signalling events"
+    "llm_ranking": [
+      {
+        "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
+        "llm-average": 16.7
+      },
+      {
+        "entity_name": "Intracellular Signalling Through Adenosine Receptor A2b and Adenosine",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Adenosine P1 receptors",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "Surfactant metabolism",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "G alpha (s) signalling events",
+        "llm-average": 4.09
+      }
+    ]
   },
   {
     "question_number": 301,
     "qid": 372,
     "text": "Which pathways are annotated with MMP1, which is compiled as a target of N-HYDROXY-2-[4-(4-PHENOXY-BENZENESULFONYL)-TETRAHYDRO-PYRAN-4-YL]-ACETAMIDE?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Basigin interactions, (2) Regulation of Insulin-like Growth Factor (IGF) transport and uptake by Insulin-like Growth Factor Binding Proteins (IGFBPs), (3) Activation of Matrix Metalloproteinases, (4) Interleukin-4 and Interleukin-13 signaling, (5) Collagen degradation, (6) Degradation of the extracellular matrix"
+    "llm_ranking": [
+      {
+        "entity_name": "Activation of Matrix Metalloproteinases",
+        "llm-average": 11.22
+      },
+      {
+        "entity_name": "Basigin interactions",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Regulation of Insulin-like Growth Factor (IGF) transport and uptake by Insulin-like Growth Factor Binding Proteins (IGFBPs)",
+        "llm-average": 9.51
+      },
+      {
+        "entity_name": "Interleukin-4 and Interleukin-13 signaling",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "Collagen degradation",
+        "llm-average": 9.08
+      },
+      {
+        "entity_name": "Degradation of the extracellular matrix",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 302,
     "qid": 376,
     "text": "Which proteins are acted on by PRPS1, which Adenosine phosphate acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PRPSAP1, (2) NUDT5, (3) G6PD, (4) PRPS1L1, (5) PGM2, (6) TKT, (7) H6PD, (8) PRPS2"
+    "llm_ranking": [
+      {
+        "entity_name": "PRPSAP1",
+        "llm-average": 17.94
+      },
+      {
+        "entity_name": "G6PD",
+        "llm-average": 13.8
+      },
+      {
+        "entity_name": "NUDT5",
+        "llm-average": 13.66
+      },
+      {
+        "entity_name": "PRPS1L1",
+        "llm-average": 11.09
+      },
+      {
+        "entity_name": "PGM2",
+        "llm-average": 9.24
+      },
+      {
+        "entity_name": "H6PD",
+        "llm-average": 8.09
+      },
+      {
+        "entity_name": "TKT",
+        "llm-average": 8.09
+      },
+      {
+        "entity_name": "PRPS2",
+        "llm-average": 5.65
+      }
+    ]
   },
   {
     "question_number": 303,
     "qid": 377,
     "text": "List the pathways that are annotated with RET, which Palmitoleic Acid acts on.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) RET signaling, (2) RAF/MAP kinase cascade"
+    "llm_ranking": [
+      {
+        "entity_name": "RET signaling",
+        "llm-average": 16.9
+      },
+      {
+        "entity_name": "RAF/MAP kinase cascade",
+        "llm-average": 8.88
+      }
+    ]
   },
   {
     "question_number": 304,
     "qid": 378,
     "text": "List the pathways that are annotated with KNTC1, which is compiled as a target of Coenzyme A.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Amplification  of signal from unattached  kinetochores via a MAD2  inhibitory signal, (2) EML4 and NUDC in mitotic spindle formation, (3) Separation of Sister Chromatids, (4) RHO GTPases Activate Formins, (5) Mitotic Prometaphase, (6) Resolution of Sister Chromatid Cohesion"
+    "llm_ranking": [
+      {
+        "entity_name": "Amplification  of signal from unattached  kinetochores via a MAD2  inhibitory signal",
+        "llm-average": 17.02
+      },
+      {
+        "entity_name": "EML4 and NUDC in mitotic spindle formation",
+        "llm-average": 14.28
+      },
+      {
+        "entity_name": "Separation of Sister Chromatids",
+        "llm-average": 12.11
+      },
+      {
+        "entity_name": "Mitotic Prometaphase",
+        "llm-average": 10.16
+      },
+      {
+        "entity_name": "Resolution of Sister Chromatid Cohesion",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "RHO GTPases Activate Formins",
+        "llm-average": 8.47
+      }
+    ]
   },
   {
     "question_number": 305,
     "qid": 381,
     "text": "Which pathways are annotated with POR, which Palmitoleic Acid acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Cytochrome P450 - arranged by substrate type, (2) Doxorubicin Metabolism Pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Cytochrome P450 - arranged by substrate type",
+        "llm-average": 10.17
+      },
+      {
+        "entity_name": "Doxorubicin Metabolism Pathway",
+        "llm-average": 9.12
+      }
+    ]
   },
   {
     "question_number": 306,
     "qid": 382,
     "text": "List the biological processes that are associated with GPR3, which is compiled as a target of 4-{2-[(7-amino-2-furan-2-yl[1,2,4]triazolo[1,5-a][1,3,5]triazin-5-yl)amino]ethyl}phenol.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) positive regulation of cold-induced thermogenesis, (2) regulation of meiotic nuclear division, (3) adenylate cyclase-activating G protein-coupled receptor signaling pathway, (4) regulation of metabolic process"
+    "llm_ranking": [
+      {
+        "entity_name": "positive regulation of cold-induced thermogenesis",
+        "llm-average": 17.08
+      },
+      {
+        "entity_name": "regulation of meiotic nuclear division",
+        "llm-average": 15.48
+      },
+      {
+        "entity_name": "adenylate cyclase-activating G protein-coupled receptor signaling pathway",
+        "llm-average": 10.17
+      },
+      {
+        "entity_name": "regulation of metabolic process",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 307,
     "qid": 384,
     "text": "List the pathways that are annotated with LYZ, which is compiled as a target of Cu-Cyclam.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Antimicrobial peptides, (2) Amyloid fiber formation, (3) Neutrophil degranulation"
+    "llm_ranking": [
+      {
+        "entity_name": "Antimicrobial peptides",
+        "llm-average": 15.54
+      },
+      {
+        "entity_name": "Amyloid fiber formation",
+        "llm-average": 10.67
+      },
+      {
+        "entity_name": "Neutrophil degranulation",
+        "llm-average": 10.17
+      }
+    ]
   },
   {
     "question_number": 308,
     "qid": 385,
     "text": "Which biological processes are associated with KLK7 that N,N-dimethylformamide acts on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) extracellular matrix disassembly, (2) positive regulation of antibacterial peptide production, (3) epidermis development, (4) proteolysis"
+    "llm_ranking": [
+      {
+        "entity_name": "extracellular matrix disassembly",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "positive regulation of antibacterial peptide production",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "epidermis development",
+        "llm-average": 11.19
+      },
+      {
+        "entity_name": "proteolysis",
+        "llm-average": 3.7
+      }
+    ]
   },
   {
     "question_number": 309,
     "qid": 0,
     "text": "Which proteins are compiled as targets of L-Dilinoleoyllecithin?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CETP, (2) PCTP, (3) APOA1"
+    "llm_ranking": [
+      {
+        "entity_name": "PCTP",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "CETP",
+        "llm-average": 11.42
+      },
+      {
+        "entity_name": "APOA1",
+        "llm-average": 10.73
+      }
+    ]
   },
   {
     "question_number": 310,
     "qid": 1,
     "text": "What proteins is N-[4-hydroxymethyl-cyclohexan-6-yl-1,2,3-triol]-4,6-dideoxy-4-aminoglucopyranoside compiled to target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SLC3A1, (2) AMY2B, (3) SLC3A2"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC3A1",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "AMY2B",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "SLC3A2",
+        "llm-average": 9.99
+      }
+    ]
   },
   {
     "question_number": 311,
     "qid": 5,
     "text": "What proteins is 4-PHENOXY-N-(PYRIDIN-2-YLMETHYL)BENZAMIDE compiled to target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) MT-CYB, (2) TMBIM6, (3) SUPV3L1, (4) YARS2, (5) REN"
+    "llm_ranking": [
+      {
+        "entity_name": "MT-CYB",
+        "llm-average": 15.52
+      },
+      {
+        "entity_name": "TMBIM6",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "SUPV3L1",
+        "llm-average": 13.92
+      },
+      {
+        "entity_name": "YARS2",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "REN",
+        "llm-average": 7.5
+      }
+    ]
   },
   {
     "question_number": 312,
     "qid": 6,
     "text": "List the proteins that are compiled as targets of (2S)-2-methyl-2,3-dihydrothieno[2,3-f][1,4]oxazepin-5-amine.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TYW1, (2) NDOR1, (3) MTRR, (4) NOS2, (5) NOS3, (6) POR"
+    "llm_ranking": [
+      {
+        "entity_name": "TYW1",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "NDOR1",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "MTRR",
+        "llm-average": 11.42
+      },
+      {
+        "entity_name": "NOS2",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "NOS3",
+        "llm-average": 9.48
+      },
+      {
+        "entity_name": "POR",
+        "llm-average": 8.92
+      }
+    ]
   },
   {
     "question_number": 313,
     "qid": 53,
     "text": "Which genes are curated as targets of Piclidenoson?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) adenosine A3 receptor, (2) serpin family F member 1"
+    "llm_ranking": [
+      {
+        "entity_name": "adenosine A3 receptor",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "serpin family F member 1",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 314,
     "qid": 61,
     "text": "Which proteins are compiled as targets of N-(2-Flouro-Benzyl)-4-Sulfamoyl-Benzamide?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SLC35B2, (2) CA2, (3) DSG1"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC35B2",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "CA2",
+        "llm-average": 12.53
+      },
+      {
+        "entity_name": "DSG1",
+        "llm-average": 12.14
+      }
+    ]
   },
   {
     "question_number": 315,
     "qid": 62,
     "text": "What proteins does N-[(2S)-3-Phenyl-2-sulfanylpropanoyl]-L-phenylalanyl-L-tyrosine act on?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) PHEX, (2) OPRD1, (3) OPRM1, (4) ECEL1, (5) ECE1, (6) KEL, (7) MMEL1, (8) ACE"
+    "llm_ranking": [
+      {
+        "entity_name": "PHEX",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "OPRD1",
+        "llm-average": 10.55
+      },
+      {
+        "entity_name": "ECEL1",
+        "llm-average": 10.32
+      },
+      {
+        "entity_name": "OPRM1",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "KEL",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "MMEL1",
+        "llm-average": 8.9
+      },
+      {
+        "entity_name": "ECE1",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "ACE",
+        "llm-average": 6.26
+      }
+    ]
   },
   {
     "question_number": 316,
     "qid": 74,
     "text": "Which genes are curated as targets of 6-PHENYL[5H]PYRROLO[2,3-B]PYRAZINE?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cyclin dependent kinase 5, (2) glycogen synthase kinase 3 alpha, (3) cyclin dependent kinase 2, (4) cyclin dependent kinase 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cyclin dependent kinase 5",
+        "llm-average": 14.1
+      },
+      {
+        "entity_name": "glycogen synthase kinase 3 alpha",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "cyclin dependent kinase 2",
+        "llm-average": 11.45
+      },
+      {
+        "entity_name": "cyclin dependent kinase 1",
+        "llm-average": 11.28
+      }
+    ]
   },
   {
     "question_number": 317,
     "qid": 91,
     "text": "What proteins is N2-[(Benzyloxy)carbonyl]-N-[(3R)-1-{N-[(benzyloxy)carbonyl]-L-leucyl}-4-oxo-3-pyrrolidinyl]-L-leucinamide compiled to target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CTSL, (2) CTSK, (3) CTSS, (4) CAPN2"
+    "llm_ranking": [
+      {
+        "entity_name": "CTSL",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "CTSK",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "CTSS",
+        "llm-average": 13.23
+      },
+      {
+        "entity_name": "CAPN2",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 318,
     "qid": 99,
     "text": "What genes is (3Z)-N,N-DIMETHYL-2-OXO-3-(4,5,6,7-TETRAHYDRO-1H-INDOL-2-YLMETHYLIDENE)-2,3-DIHYDRO-1H-INDOLE-5-SULFONAMIDE curated to target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LCK proto-oncogene, Src family tyrosine kinase, (2) LYN proto-oncogene, Src family tyrosine kinase, (3) YES proto-oncogene 1, Src family tyrosine kinase, (4) aurora kinase C, (5) SRC proto-oncogene, non-receptor tyrosine kinase, (6) BR serine/threonine kinase 2, (7) aurora kinase B"
+    "llm_ranking": [
+      {
+        "entity_name": "LCK proto-oncogene, Src family tyrosine kinase",
+        "llm-average": 16.26
+      },
+      {
+        "entity_name": "LYN proto-oncogene, Src family tyrosine kinase",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "YES proto-oncogene 1, Src family tyrosine kinase",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "aurora kinase C",
+        "llm-average": 13.9
+      },
+      {
+        "entity_name": "SRC proto-oncogene, non-receptor tyrosine kinase",
+        "llm-average": 13.23
+      },
+      {
+        "entity_name": "BR serine/threonine kinase 2",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "aurora kinase B",
+        "llm-average": 11.76
+      }
+    ]
   },
   {
     "question_number": 319,
     "qid": 109,
     "text": "What proteins is (2R,4S)-2-[(1R)-1-{[(2R)-2-Amino-2-(4-hydroxyphenyl)acetyl]amino}-2-oxoethyl]-5,5-dimethyl-1,3-thiazolidine-4-carboxylic acid compiled to target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) LACTBL1, (2) LACTB"
+    "llm_ranking": [
+      {
+        "entity_name": "LACTBL1",
+        "llm-average": 14.97
+      },
+      {
+        "entity_name": "LACTB",
+        "llm-average": 12.14
+      }
+    ]
   },
   {
     "question_number": 320,
     "qid": 115,
     "text": "What genes is 2-Undecanone curated to target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) checkpoint kinase 1, (2) Rho associated coiled-coil containing protein kinase 1, (3) MAPK activated protein kinase 2, (4) ribosomal protein S6 kinase A1, (5) casein kinase 1 gamma 1, (6) protein kinase cAMP-dependent type II regulatory subunit beta"
+    "llm_ranking": [
+      {
+        "entity_name": "checkpoint kinase 1",
+        "llm-average": 18.03
+      },
+      {
+        "entity_name": "Rho associated coiled-coil containing protein kinase 1",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "MAPK activated protein kinase 2",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "ribosomal protein S6 kinase A1",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "casein kinase 1 gamma 1",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "protein kinase cAMP-dependent type II regulatory subunit beta",
+        "llm-average": 9.28
+      }
+    ]
   },
   {
     "question_number": 321,
     "qid": 121,
     "text": "List the genes that are curated as targets of Coenzyme A.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 4, (2) cholinergic receptor muscarinic 5, (3) cholinergic receptor muscarinic 1, (4) cholinergic receptor muscarinic 2, (5) cholinergic receptor muscarinic 3"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 4",
+        "llm-average": 10.0
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 5",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 2",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 3",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 322,
     "qid": 125,
     "text": "What proteins is Tirapazamine compiled to target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) ERCC1, (2) BNIP3, (3) TP53, (4) MFSD9, (5) SPP1, (6) MFSD10"
+    "llm_ranking": [
+      {
+        "entity_name": "ERCC1",
+        "llm-average": 14.31
+      },
+      {
+        "entity_name": "BNIP3",
+        "llm-average": 13.18
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "MFSD9",
+        "llm-average": 9.96
+      },
+      {
+        "entity_name": "SPP1",
+        "llm-average": 9.27
+      },
+      {
+        "entity_name": "MFSD10",
+        "llm-average": 8.35
+      }
+    ]
   },
   {
     "question_number": 323,
     "qid": 128,
     "text": "Which proteins are compiled as targets of Docosanol?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) TLR7, (2) PTGES2"
+    "llm_ranking": [
+      {
+        "entity_name": "TLR7",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "PTGES2",
+        "llm-average": 8.22
+      }
+    ]
   },
   {
     "question_number": 324,
     "qid": 131,
     "text": "List the proteins that are compiled as targets of 4-(5-phenyl-1H-pyrrolo[2,3-b]pyridin-3-yl)benzoic acid.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) SGK1, (2) ITGB4"
+    "llm_ranking": [
+      {
+        "entity_name": "SGK1",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "ITGB4",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 325,
     "qid": 137,
     "text": "Which proteins are compiled as targets of Tetrachlorodecaoxide?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CD163, (2) MAEA"
+    "llm_ranking": [
+      {
+        "entity_name": "CD163",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "MAEA",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 326,
     "qid": 148,
     "text": "List the proteins that are compiled as targets of L-Dilinoleoyllecithin.",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) CETP, (2) APOA1, (3) PCTP"
+    "llm_ranking": [
+      {
+        "entity_name": "CETP",
+        "llm-average": 13.02
+      },
+      {
+        "entity_name": "APOA1",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "PCTP",
+        "llm-average": 9.99
+      }
+    ]
   },
   {
     "question_number": 327,
     "qid": 154,
     "text": "What drugs have ATPase secretory pathway Ca2+ transporting 1 as a curated target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Isoflurane, (2) Sevoflurane, (3) Desflurane, (4) Enflurane"
+    "llm_ranking": [
+      {
+        "entity_name": "Isoflurane",
+        "llm-average": 10.58
+      },
+      {
+        "entity_name": "Sevoflurane",
+        "llm-average": 10.42
+      },
+      {
+        "entity_name": "Desflurane",
+        "llm-average": 10.32
+      },
+      {
+        "entity_name": "Enflurane",
+        "llm-average": 10.22
+      }
+    ]
   },
   {
     "question_number": 328,
     "qid": 167,
     "text": "What drugs have SH3PXD2B as a compiled target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) D-1,4-dithiothreitol, (2) Dithioerythritol, (3) 1,4-Dithiothreitol"
+    "llm_ranking": [
+      {
+        "entity_name": "D-1,4-dithiothreitol",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Dithioerythritol",
+        "llm-average": 5.55
+      },
+      {
+        "entity_name": "1,4-Dithiothreitol",
+        "llm-average": 5.45
+      }
+    ]
   },
   {
     "question_number": 329,
     "qid": 175,
     "text": "What drugs have gap junction protein beta 2 as a curated target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Carbenoxolone, (2) Caprylic alcohol, (3) Flufenamic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Carbenoxolone",
+        "llm-average": 15.44
+      },
+      {
+        "entity_name": "Caprylic alcohol",
+        "llm-average": 13.72
+      },
+      {
+        "entity_name": "Flufenamic acid",
+        "llm-average": 12.34
+      }
+    ]
   },
   {
     "question_number": 330,
     "qid": 194,
     "text": "What drugs have COG3 as a compiled target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Methyl alpha-D-mannoside, (2) Methyl alpha-galactoside, (3) methyl beta-D-glucopyranoside, (4) Methyl beta-galactoside"
+    "llm_ranking": [
+      {
+        "entity_name": "Methyl alpha-D-mannoside",
+        "llm-average": 9.24
+      },
+      {
+        "entity_name": "Methyl alpha-galactoside",
+        "llm-average": 7.3
+      },
+      {
+        "entity_name": "methyl beta-D-glucopyranoside",
+        "llm-average": 5.81
+      },
+      {
+        "entity_name": "Methyl beta-galactoside",
+        "llm-average": 5.71
+      }
+    ]
   },
   {
     "question_number": 331,
     "qid": 204,
     "text": "What drugs have maltase-glucoamylase as a curated target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Miglitol, (2) Acarbose, (3) Voglibose"
+    "llm_ranking": [
+      {
+        "entity_name": "Miglitol",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Acarbose",
+        "llm-average": 8.75
+      },
+      {
+        "entity_name": "Voglibose",
+        "llm-average": 7.35
+      }
+    ]
   },
   {
     "question_number": 332,
     "qid": 210,
     "text": "What drugs have GAS6 as a compiled target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Raloxifene, (2) Phylloquinone, (3) 2-acetylamino-2-deoxy-b-D-allopyranose, (4) alpha-N-Acetyl-D-galactosamine, (5) N-acetyl-alpha-D-glucosamine, (6) 5beta-dihydrotestosterone, (7) Stanolone, (8) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "Raloxifene",
+        "llm-average": 13.07
+      },
+      {
+        "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
+        "llm-average": 11.25
+      },
+      {
+        "entity_name": "Phylloquinone",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "alpha-N-Acetyl-D-galactosamine",
+        "llm-average": 9.18
+      },
+      {
+        "entity_name": "N-acetyl-alpha-D-glucosamine",
+        "llm-average": 8.94
+      },
+      {
+        "entity_name": "5beta-dihydrotestosterone",
+        "llm-average": 5.94
+      },
+      {
+        "entity_name": "Stanolone",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 2.71
+      }
+    ]
   },
   {
     "question_number": 333,
     "qid": 211,
     "text": "What drugs have gap junction protein beta 6 as a curated target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Flufenamic acid, (2) Carbenoxolone, (3) Caprylic alcohol"
+    "llm_ranking": [
+      {
+        "entity_name": "Flufenamic acid",
+        "llm-average": 16.54
+      },
+      {
+        "entity_name": "Carbenoxolone",
+        "llm-average": 15.04
+      },
+      {
+        "entity_name": "Caprylic alcohol",
+        "llm-average": 10.49
+      }
+    ]
   },
   {
     "question_number": 334,
     "qid": 213,
     "text": "What drugs have ADGRD1 as a compiled target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) N-acetyl-alpha-D-glucosamine, (2) 2-acetylamino-2-deoxy-b-D-allopyranose, (3) alpha-D-quinovopyranose, (4) alpha-N-Acetyl-D-galactosamine, (5) alpha-L-fucose, (6) alpha-D-Fucopyranose, (7) beta-D-fucose, (8) beta-L-fucose"
+    "llm_ranking": [
+      {
+        "entity_name": "N-acetyl-alpha-D-glucosamine",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
+        "llm-average": 13.66
+      },
+      {
+        "entity_name": "alpha-D-quinovopyranose",
+        "llm-average": 13.29
+      },
+      {
+        "entity_name": "alpha-N-Acetyl-D-galactosamine",
+        "llm-average": 12.5
+      },
+      {
+        "entity_name": "alpha-D-Fucopyranose",
+        "llm-average": 10.55
+      },
+      {
+        "entity_name": "alpha-L-fucose",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "beta-D-fucose",
+        "llm-average": 9.3
+      },
+      {
+        "entity_name": "beta-L-fucose",
+        "llm-average": 7.98
+      }
+    ]
   },
   {
     "question_number": 335,
     "qid": 218,
     "text": "What drugs have HDAC10 as a compiled target?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Vorinostat, (2) Trichostatin A, (3) Colistimethate, (4) D-tartaric acid, (5) N,N-dimethylformamide"
+    "llm_ranking": [
+      {
+        "entity_name": "Vorinostat",
+        "llm-average": 16.54
+      },
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 15.77
+      },
+      {
+        "entity_name": "Colistimethate",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "D-tartaric acid",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "N,N-dimethylformamide",
+        "llm-average": 5.08
+      }
+    ]
   },
   {
     "question_number": 336,
     "qid": 226,
     "text": "What drugs act on DSTN?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) Y-27632, (2) Quercetin, (3) S-Hydroxycysteine, (4) Valproic acid, (5) Kojic acid, (6) Dodecyldimethylamine N-oxide, (7) Mercaptoethanol, (8) D-tartaric acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Y-27632",
+        "llm-average": 17.92
+      },
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 11.49
+      },
+      {
+        "entity_name": "S-Hydroxycysteine",
+        "llm-average": 10.95
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.7
+      },
+      {
+        "entity_name": "Kojic acid",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "Dodecyldimethylamine N-oxide",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Mercaptoethanol",
+        "llm-average": 5.41
+      },
+      {
+        "entity_name": "D-tartaric acid",
+        "llm-average": 4.25
+      }
+    ]
   },
   {
     "question_number": 337,
     "qid": 388,
     "text": "Which genes are curated as targets of Dexfosfoserine, which acts on BRCA1 that is annotated in pathway HDR through Single Strand Annealing (SSA)?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) adhesion G protein-coupled receptor B1, (2) glutamate metabotropic receptor 8, (3) glutamate metabotropic receptor 4, (4) glutamate metabotropic receptor 7, (5) glutamate metabotropic receptor 6"
+    "llm_ranking": [
+      {
+        "entity_name": "adhesion G protein-coupled receptor B1",
+        "llm-average": 12.28
+      },
+      {
+        "entity_name": "glutamate metabotropic receptor 8",
+        "llm-average": 7.03
+      },
+      {
+        "entity_name": "glutamate metabotropic receptor 4",
+        "llm-average": 5.81
+      },
+      {
+        "entity_name": "glutamate metabotropic receptor 7",
+        "llm-average": 5.74
+      },
+      {
+        "entity_name": "glutamate metabotropic receptor 6",
+        "llm-average": 4.46
+      }
+    ]
   },
   {
     "question_number": 338,
     "qid": 389,
     "text": "Which genes are curated as targets of D-Aspartic Acid, which acts on ASPA that is compiled as interacting with GLUD1?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) glutamate ionotropic receptor NMDA type subunit 2B, (2) glutamate ionotropic receptor NMDA type subunit 2A, (3) glutamate ionotropic receptor NMDA type subunit 2C"
+    "llm_ranking": [
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
+        "llm-average": 11.65
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
+        "llm-average": 10.89
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
+        "llm-average": 8.02
+      }
+    ]
   },
   {
     "question_number": 339,
     "qid": 392,
     "text": "Which genes are curated as targets of Coenzyme A, which acts on ACLY that is annotated in pathway Fatty acyl-CoA biosynthesis?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 4, (2) cholinergic receptor muscarinic 5, (3) cholinergic receptor muscarinic 1, (4) cholinergic receptor muscarinic 2, (5) cholinergic receptor muscarinic 3"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 4",
+        "llm-average": 5.87
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 5",
+        "llm-average": 5.15
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 2.34
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 3",
+        "llm-average": 1.78
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 2",
+        "llm-average": 1.62
+      }
+    ]
   },
   {
     "question_number": 340,
     "qid": 398,
     "text": "Which genes are curated as targets of Palmitic Acid, which acts on BAX that is annotated in pathway P53 Signaling Pathway?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) free fatty acid receptor 1, (2) dopamine receptor D5, (3) dopamine receptor D1"
+    "llm_ranking": [
+      {
+        "entity_name": "free fatty acid receptor 1",
+        "llm-average": 12.57
+      },
+      {
+        "entity_name": "dopamine receptor D5",
+        "llm-average": 5.08
+      },
+      {
+        "entity_name": "dopamine receptor D1",
+        "llm-average": 2.34
+      }
+    ]
   },
   {
     "question_number": 341,
     "qid": 400,
     "text": "Which genes are curated as targets of Adenosine phosphate, which acts on AASS that is annotated in pathway Glutaric Aciduria Type I?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) adenylate cyclase 1, (2) galanin receptor 3, (3) galanin receptor 1, (4) galanin receptor 2"
+    "llm_ranking": [
+      {
+        "entity_name": "adenylate cyclase 1",
+        "llm-average": 10.3
+      },
+      {
+        "entity_name": "galanin receptor 3",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "galanin receptor 1",
+        "llm-average": 6.93
+      },
+      {
+        "entity_name": "galanin receptor 2",
+        "llm-average": 6.9
+      }
+    ]
   },
   {
     "question_number": 342,
     "qid": 401,
     "text": "Which pathways are annotated with APOBEC3A, which acts on APOBEC3H that is detected in pathology samples of kidney cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) mRNA Editing: C to U Conversion, (2) Formation of the Editosome"
+    "llm_ranking": [
+      {
+        "entity_name": "mRNA Editing: C to U Conversion",
+        "llm-average": 12.05
+      },
+      {
+        "entity_name": "Formation of the Editosome",
+        "llm-average": 10.5
+      }
+    ]
   },
   {
     "question_number": 343,
     "qid": 403,
     "text": "Which genes are curated as targets of K-00546, which acts on ACVR1 that is detected in pathology samples of colorectal cancer?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) fms related receptor tyrosine kinase 1, (2) cyclin dependent kinase 1, (3) cyclin dependent kinase 2"
+    "llm_ranking": [
+      {
+        "entity_name": "cyclin dependent kinase 1",
+        "llm-average": 9.01
+      },
+      {
+        "entity_name": "cyclin dependent kinase 2",
+        "llm-average": 8.38
+      },
+      {
+        "entity_name": "fms related receptor tyrosine kinase 1",
+        "llm-average": 8.02
+      }
+    ]
   },
   {
     "question_number": 344,
     "qid": 405,
     "text": "Which genes are curated as targets of Coenzyme A, which acts on ACBD5 that is compiled as interacting with SLC25A17?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 4, (2) cholinergic receptor muscarinic 5, (3) cholinergic receptor muscarinic 1, (4) cholinergic receptor muscarinic 2, (5) cholinergic receptor muscarinic 3"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 4",
+        "llm-average": 10.13
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 5",
+        "llm-average": 8.61
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 6.2
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 2",
+        "llm-average": 4.69
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 3",
+        "llm-average": 4.46
+      }
+    ]
   },
   {
     "question_number": 345,
     "qid": 407,
     "text": "Which genes are curated as targets of D-Aspartic Acid, which acts on ASPA that is curated as interacting with COPS3?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) glutamate ionotropic receptor NMDA type subunit 2B, (2) glutamate ionotropic receptor NMDA type subunit 2A, (3) glutamate ionotropic receptor NMDA type subunit 2C"
+    "llm_ranking": [
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
+        "llm-average": 11.65
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
+        "llm-average": 10.89
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
+        "llm-average": 8.02
+      }
+    ]
   },
   {
     "question_number": 346,
     "qid": 415,
     "text": "Which genes are curated as targets of Isopropyl alcohol, which acts on AGO2 that is curated as interacting with GNL3?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cytochrome P450 family 19 subfamily A member 1, (2) cytochrome P450 family 3 subfamily A member 5, (3) cytochrome P450 family 1 subfamily B member 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 19 subfamily A member 1",
+        "llm-average": 12.18
+      },
+      {
+        "entity_name": "cytochrome P450 family 3 subfamily A member 5",
+        "llm-average": 9.31
+      },
+      {
+        "entity_name": "cytochrome P450 family 1 subfamily B member 1",
+        "llm-average": 6.44
+      }
+    ]
   },
   {
     "question_number": 347,
     "qid": 424,
     "text": "Which genes are curated as targets of K-00546, which acts on ACVR1 that is compiled as interacting with NCOA3?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cyclin dependent kinase 2, (2) fms related receptor tyrosine kinase 1, (3) cyclin dependent kinase 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cyclin dependent kinase 2",
+        "llm-average": 6.9
+      },
+      {
+        "entity_name": "fms related receptor tyrosine kinase 1",
+        "llm-average": 6.44
+      },
+      {
+        "entity_name": "cyclin dependent kinase 1",
+        "llm-average": 6.04
+      }
+    ]
   },
   {
     "question_number": 348,
     "qid": 431,
     "text": "Which genes are curated as targets of D-Aspartic Acid, which acts on APP that is curated as interacting with APBA1?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) glutamate ionotropic receptor NMDA type subunit 2B, (2) glutamate ionotropic receptor NMDA type subunit 2A, (3) glutamate ionotropic receptor NMDA type subunit 2C"
+    "llm_ranking": [
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
+        "llm-average": 15.12
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
+        "llm-average": 10.5
+      }
+    ]
   },
   {
     "question_number": 349,
     "qid": 437,
     "text": "Which genes are curated as targets of Isopropyl alcohol, which acts on PGD that is curated as interacting with TERF1?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cytochrome P450 family 19 subfamily A member 1, (2) cytochrome P450 family 3 subfamily A member 5, (3) cytochrome P450 family 1 subfamily B member 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 19 subfamily A member 1",
+        "llm-average": 14.26
+      },
+      {
+        "entity_name": "cytochrome P450 family 3 subfamily A member 5",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "cytochrome P450 family 1 subfamily B member 1",
+        "llm-average": 10.5
+      }
+    ]
   },
   {
     "question_number": 350,
     "qid": 443,
     "text": "Which genes are curated as targets of Coenzyme A, which acts on ACLY that is compiled as interacting with GOT1?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 4, (2) cholinergic receptor muscarinic 5, (3) cholinergic receptor muscarinic 1, (4) cholinergic receptor muscarinic 2, (5) cholinergic receptor muscarinic 3"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 4",
+        "llm-average": 10.13
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 5",
+        "llm-average": 8.61
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 6.2
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 2",
+        "llm-average": 4.69
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 3",
+        "llm-average": 4.46
+      }
+    ]
   },
   {
     "question_number": 351,
     "qid": 447,
     "text": "Which genes are curated as targets of Butyric Acid, which acts on ACAD9 that is curated as interacting with SDHA?",
     "category": "cancer:organ system cancer",
-    "llm_ranking": "(1) free fatty acid receptor 2, (2) hydroxycarboxylic acid receptor 2, (3) 5-hydroxytryptamine receptor 5A, (4) histone deacetylase 1, (5) histone deacetylase 2, (6) adenosine deaminase RNA specific B2 (inactive), (7) histone deacetylase 3, (8) histone deacetylase 8"
+    "llm_ranking": [
+      {
+        "entity_name": "free fatty acid receptor 2",
+        "llm-average": 17.33
+      },
+      {
+        "entity_name": "hydroxycarboxylic acid receptor 2",
+        "llm-average": 15.91
+      },
+      {
+        "entity_name": "5-hydroxytryptamine receptor 5A",
+        "llm-average": 14.13
+      },
+      {
+        "entity_name": "histone deacetylase 1",
+        "llm-average": 10.5
+      },
+      {
+        "entity_name": "histone deacetylase 2",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "histone deacetylase 3",
+        "llm-average": 8.09
+      },
+      {
+        "entity_name": "adenosine deaminase RNA specific B2 (inactive)",
+        "llm-average": 8.02
+      },
+      {
+        "entity_name": "histone deacetylase 8",
+        "llm-average": 6.17
+      }
+    ]
   }
 ]

--- a/lib/batches/batch4.ts
+++ b/lib/batches/batch4.ts
@@ -6,2022 +6,6803 @@ export const batch4: Question[] = [
     "qid": 564,
     "text": "Which proteins are curated as interacting with GLOD4, which is associated with hepatocellular carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) BCL2L1, (2) LTB4R2, (3) SCLT1, (4) MAX"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "LTB4R2",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "SCLT1",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "MAX",
+        "llm-average": 11.63
+      }
+    ]
   },
   {
     "question_number": 2,
     "qid": 582,
     "text": "Which proteins act on ZNF420, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) ATM, (2) TRIM28"
+    "llm_ranking": [
+      {
+        "entity_name": "ATM",
+        "llm-average": 13.59
+      },
+      {
+        "entity_name": "TRIM28",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 3,
     "qid": 593,
     "text": "Which drugs are curated as targeting thyroid peroxidase, which is transcribed into thyroid peroxidase isoform X5 and is translated into TPO?",
     "category": "Abnormality of the endocrine system:Abnormality of thyroid physiology",
-    "llm_ranking": "(1) Propylthiouracil, (2) Methimazole, (3) Carbimazole, (4) Tretinoin"
+    "llm_ranking": [
+      {
+        "entity_name": "Propylthiouracil",
+        "llm-average": 12.29
+      },
+      {
+        "entity_name": "Methimazole",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Carbimazole",
+        "llm-average": 9.67
+      },
+      {
+        "entity_name": "Tretinoin",
+        "llm-average": 9.02
+      }
+    ]
   },
   {
     "question_number": 4,
     "qid": 606,
     "text": "Which drugs have FSCN1 as a compiled target, which is annotated in pathway Interleukin-4 and Interleukin-13 signaling and is associated with sarcomatoid carcinoma?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Paclitaxel, (2) Mitomycin, (3) Codeine, (4) Butyric Acid, (5) Dithioerythritol, (6) 1,4-Dithiothreitol, (7) D-1,4-dithiothreitol, (8) Beta-D-Fructopyranose"
+    "llm_ranking": [
+      {
+        "entity_name": "Paclitaxel",
+        "llm-average": 17.65
+      },
+      {
+        "entity_name": "Mitomycin",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Butyric Acid",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Dithioerythritol",
+        "llm-average": 5.1
+      },
+      {
+        "entity_name": "1,4-Dithiothreitol",
+        "llm-average": 4.97
+      },
+      {
+        "entity_name": "D-1,4-dithiothreitol",
+        "llm-average": 3.4
+      },
+      {
+        "entity_name": "Beta-D-Fructopyranose",
+        "llm-average": 2.88
+      }
+    ]
   },
   {
     "question_number": 5,
     "qid": 620,
     "text": "Which proteins act on SPARC, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) HGF, (2) LGALS1, (3) C5, (4) SERPINE1, (5) CHRD, (6) TGFB1, (7) TIMP1, (8) LAMB1"
+    "llm_ranking": [
+      {
+        "entity_name": "HGF",
+        "llm-average": 13.07
+      },
+      {
+        "entity_name": "LGALS1",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "C5",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "SERPINE1",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "CHRD",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "TGFB1",
+        "llm-average": 11.24
+      },
+      {
+        "entity_name": "TIMP1",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "LAMB1",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 6,
     "qid": 629,
     "text": "Which proteins act on PRSS55, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) F2R, (2) F2RL2, (3) F2RL3"
+    "llm_ranking": [
+      {
+        "entity_name": "F2R",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "F2RL2",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "F2RL3",
+        "llm-average": 10.2
+      }
+    ]
   },
   {
     "question_number": 7,
     "qid": 635,
     "text": "Which drugs act on CDC42EP4, which is annotated in pathway CDC42 GTPase cycle and is associated with central nervous system disease?",
     "category": "nervous system disease:central nervous system disease",
-    "llm_ranking": "(1) Vincristine, (2) Cyclosporine, (3) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Vincristine",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 8,
     "qid": 649,
     "text": "Which proteins are curated as interacting with MSMB, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) SGTA, (2) HAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "SGTA",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "HAT1",
+        "llm-average": 12.03
+      }
+    ]
   },
   {
     "question_number": 9,
     "qid": 660,
     "text": "Which proteins are curated as interacting with MYNN, which is associated with mucinous cystadenocarcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:malignant adenoma",
-    "llm_ranking": "(1) TGFBR2, (2) CHD4, (3) CDH1, (4) JPH3, (5) COPS5, (6) NEK7"
+    "llm_ranking": [
+      {
+        "entity_name": "TGFBR2",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "CHD4",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "CDH1",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "JPH3",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "COPS5",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "NEK7",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 10,
     "qid": 666,
     "text": "Which proteins are curated as interacting with AGTR2, which is annotated in pathway Peptide ligand-binding receptors and is associated with sarcomatoid carcinoma?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) TIMP3, (2) AGT"
+    "llm_ranking": [
+      {
+        "entity_name": "TIMP3",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "AGT",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 11,
     "qid": 667,
     "text": "Which metabolites are associated with SLC38A1, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Lithium, (2) Sodium"
+    "llm_ranking": [
+      {
+        "entity_name": "Lithium",
+        "llm-average": 4.58
+      },
+      {
+        "entity_name": "Sodium",
+        "llm-average": 2.35
+      }
+    ]
   },
   {
     "question_number": 12,
     "qid": 683,
     "text": "Which proteins are curated as interacting with CCDC81, which is associated with pancreatic ductal adenocarcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) SCIMP, (2) CD53, (3) CD37"
+    "llm_ranking": [
+      {
+        "entity_name": "SCIMP",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "CD53",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "CD37",
+        "llm-average": 12.16
+      }
+    ]
   },
   {
     "question_number": 13,
     "qid": 691,
     "text": "Which proteins are curated as interacting with RAB40B, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) CUL5, (2) WFDC1"
+    "llm_ranking": [
+      {
+        "entity_name": "CUL5",
+        "llm-average": 18.82
+      },
+      {
+        "entity_name": "WFDC1",
+        "llm-average": 12.55
+      }
+    ]
   },
   {
     "question_number": 14,
     "qid": 699,
     "text": "Which proteins are curated as interacting with EPN3, which is associated with mixed glioma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:cell type cancer",
-    "llm_ranking": "(1) PLEKHA7, (2) YWHAE"
+    "llm_ranking": [
+      {
+        "entity_name": "PLEKHA7",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "YWHAE",
+        "llm-average": 12.42
+      }
+    ]
   },
   {
     "question_number": 15,
     "qid": 717,
     "text": "Which drugs have BSND as a compiled target, which is associated with sarcomatoid carcinoma and detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) D-Tyrosine, (2) Tyrosine, (3) Furosemide, (4) Chlorothiazide"
+    "llm_ranking": [
+      {
+        "entity_name": "D-Tyrosine",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Tyrosine",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "Furosemide",
+        "llm-average": 7.06
+      },
+      {
+        "entity_name": "Chlorothiazide",
+        "llm-average": 6.54
+      }
+    ]
   },
   {
     "question_number": 16,
     "qid": 721,
     "text": "Which drugs act on C12orf76, which is associated with swine influenza and is curated as interacting with FKBP5?",
     "category": "respiratory system disease:None",
-    "llm_ranking": "(1) Trichostatin A, (2) Valproic acid, (3) Formaldehyde"
+    "llm_ranking": [
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 16.08
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "Formaldehyde",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 17,
     "qid": 729,
     "text": "Which proteins are curated as interacting with POLE4, which is annotated in pathway Recognition of DNA damage by PCNA-containing replication complex and is associated with congenital dyserythropoietic anemia type I?",
     "category": "hematopoietic system disease:normocytic anemia",
-    "llm_ranking": "(1) POLE3, (2) POLE, (3) POLE2, (4) QTRT1, (5) RPS27, (6) NFYB, (7) ARL4C, (8) FXYD1"
+    "llm_ranking": [
+      {
+        "entity_name": "POLE3",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "POLE",
+        "llm-average": 18.17
+      },
+      {
+        "entity_name": "POLE2",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "QTRT1",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "RPS27",
+        "llm-average": 9.15
+      },
+      {
+        "entity_name": "NFYB",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "ARL4C",
+        "llm-average": 7.32
+      },
+      {
+        "entity_name": "FXYD1",
+        "llm-average": 5.62
+      }
+    ]
   },
   {
     "question_number": 18,
     "qid": 741,
     "text": "Which drugs act on ISM2, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Quercetin, (2) Estradiol, (3) Cyclosporine"
+    "llm_ranking": [
+      {
+        "entity_name": "Quercetin",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 19,
     "qid": 742,
     "text": "Which drugs have OSMR as a compiled target, which is associated with sarcomatoid carcinoma and detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Irinotecan, (2) Paclitaxel"
+    "llm_ranking": [
+      {
+        "entity_name": "Irinotecan",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Paclitaxel",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 20,
     "qid": 771,
     "text": "Which drugs act on RARS2, which is annotated in pathway Hyperprolinemia Type I and is associated with peripheral retinal degeneration?",
     "category": "nervous system disease:eye disease",
-    "llm_ranking": "(1) D-arginine, (2) Valproic acid, (3) Phosphoaminophosphonic Acid-Adenylate Ester, (4) Magnesium cation, (5) ATP, (6) Adenosine phosphate, (7) Pyrophosphoric acid, (8) Arginine"
+    "llm_ranking": [
+      {
+        "entity_name": "D-arginine",
+        "llm-average": 10.85
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Phosphoaminophosphonic Acid-Adenylate Ester",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 7.19
+      },
+      {
+        "entity_name": "Adenosine phosphate",
+        "llm-average": 5.75
+      },
+      {
+        "entity_name": "Pyrophosphoric acid",
+        "llm-average": 4.71
+      },
+      {
+        "entity_name": "Arginine",
+        "llm-average": 3.53
+      }
+    ]
   },
   {
     "question_number": 21,
     "qid": 777,
     "text": "Which genes are translated into SPATA12, which is associated with seminoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:germ cell cancer",
-    "llm_ranking": "(1) spermatogenesis associated 12, (2) spermatogenesis-associated protein 12"
+    "llm_ranking": [
+      {
+        "entity_name": "spermatogenesis associated 12",
+        "llm-average": 5.75
+      },
+      {
+        "entity_name": "spermatogenesis-associated protein 12",
+        "llm-average": 5.1
+      }
+    ]
   },
   {
     "question_number": 22,
     "qid": 781,
     "text": "Which drugs interact with Pregnenolone, which is curated as targeting protein arginine methyltransferase 1 and acts on CYP2S1?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Abametapir, (2) Ritonavir, (3) Cenobamate, (4) Tucatinib, (5) Satralizumab, (6) Pitolisant, (7) Metreleptin, (8) Haloperidol"
+    "llm_ranking": [
+      {
+        "entity_name": "Abametapir",
+        "llm-average": 17.52
+      },
+      {
+        "entity_name": "Ritonavir",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Cenobamate",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "Tucatinib",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Satralizumab",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "Pitolisant",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "Metreleptin",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "Haloperidol",
+        "llm-average": 4.44
+      }
+    ]
   },
   {
     "question_number": 23,
     "qid": 786,
     "text": "Which drugs act on CLDN7, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Plerixafor, (2) Trichostatin A, (3) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Plerixafor",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Trichostatin A",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 24,
     "qid": 792,
     "text": "Which genes are translated into MAGEA2, which is associated with sarcomatoid carcinoma and is detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) MAGE family member A2B, (2) MAGE family member A2"
+    "llm_ranking": [
+      {
+        "entity_name": "MAGE family member A2B",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "MAGE family member A2",
+        "llm-average": 14.51
+      }
+    ]
   },
   {
     "question_number": 25,
     "qid": 796,
     "text": "Which drugs act on MCRS1, which is annotated in pathway UCH proteinases and is associated with adrenal cortex disease?",
     "category": "endocrine system disease:adrenal cortex disease",
-    "llm_ranking": "(1) Coenzyme A, (2) Vitamin E"
+    "llm_ranking": [
+      {
+        "entity_name": "Coenzyme A",
+        "llm-average": 8.5
+      },
+      {
+        "entity_name": "Vitamin E",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 26,
     "qid": 800,
     "text": "Which drugs have SLC45A3 as a compiled target, which is associated with sarcomatoid carcinoma and detected in pathology samples of kidney cancer?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Glutathione disulfide, (2) Sucrose"
+    "llm_ranking": [
+      {
+        "entity_name": "Glutathione disulfide",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Sucrose",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 27,
     "qid": 1521,
     "text": "Find all drugs that have the side effect Nausea and are indicated for Hepatic encephalopathy, and also find the drugs that are indicated for Nausea and have the side effect Hepatic encephalopathy.",
     "category": "Abnormality of the nervous system:Encephalopathy",
-    "llm_ranking": "(1) Rifaximin, (2) Neomycin, (3) Framycetin, (4) Omeprazole, (5) Lactulose"
+    "llm_ranking": [
+      {
+        "entity_name": "Rifaximin",
+        "llm-average": 12.54
+      },
+      {
+        "entity_name": "Neomycin",
+        "llm-average": 9.08
+      },
+      {
+        "entity_name": "Omeprazole",
+        "llm-average": 8.73
+      },
+      {
+        "entity_name": "Framycetin",
+        "llm-average": 8.56
+      },
+      {
+        "entity_name": "Lactulose",
+        "llm-average": 6.23
+      }
+    ]
   },
   {
     "question_number": 28,
     "qid": 1523,
     "text": "Find all drugs that interact with Chlormadinone and have the side effect Obstructive sleep apnea, and also find the drugs that interact with Chlormadinone and are indicated for Obstructive sleep apnea.",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Modafinil, (2) Lorazepam"
+    "llm_ranking": [
+      {
+        "entity_name": "Modafinil",
+        "llm-average": 17.44
+      },
+      {
+        "entity_name": "Lorazepam",
+        "llm-average": 6.51
+      }
+    ]
   },
   {
     "question_number": 29,
     "qid": 1528,
     "text": "Find all drugs that interact with Propafenone and have the side effect Brain abscess, and also find the drugs that interact with Propafenone and are indicated for Brain abscess.",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) Clomifene, (2) Metronidazole, (3) Carmustine"
+    "llm_ranking": [
+      {
+        "entity_name": "Clomifene",
+        "llm-average": 16.47
+      },
+      {
+        "entity_name": "Metronidazole",
+        "llm-average": 12.54
+      },
+      {
+        "entity_name": "Carmustine",
+        "llm-average": 11.41
+      }
+    ]
   },
   {
     "question_number": 30,
     "qid": 1531,
     "text": "Find all drugs that have the side effect Stillbirth and interact with Coumaphos, and also find the drugs that are indicated for Stillbirth and interact with Coumaphos.",
     "category": "Age of death:Stillbirth",
-    "llm_ranking": "(1) Mifepristone, (2) Felbamate, (3) Paliperidone, (4) Citalopram, (5) Escitalopram, (6) Risperidone, (7) Cetirizine, (8) Bisoprolol"
+    "llm_ranking": [
+      {
+        "entity_name": "Mifepristone",
+        "llm-average": 14.19
+      },
+      {
+        "entity_name": "Felbamate",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "Paliperidone",
+        "llm-average": 5.42
+      },
+      {
+        "entity_name": "Citalopram",
+        "llm-average": 5.18
+      },
+      {
+        "entity_name": "Escitalopram",
+        "llm-average": 4.36
+      },
+      {
+        "entity_name": "Risperidone",
+        "llm-average": 4.19
+      },
+      {
+        "entity_name": "Cetirizine",
+        "llm-average": 1.73
+      },
+      {
+        "entity_name": "Bisoprolol",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 31,
     "qid": 450,
     "text": "Which drugs act on ZNF770, which is detected in pathology samples of endometrial cancer, and interact with Phenyl aminosalicylate?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.39
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.92
+      }
+    ]
   },
   {
     "question_number": 32,
     "qid": 451,
     "text": "Which proteins are compiled as interacting with CBX6, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) PPARG, (2) SFPQ, (3) EGR1, (4) YY1, (5) CBX2, (6) JUN, (7) TP53, (8) H3-2"
+    "llm_ranking": [
+      {
+        "entity_name": "PPARG",
+        "llm-average": 16.13
+      },
+      {
+        "entity_name": "SFPQ",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "EGR1",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "YY1",
+        "llm-average": 12.31
+      },
+      {
+        "entity_name": "CBX2",
+        "llm-average": 11.56
+      },
+      {
+        "entity_name": "JUN",
+        "llm-average": 9.87
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.44
+      },
+      {
+        "entity_name": "H3-2",
+        "llm-average": 5.92
+      }
+    ]
   },
   {
     "question_number": 33,
     "qid": 452,
     "text": "Which proteins are curated as interacting with LMO7, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) DBN1, (2) CAPZA2"
+    "llm_ranking": [
+      {
+        "entity_name": "DBN1",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "CAPZA2",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 34,
     "qid": 453,
     "text": "Which proteins are compiled as interacting with NCAPD2, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) PRKAR2B, (2) PARP1, (3) DNMT1, (4) BUB1B, (5) NUP50, (6) CCNA2, (7) MAD2L1"
+    "llm_ranking": [
+      {
+        "entity_name": "PRKAR2B",
+        "llm-average": 19.42
+      },
+      {
+        "entity_name": "DNMT1",
+        "llm-average": 15.61
+      },
+      {
+        "entity_name": "PARP1",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "BUB1B",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "NUP50",
+        "llm-average": 11.54
+      },
+      {
+        "entity_name": "CCNA2",
+        "llm-average": 11.1
+      },
+      {
+        "entity_name": "MAD2L1",
+        "llm-average": 10.37
+      }
+    ]
   },
   {
     "question_number": 35,
     "qid": 456,
     "text": "Which proteins act on MAGI3, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) RERG, (2) IGF1R, (3) RAF1, (4) KRAS"
+    "llm_ranking": [
+      {
+        "entity_name": "RERG",
+        "llm-average": 15.28
+      },
+      {
+        "entity_name": "IGF1R",
+        "llm-average": 14.56
+      },
+      {
+        "entity_name": "RAF1",
+        "llm-average": 12.83
+      },
+      {
+        "entity_name": "KRAS",
+        "llm-average": 8.04
+      }
+    ]
   },
   {
     "question_number": 36,
     "qid": 457,
     "text": "Which proteins are curated as interacting with LIMCH1, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) OTUD6B, (2) PLEKHA7, (3) KLHL15"
+    "llm_ranking": [
+      {
+        "entity_name": "OTUD6B",
+        "llm-average": 15.24
+      },
+      {
+        "entity_name": "PLEKHA7",
+        "llm-average": 12.28
+      },
+      {
+        "entity_name": "KLHL15",
+        "llm-average": 10.41
+      }
+    ]
   },
   {
     "question_number": 37,
     "qid": 459,
     "text": "Which proteins act on SEMA4B, which is associated with hepatocellular carcinoma, and are associated with parasympathetic ganglion?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) PLXNA2, (2) DLG4"
+    "llm_ranking": [
+      {
+        "entity_name": "PLXNA2",
+        "llm-average": 14.1
+      },
+      {
+        "entity_name": "DLG4",
+        "llm-average": 14.09
+      }
+    ]
   },
   {
     "question_number": 38,
     "qid": 461,
     "text": "Which proteins are compiled as interacting with DNAJC9, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) DNMT1, (2) MAD2L1"
+    "llm_ranking": [
+      {
+        "entity_name": "DNMT1",
+        "llm-average": 12.28
+      },
+      {
+        "entity_name": "MAD2L1",
+        "llm-average": 10.41
+      }
+    ]
   },
   {
     "question_number": 39,
     "qid": 462,
     "text": "Which proteins are curated as interacting with TRIM52, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) TRIM41, (2) RNF114"
+    "llm_ranking": [
+      {
+        "entity_name": "TRIM41",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "RNF114",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 40,
     "qid": 464,
     "text": "Which proteins are curated as interacting with ZMYND8, which is detected in pathology samples of endometrial cancer, and are associated with cystic lymphangioma?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) RBM8A, (2) ZNF408"
+    "llm_ranking": [
+      {
+        "entity_name": "RBM8A",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "ZNF408",
+        "llm-average": 14.09
+      }
+    ]
   },
   {
     "question_number": 41,
     "qid": 465,
     "text": "Which proteins are curated as interacting with TSEN2, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) ZNRF1, (2) TSEN15"
+    "llm_ranking": [
+      {
+        "entity_name": "ZNRF1",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "TSEN15",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 42,
     "qid": 466,
     "text": "Which proteins act on IL13RA1, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) OSM, (2) EGF, (3) PRL, (4) CSF3, (5) IL3"
+    "llm_ranking": [
+      {
+        "entity_name": "OSM",
+        "llm-average": 17.59
+      },
+      {
+        "entity_name": "PRL",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "EGF",
+        "llm-average": 10.09
+      },
+      {
+        "entity_name": "CSF3",
+        "llm-average": 8.31
+      },
+      {
+        "entity_name": "IL3",
+        "llm-average": 4.03
+      }
+    ]
   },
   {
     "question_number": 43,
     "qid": 468,
     "text": "Which proteins are curated as interacting with XBP1, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) CROCC, (2) CCDC102B"
+    "llm_ranking": [
+      {
+        "entity_name": "CROCC",
+        "llm-average": 15.4
+      },
+      {
+        "entity_name": "CCDC102B",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 44,
     "qid": 469,
     "text": "Which drugs are compiled as targeting PHF8, which is associated with hepatocellular carcinoma, and act on PRDX4?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Acetic acid, (2) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 8.19
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 4.03
+      }
+    ]
   },
   {
     "question_number": 45,
     "qid": 470,
     "text": "Which proteins act on VPREB1, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) IGLL1, (2) JCHAIN"
+    "llm_ranking": [
+      {
+        "entity_name": "IGLL1",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "JCHAIN",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 46,
     "qid": 471,
     "text": "Which proteins are compiled as interacting with RAET1L, which is associated with hepatocellular carcinoma, and are associated with cystic lymphangioma?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) CEACAM5, (2) CNTN4, (3) CD52"
+    "llm_ranking": [
+      {
+        "entity_name": "CEACAM5",
+        "llm-average": 17.05
+      },
+      {
+        "entity_name": "CNTN4",
+        "llm-average": 13.24
+      },
+      {
+        "entity_name": "CD52",
+        "llm-average": 12.83
+      }
+    ]
   },
   {
     "question_number": 47,
     "qid": 472,
     "text": "Which drugs act on MTHFD2, which is associated with hepatocellular carcinoma, and interact with Phenyl aminosalicylate?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Valproic acid, (2) Sulindac, (3) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "Sulindac",
+        "llm-average": 10.15
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 9.04
+      }
+    ]
   },
   {
     "question_number": 48,
     "qid": 473,
     "text": "Which proteins are compiled as interacting with LIPT1, which is associated with blood, and are associated with cystic lymphangioma?",
     "category": "cardiovascular system disease:benign vascular tumor",
-    "llm_ranking": "(1) STAT2, (2) ZNF521"
+    "llm_ranking": [
+      {
+        "entity_name": "STAT2",
+        "llm-average": 11.68
+      },
+      {
+        "entity_name": "ZNF521",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 49,
     "qid": 477,
     "text": "Which drugs act on NTM, which is associated with hepatocellular carcinoma, and interact with Phenyl aminosalicylate?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.2
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 10.32
+      }
+    ]
   },
   {
     "question_number": 50,
     "qid": 478,
     "text": "Which proteins are compiled as interacting with KLHL32, which is detected in pathology samples of endometrial cancer, and are associated with A-427 cell?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) CUL3, (2) CUL1"
+    "llm_ranking": [
+      {
+        "entity_name": "CUL3",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "CUL1",
+        "llm-average": 7.95
+      }
+    ]
   },
   {
     "question_number": 51,
     "qid": 479,
     "text": "Which drugs act on SERPINE2, which is associated with hepatocellular carcinoma, and interact with Phenyl aminosalicylate?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Troglitazone, (2) Resveratrol, (3) Balsalazide, (4) Enalapril"
+    "llm_ranking": [
+      {
+        "entity_name": "Troglitazone",
+        "llm-average": 18.87
+      },
+      {
+        "entity_name": "Resveratrol",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 12.67
+      },
+      {
+        "entity_name": "Enalapril",
+        "llm-average": 10.37
+      }
+    ]
   },
   {
     "question_number": 52,
     "qid": 481,
     "text": "Which proteins are curated as interacting with MFSD12, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) LPAR1, (2) SLC22A9, (3) CD79A, (4) SSMEM1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPAR1",
+        "llm-average": 14.92
+      },
+      {
+        "entity_name": "SLC22A9",
+        "llm-average": 13.3
+      },
+      {
+        "entity_name": "CD79A",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "SSMEM1",
+        "llm-average": 9.61
+      }
+    ]
   },
   {
     "question_number": 53,
     "qid": 484,
     "text": "Which proteins are subunits of ITGA9-ITGB1-FIGF complex, which is associated with cell migration, and are associated with cystic lymphangioma?",
     "category": "cardiovascular system disease:benign vascular tumor",
-    "llm_ranking": "(1) ITGA9, (2) VEGFD"
+    "llm_ranking": [
+      {
+        "entity_name": "ITGA9",
+        "llm-average": 15.92
+      },
+      {
+        "entity_name": "VEGFD",
+        "llm-average": 13.11
+      }
+    ]
   },
   {
     "question_number": 54,
     "qid": 485,
     "text": "Which proteins are curated as interacting with CEP63, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) ROGDI, (2) CAPN7, (3) DAXX, (4) TSG101, (5) TBC1D22B, (6) POLR3C"
+    "llm_ranking": [
+      {
+        "entity_name": "ROGDI",
+        "llm-average": 13.35
+      },
+      {
+        "entity_name": "CAPN7",
+        "llm-average": 12.33
+      },
+      {
+        "entity_name": "DAXX",
+        "llm-average": 12.2
+      },
+      {
+        "entity_name": "TSG101",
+        "llm-average": 11.99
+      },
+      {
+        "entity_name": "TBC1D22B",
+        "llm-average": 7.92
+      },
+      {
+        "entity_name": "POLR3C",
+        "llm-average": 6.81
+      }
+    ]
   },
   {
     "question_number": 55,
     "qid": 486,
     "text": "Which proteins are curated as interacting with MITD1, which is associated with hepatocellular carcinoma, and are associated with conoid?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) RAB5C, (2) XRCC5, (3) CLTC"
+    "llm_ranking": [
+      {
+        "entity_name": "RAB5C",
+        "llm-average": 12.21
+      },
+      {
+        "entity_name": "XRCC5",
+        "llm-average": 9.54
+      },
+      {
+        "entity_name": "CLTC",
+        "llm-average": 7.76
+      }
+    ]
   },
   {
     "question_number": 56,
     "qid": 487,
     "text": "Which drugs act on ZNF821, which is detected in pathology samples of endometrial cancer, and interact with Anagrelide?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) Conjugated estrogens, (2) Estradiol, (3) Estrone sulfate"
+    "llm_ranking": [
+      {
+        "entity_name": "Conjugated estrogens",
+        "llm-average": 7.98
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 6.91
+      },
+      {
+        "entity_name": "Estrone sulfate",
+        "llm-average": 6.45
+      }
+    ]
   },
   {
     "question_number": 57,
     "qid": 488,
     "text": "Which proteins act on DSE, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) NCAN, (2) CSPG4, (3) VCAN, (4) BCAN, (5) HMOX1, (6) BGN, (7) DCN"
+    "llm_ranking": [
+      {
+        "entity_name": "NCAN",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "CSPG4",
+        "llm-average": 14.09
+      },
+      {
+        "entity_name": "VCAN",
+        "llm-average": 12.61
+      },
+      {
+        "entity_name": "HMOX1",
+        "llm-average": 11.34
+      },
+      {
+        "entity_name": "BCAN",
+        "llm-average": 11.03
+      },
+      {
+        "entity_name": "BGN",
+        "llm-average": 7.43
+      },
+      {
+        "entity_name": "DCN",
+        "llm-average": 6.31
+      }
+    ]
   },
   {
     "question_number": 58,
     "qid": 493,
     "text": "Which proteins act on OR7G3, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) RTP4, (2) GNGT1, (3) GNG13, (4) RTP3"
+    "llm_ranking": [
+      {
+        "entity_name": "RTP4",
+        "llm-average": 12.28
+      },
+      {
+        "entity_name": "GNGT1",
+        "llm-average": 11.61
+      },
+      {
+        "entity_name": "GNG13",
+        "llm-average": 10.41
+      },
+      {
+        "entity_name": "RTP3",
+        "llm-average": 10.37
+      }
+    ]
   },
   {
     "question_number": 59,
     "qid": 495,
     "text": "Which proteins are compiled as interacting with TTYH1, which is associated with hepatocellular carcinoma, and are associated with parasympathetic ganglion?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) BEST1, (2) GLRA2"
+    "llm_ranking": [
+      {
+        "entity_name": "BEST1",
+        "llm-average": 17.05
+      },
+      {
+        "entity_name": "GLRA2",
+        "llm-average": 15.6
+      }
+    ]
   },
   {
     "question_number": 60,
     "qid": 496,
     "text": "Which proteins act on PRSS55, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) F2RL3, (2) F2R"
+    "llm_ranking": [
+      {
+        "entity_name": "F2RL3",
+        "llm-average": 15.6
+      },
+      {
+        "entity_name": "F2R",
+        "llm-average": 15.4
+      }
+    ]
   },
   {
     "question_number": 61,
     "qid": 500,
     "text": "Which proteins act on CBX6, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) CBX2, (2) YY1"
+    "llm_ranking": [
+      {
+        "entity_name": "CBX2",
+        "llm-average": 17.05
+      },
+      {
+        "entity_name": "YY1",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 62,
     "qid": 501,
     "text": "Which proteins are compiled as interacting with SMYD3, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) KAT2B, (2) KAT2A, (3) DNMT1, (4) TP53, (5) EP300, (6) AKT1, (7) H3-2"
+    "llm_ranking": [
+      {
+        "entity_name": "KAT2B",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "KAT2A",
+        "llm-average": 13.76
+      },
+      {
+        "entity_name": "DNMT1",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "EP300",
+        "llm-average": 12.84
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 12.82
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "H3-2",
+        "llm-average": 6.79
+      }
+    ]
   },
   {
     "question_number": 63,
     "qid": 503,
     "text": "Which proteins act on APOA1, which is associated with fruit, and are associated with cystic lymphangioma?",
     "category": "cardiovascular system disease:benign vascular tumor",
-    "llm_ranking": "(1) CETP, (2) PON1, (3) APOB, (4) APOC3"
+    "llm_ranking": [
+      {
+        "entity_name": "CETP",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "PON1",
+        "llm-average": 12.26
+      },
+      {
+        "entity_name": "APOB",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "APOC3",
+        "llm-average": 5.92
+      }
+    ]
   },
   {
     "question_number": 64,
     "qid": 504,
     "text": "Which proteins are curated as interacting with CALN1, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) LIME1, (2) SEC22A, (3) DNAJC30, (4) USE1"
+    "llm_ranking": [
+      {
+        "entity_name": "LIME1",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "SEC22A",
+        "llm-average": 11.54
+      },
+      {
+        "entity_name": "DNAJC30",
+        "llm-average": 9.61
+      },
+      {
+        "entity_name": "USE1",
+        "llm-average": 7.77
+      }
+    ]
   },
   {
     "question_number": 65,
     "qid": 505,
     "text": "Which proteins are curated as interacting with MEAF6, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) MAGEA1, (2) ING4, (3) ING3, (4) RPL10, (5) H2BC1"
+    "llm_ranking": [
+      {
+        "entity_name": "MAGEA1",
+        "llm-average": 17.59
+      },
+      {
+        "entity_name": "ING4",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "ING3",
+        "llm-average": 12.73
+      },
+      {
+        "entity_name": "H2BC1",
+        "llm-average": 5.92
+      },
+      {
+        "entity_name": "RPL10",
+        "llm-average": 5.89
+      }
+    ]
   },
   {
     "question_number": 66,
     "qid": 507,
     "text": "Which proteins are curated as interacting with FMNL2, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) PLEKHA7, (2) UNC119"
+    "llm_ranking": [
+      {
+        "entity_name": "PLEKHA7",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "UNC119",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 67,
     "qid": 508,
     "text": "Which drugs interact with Clotrimazole, which is indicated for Pruritus, and have side effects Sensory impairment?",
     "category": "Abnormality of the nervous system:Abnormal peripheral nervous system morphology",
-    "llm_ranking": "(1) Sirolimus, (2) Tacrolimus"
+    "llm_ranking": [
+      {
+        "entity_name": "Sirolimus",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "Tacrolimus",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 68,
     "qid": 509,
     "text": "Which proteins are curated as interacting with ADAM22, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) YWHAQ, (2) YWHAB, (3) HCK"
+    "llm_ranking": [
+      {
+        "entity_name": "YWHAQ",
+        "llm-average": 13.35
+      },
+      {
+        "entity_name": "YWHAB",
+        "llm-average": 10.15
+      },
+      {
+        "entity_name": "HCK",
+        "llm-average": 9.56
+      }
+    ]
   },
   {
     "question_number": 69,
     "qid": 510,
     "text": "Which proteins are subunits of C complex spliceosome, which is associated with RNA splicing, and are associated with cystic lymphangioma?",
     "category": "cardiovascular system disease:benign vascular tumor",
-    "llm_ranking": "(1) RBM8A, (2) FRG1, (3) SNRPB"
+    "llm_ranking": [
+      {
+        "entity_name": "RBM8A",
+        "llm-average": 13.96
+      },
+      {
+        "entity_name": "FRG1",
+        "llm-average": 12.28
+      },
+      {
+        "entity_name": "SNRPB",
+        "llm-average": 11.68
+      }
+    ]
   },
   {
     "question_number": 70,
     "qid": 513,
     "text": "Which proteins are curated as interacting with EIF4EBP2, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) RDH12, (2) EIF4E2"
+    "llm_ranking": [
+      {
+        "entity_name": "RDH12",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "EIF4E2",
+        "llm-average": 8.04
+      }
+    ]
   },
   {
     "question_number": 71,
     "qid": 514,
     "text": "Which proteins are compiled as interacting with EPS8, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) AKT1, (2) OSMR, (3) SRC, (4) EGF"
+    "llm_ranking": [
+      {
+        "entity_name": "OSMR",
+        "llm-average": 12.18
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 11.61
+      },
+      {
+        "entity_name": "SRC",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "EGF",
+        "llm-average": 7.08
+      }
+    ]
   },
   {
     "question_number": 72,
     "qid": 515,
     "text": "Which proteins are curated as interacting with MMTAG2, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) HIF1AN, (2) ECH1"
+    "llm_ranking": [
+      {
+        "entity_name": "HIF1AN",
+        "llm-average": 15.92
+      },
+      {
+        "entity_name": "ECH1",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 73,
     "qid": 516,
     "text": "Which proteins are curated as interacting with DDT, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) MAD2L2, (2) ZDHHC5"
+    "llm_ranking": [
+      {
+        "entity_name": "MAD2L2",
+        "llm-average": 15.6
+      },
+      {
+        "entity_name": "ZDHHC5",
+        "llm-average": 15.4
+      }
+    ]
   },
   {
     "question_number": 74,
     "qid": 517,
     "text": "Which proteins act on ZNF286A, which is associated with Charcot-Marie-Tooth disease type 1, and are associated with neck?",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) LONRF2, (2) FBXL19"
+    "llm_ranking": [
+      {
+        "entity_name": "LONRF2",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "FBXL19",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 75,
     "qid": 518,
     "text": "Which proteins act on H3C15, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) KAT2B, (2) KAT2A, (3) EP300, (4) CBX2, (5) CREBBP, (6) UBE2I, (7) DNMT1, (8) MAD2L1"
+    "llm_ranking": [
+      {
+        "entity_name": "KAT2B",
+        "llm-average": 15.78
+      },
+      {
+        "entity_name": "KAT2A",
+        "llm-average": 13.94
+      },
+      {
+        "entity_name": "EP300",
+        "llm-average": 13.35
+      },
+      {
+        "entity_name": "CBX2",
+        "llm-average": 13.19
+      },
+      {
+        "entity_name": "CREBBP",
+        "llm-average": 11.94
+      },
+      {
+        "entity_name": "UBE2I",
+        "llm-average": 11.12
+      },
+      {
+        "entity_name": "DNMT1",
+        "llm-average": 7.88
+      },
+      {
+        "entity_name": "MAD2L1",
+        "llm-average": 6.34
+      }
+    ]
   },
   {
     "question_number": 76,
     "qid": 520,
     "text": "Which proteins are compiled as interacting with OR10Z1, which is detected in pathology samples of endometrial cancer, and are associated with adrenal cortex cell line?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) ARRB1, (2) GRK2"
+    "llm_ranking": [
+      {
+        "entity_name": "ARRB1",
+        "llm-average": 15.6
+      },
+      {
+        "entity_name": "GRK2",
+        "llm-average": 15.4
+      }
+    ]
   },
   {
     "question_number": 77,
     "qid": 521,
     "text": "Which proteins act on TSHB, which is associated with hepatocellular carcinoma, and are associated with parasympathetic ganglion?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) RAMP2, (2) IAPP, (3) RAMP1, (4) RAMP3"
+    "llm_ranking": [
+      {
+        "entity_name": "RAMP2",
+        "llm-average": 13.11
+      },
+      {
+        "entity_name": "IAPP",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "RAMP1",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "RAMP3",
+        "llm-average": 8.83
+      }
+    ]
   },
   {
     "question_number": 78,
     "qid": 522,
     "text": "Which proteins act on RBMX, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) PPIG, (2) KHDRBS3, (3) HNRNPD"
+    "llm_ranking": [
+      {
+        "entity_name": "PPIG",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "KHDRBS3",
+        "llm-average": 15.78
+      },
+      {
+        "entity_name": "HNRNPD",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 79,
     "qid": 526,
     "text": "Which metabolites are associated with PLEKHA8, which is detected in pathology samples of endometrial cancer, and are annotated in pathway Extra-nuclear estrogen signaling?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) Sphingosine 1-phosphate, (2) Sphingosine"
+    "llm_ranking": [
+      {
+        "entity_name": "Sphingosine 1-phosphate",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "Sphingosine",
+        "llm-average": 8.8
+      }
+    ]
   },
   {
     "question_number": 80,
     "qid": 527,
     "text": "Which proteins are subunits of VEcad-VEGFR complex, which is associated with cellular response to oscillatory fluid shear stress, and are associated with cystic lymphangioma?",
     "category": "cardiovascular system disease:benign vascular tumor",
-    "llm_ranking": "(1) FLT4, (2) KDR"
+    "llm_ranking": [
+      {
+        "entity_name": "FLT4",
+        "llm-average": 15.4
+      },
+      {
+        "entity_name": "KDR",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 81,
     "qid": 528,
     "text": "Which proteins are compiled as interacting with SEMA3F, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) FURIN, (2) AKT1, (3) FN1, (4) TP53"
+    "llm_ranking": [
+      {
+        "entity_name": "FURIN",
+        "llm-average": 15.78
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "FN1",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 5.53
+      }
+    ]
   },
   {
     "question_number": 82,
     "qid": 530,
     "text": "Which proteins are curated as interacting with PPHLN1, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) METTL3, (2) MATR3"
+    "llm_ranking": [
+      {
+        "entity_name": "METTL3",
+        "llm-average": 15.6
+      },
+      {
+        "entity_name": "MATR3",
+        "llm-average": 14.86
+      }
+    ]
   },
   {
     "question_number": 83,
     "qid": 532,
     "text": "Which drugs act on IMPDH2, which is associated with hepatocellular carcinoma, and are compiled as targeting FTMT?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Iron, (2) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "Iron",
+        "llm-average": 1.62
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 84,
     "qid": 533,
     "text": "Which proteins are curated as interacting with RILPL1, which is detected in pathology samples of endometrial cancer, and are associated with neck?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) TRAF3IP3, (2) APPBP2, (3) PIP4P1, (4) NTAQ1, (5) SEC22A"
+    "llm_ranking": [
+      {
+        "entity_name": "TRAF3IP3",
+        "llm-average": 11.12
+      },
+      {
+        "entity_name": "APPBP2",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "PIP4P1",
+        "llm-average": 9.21
+      },
+      {
+        "entity_name": "NTAQ1",
+        "llm-average": 4.42
+      },
+      {
+        "entity_name": "SEC22A",
+        "llm-average": 4.03
+      }
+    ]
   },
   {
     "question_number": 85,
     "qid": 538,
     "text": "Which proteins are curated as interacting with ADRM1, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) PRKAR1A, (2) JUN"
+    "llm_ranking": [
+      {
+        "entity_name": "PRKAR1A",
+        "llm-average": 15.4
+      },
+      {
+        "entity_name": "JUN",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 86,
     "qid": 539,
     "text": "Which drugs are compiled as targeting AQP10, which is associated with hepatocellular carcinoma, and interact with Anagrelide?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Lithium cation, (2) Hydrochlorothiazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Lithium cation",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "Hydrochlorothiazide",
+        "llm-average": 8.34
+      }
+    ]
   },
   {
     "question_number": 87,
     "qid": 541,
     "text": "Which drugs are compiled as targeting UNC50, which is associated with hepatocellular carcinoma, and interact with Rifampicin?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) R,S-Warfarin alcohol, (2) S,R-Warfarin alcohol"
+    "llm_ranking": [
+      {
+        "entity_name": "R,S-Warfarin alcohol",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "S,R-Warfarin alcohol",
+        "llm-average": 11.24
+      }
+    ]
   },
   {
     "question_number": 88,
     "qid": 542,
     "text": "Which proteins are compiled as interacting with PCBP4, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) TP53, (2) CDK2, (3) CCNA1, (4) CCNA2"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 14.92
+      },
+      {
+        "entity_name": "CCNA1",
+        "llm-average": 8.34
+      },
+      {
+        "entity_name": "CDK2",
+        "llm-average": 8.1
+      },
+      {
+        "entity_name": "CCNA2",
+        "llm-average": 7.1
+      }
+    ]
   },
   {
     "question_number": 89,
     "qid": 546,
     "text": "Which drugs act on ING4, which is associated with hepatocellular carcinoma, and interact with Phenyl aminosalicylate?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Valproic acid, (2) Balsalazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 15.78
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 8.71
+      }
+    ]
   },
   {
     "question_number": 90,
     "qid": 548,
     "text": "Which proteins are compiled as interacting with LRIG3, which is associated with hepatocellular carcinoma, and are associated with parasympathetic ganglion?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) RET, (2) NOTCH1, (3) EGFR"
+    "llm_ranking": [
+      {
+        "entity_name": "RET",
+        "llm-average": 17.59
+      },
+      {
+        "entity_name": "NOTCH1",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "EGFR",
+        "llm-average": 7.95
+      }
+    ]
   },
   {
     "question_number": 91,
     "qid": 549,
     "text": "Which drugs act on ACSS3, which is associated with hepatocellular carcinoma, and interact with Phenyl aminosalicylate?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 10.39
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 6.63
+      }
+    ]
   },
   {
     "question_number": 92,
     "qid": 550,
     "text": "Which proteins are curated as interacting with CETN1, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) CEP290, (2) POC5, (3) USP49, (4) TBCCD1, (5) ZFAND5"
+    "llm_ranking": [
+      {
+        "entity_name": "CEP290",
+        "llm-average": 18.87
+      },
+      {
+        "entity_name": "USP49",
+        "llm-average": 13.51
+      },
+      {
+        "entity_name": "POC5",
+        "llm-average": 13.41
+      },
+      {
+        "entity_name": "TBCCD1",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "ZFAND5",
+        "llm-average": 6.81
+      }
+    ]
   },
   {
     "question_number": 93,
     "qid": 551,
     "text": "Which proteins act on FZD3, which is associated with hepatocellular carcinoma, and are associated with parasympathetic ganglion?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) GNAQ, (2) WNT1"
+    "llm_ranking": [
+      {
+        "entity_name": "GNAQ",
+        "llm-average": 17.59
+      },
+      {
+        "entity_name": "WNT1",
+        "llm-average": 11.98
+      }
+    ]
   },
   {
     "question_number": 94,
     "qid": 553,
     "text": "Which drugs act on CDCA7, which is associated with hepatocellular carcinoma, and interact with Phenyl aminosalicylate?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) Troglitazone, (2) Valproic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Troglitazone",
+        "llm-average": 15.6
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 13.58
+      }
+    ]
   },
   {
     "question_number": 95,
     "qid": 554,
     "text": "Which proteins act on DIAPH3, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) SRC, (2) BUB1B"
+    "llm_ranking": [
+      {
+        "entity_name": "SRC",
+        "llm-average": 12.83
+      },
+      {
+        "entity_name": "BUB1B",
+        "llm-average": 9.84
+      }
+    ]
   },
   {
     "question_number": 96,
     "qid": 556,
     "text": "Which proteins are compiled as interacting with CCDC170, which is associated with mammary gland cell line, and are associated with cystic lymphangioma?",
     "category": "cardiovascular system disease:benign vascular tumor",
-    "llm_ranking": "(1) FOXE1, (2) SYNE1, (3) ZNF408"
+    "llm_ranking": [
+      {
+        "entity_name": "FOXE1",
+        "llm-average": 15.24
+      },
+      {
+        "entity_name": "SYNE1",
+        "llm-average": 11.43
+      },
+      {
+        "entity_name": "ZNF408",
+        "llm-average": 10.41
+      }
+    ]
   },
   {
     "question_number": 97,
     "qid": 558,
     "text": "Which proteins are compiled as interacting with RASA2, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) KRAS, (2) HRAS"
+    "llm_ranking": [
+      {
+        "entity_name": "KRAS",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "HRAS",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 98,
     "qid": 559,
     "text": "Which proteins are compiled as interacting with MTMR11, which is associated with hepatocellular carcinoma, and are associated with neck?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) DUSP10, (2) OTUD7B, (3) POLD4, (4) TRMT9B, (5) TMEM205, (6) ZNF212, (7) ACAD8"
+    "llm_ranking": [
+      {
+        "entity_name": "DUSP10",
+        "llm-average": 11.14
+      },
+      {
+        "entity_name": "OTUD7B",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "POLD4",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "TRMT9B",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "TMEM205",
+        "llm-average": 5.65
+      },
+      {
+        "entity_name": "ZNF212",
+        "llm-average": 5.3
+      },
+      {
+        "entity_name": "ACAD8",
+        "llm-average": 4.22
+      }
+    ]
   },
   {
     "question_number": 99,
     "qid": 560,
     "text": "Which proteins act on LPAR5, which is associated with hepatocellular carcinoma, and are associated with adrenal cortex cell line?",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) APP, (2) P2RY14, (3) P2RY13, (4) GNRHR"
+    "llm_ranking": [
+      {
+        "entity_name": "APP",
+        "llm-average": 14.09
+      },
+      {
+        "entity_name": "P2RY14",
+        "llm-average": 12.26
+      },
+      {
+        "entity_name": "P2RY13",
+        "llm-average": 11.66
+      },
+      {
+        "entity_name": "GNRHR",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 100,
     "qid": 562,
     "text": "Which drugs act on RNFT2, which is detected in pathology samples of endometrial cancer, and interact with Phenyl aminosalicylate?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) Valproic acid, (2) Resveratrol, (3) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 14.1
+      },
+      {
+        "entity_name": "Resveratrol",
+        "llm-average": 14.09
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.78
+      }
+    ]
   },
   {
     "question_number": 101,
     "qid": 805,
     "text": "List the drugs that interact with Bisoxatin and have the side effect Hepatic encephalopathy.",
     "category": "Abnormality of the nervous system:Encephalopathy",
-    "llm_ranking": "(1) Flutamide, (2) Bendroflumethiazide, (3) Amiloride, (4) Indapamide, (5) Rabeprazole, (6) Furosemide"
+    "llm_ranking": [
+      {
+        "entity_name": "Flutamide",
+        "llm-average": 13.62
+      },
+      {
+        "entity_name": "Bendroflumethiazide",
+        "llm-average": 9.92
+      },
+      {
+        "entity_name": "Amiloride",
+        "llm-average": 8.2
+      },
+      {
+        "entity_name": "Indapamide",
+        "llm-average": 7.9
+      },
+      {
+        "entity_name": "Rabeprazole",
+        "llm-average": 7.03
+      },
+      {
+        "entity_name": "Furosemide",
+        "llm-average": 6.02
+      }
+    ]
   },
   {
     "question_number": 102,
     "qid": 811,
     "text": "List the proteins that are associated with follicular adenoma and act on MRPS6.",
     "category": "endocrine system disease:thyroid gland disease",
-    "llm_ranking": "(1) IMP3, (2) MRPS2, (3) MRPL28, (4) RPSA, (5) RPL10A"
+    "llm_ranking": [
+      {
+        "entity_name": "IMP3",
+        "llm-average": 13.54
+      },
+      {
+        "entity_name": "MRPL28",
+        "llm-average": 10.0
+      },
+      {
+        "entity_name": "MRPS2",
+        "llm-average": 9.72
+      },
+      {
+        "entity_name": "RPSA",
+        "llm-average": 5.5
+      },
+      {
+        "entity_name": "RPL10A",
+        "llm-average": 5.26
+      }
+    ]
   },
   {
     "question_number": 103,
     "qid": 812,
     "text": "List the proteins that are compiled as interacting with TAP1 and are associated with peripheral artery disease.",
     "category": "cardiovascular system disease:artery disease",
-    "llm_ranking": "(1) ABCB6, (2) LAMP2, (3) B2M"
+    "llm_ranking": [
+      {
+        "entity_name": "ABCB6",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "LAMP2",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "B2M",
+        "llm-average": 5.41
+      }
+    ]
   },
   {
     "question_number": 104,
     "qid": 813,
     "text": "List the drugs that are indicated for Anxiety and have the side effect Myositis.",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) (S)-Fluoxetine, (2) (R)-Fluoxetine, (3) Mirtazapine, (4) Paroxetine, (5) Fluoxetine"
+    "llm_ranking": [
+      {
+        "entity_name": "(S)-Fluoxetine",
+        "llm-average": 17.59
+      },
+      {
+        "entity_name": "(R)-Fluoxetine",
+        "llm-average": 16.3
+      },
+      {
+        "entity_name": "Mirtazapine",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Paroxetine",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Fluoxetine",
+        "llm-average": 8.32
+      }
+    ]
   },
   {
     "question_number": 105,
     "qid": 814,
     "text": "List the proteins that are associated with endometrial carcinoma and are annotated in the pathway Meclizine H1-Antihistamine Action.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) NFKB1, (2) GNAQ, (3) GNG2"
+    "llm_ranking": [
+      {
+        "entity_name": "NFKB1",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "GNAQ",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "GNG2",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 106,
     "qid": 815,
     "text": "List the proteins that are subunits of NCR3-CD247 complex and are detected in pathology samples of head and neck cancer.",
     "category": "cancer:head and neck cancer",
-    "llm_ranking": "(1) NCR3, (2) CD247"
+    "llm_ranking": [
+      {
+        "entity_name": "NCR3",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "CD247",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 107,
     "qid": 816,
     "text": "List the proteins that are subunits of MTA2 complex and are associated with lens disease.",
     "category": "nervous system disease:eye disease",
-    "llm_ranking": "(1) HDAC2, (2) HDAC1"
+    "llm_ranking": [
+      {
+        "entity_name": "HDAC2",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "HDAC1",
+        "llm-average": 8.85
+      }
+    ]
   },
   {
     "question_number": 108,
     "qid": 817,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(10:0/i-19:0/i-14:0) and are associated with heart disease.",
     "category": "cardiovascular system disease:heart disease",
-    "llm_ranking": "(1) DGAT1, (2) LPIN1, (3) GPAM, (4) GPD1, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 15.77
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 14.22
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 109,
     "qid": 818,
     "text": "List the drugs that interact with Rifampicin and are indicated for Abnormality of movement.",
     "category": "Abnormality of the nervous system:Abnormality of movement",
-    "llm_ranking": "(1) Olanzapine, (2) Paroxetine"
+    "llm_ranking": [
+      {
+        "entity_name": "Olanzapine",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "Paroxetine",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 110,
     "qid": 828,
     "text": "List the proteins that are associated with arteriosclerosis and are annotated in the pathway Cardiolipin Biosynthesis CL(i-14:0/i-16:0/a-13:0/a-25:0).",
     "category": "cardiovascular system disease:artery disease",
-    "llm_ranking": "(1) GPAM, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 111,
     "qid": 836,
     "text": "List the proteins that are associated with melanoma and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(18:0/14:1(9Z)/20:3(5Z,8Z,11Z)).",
     "category": "cancer:melanoma",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 16.3
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 13.45
+      }
+    ]
   },
   {
     "question_number": 112,
     "qid": 839,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(10:0/i-18:0/12:0) and are associated with influenza.",
     "category": "respiratory system disease:None",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 113,
     "qid": 841,
     "text": "List the proteins that are associated with arteriosclerotic cardiovascular disease and act on NPR3.",
     "category": "cardiovascular system disease:artery disease",
-    "llm_ranking": "(1) GUCA1B, (2) PDE1B, (3) GUCY1B1"
+    "llm_ranking": [
+      {
+        "entity_name": "GUCA1B",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "PDE1B",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "GUCY1B1",
+        "llm-average": 7.66
+      }
+    ]
   },
   {
     "question_number": 114,
     "qid": 842,
     "text": "List the proteins that are compiled as interacting with AGTR1 and are associated with meningeal melanocytoma.",
     "category": "cancer:nervous system cancer",
-    "llm_ranking": "(1) PTGFR, (2) APLNR, (3) GRM1, (4) GNAQ, (5) EDN3, (6) HRAS, (7) GNA11, (8) EDN2"
+    "llm_ranking": [
+      {
+        "entity_name": "PTGFR",
+        "llm-average": 16.49
+      },
+      {
+        "entity_name": "APLNR",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "GRM1",
+        "llm-average": 13.68
+      },
+      {
+        "entity_name": "GNAQ",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "HRAS",
+        "llm-average": 10.48
+      },
+      {
+        "entity_name": "EDN3",
+        "llm-average": 9.86
+      },
+      {
+        "entity_name": "GNA11",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "EDN2",
+        "llm-average": 9.25
+      }
+    ]
   },
   {
     "question_number": 115,
     "qid": 848,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(16:1(9Z)/18:1(9Z)/16:1(9Z)/18:2(9Z,12Z)) and are associated with lung adenocarcinoma.",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) CRLS1, (2) PGS1"
+    "llm_ranking": [
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 116,
     "qid": 851,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(a-21:0/18:0/i-22:0) and are associated with Huntington's disease.",
     "category": "nervous system disease:neurodegenerative disease",
-    "llm_ranking": "(1) LPIN1, (2) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 15.07
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 13.65
+      }
+    ]
   },
   {
     "question_number": 117,
     "qid": 852,
     "text": "List the drugs that interact with Regramostim and have the side effect Choreoathetosis.",
     "category": "Abnormality of the nervous system:Abnormality of movement",
-    "llm_ranking": "(1) Lamotrigine, (2) Ziprasidone, (3) Aripiprazole, (4) Quetiapine, (5) Paroxetine, (6) Olanzapine, (7) Escitalopram"
+    "llm_ranking": [
+      {
+        "entity_name": "Aripiprazole",
+        "llm-average": 10.99
+      },
+      {
+        "entity_name": "Lamotrigine",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "Ziprasidone",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "Quetiapine",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Olanzapine",
+        "llm-average": 7.44
+      },
+      {
+        "entity_name": "Paroxetine",
+        "llm-average": 7.33
+      },
+      {
+        "entity_name": "Escitalopram",
+        "llm-average": 6.55
+      }
+    ]
   },
   {
     "question_number": 118,
     "qid": 856,
     "text": "List the proteins that are subunits of SHARP-CtBP1-CtIP-RBP-Jkappa corepressor complex and are associated with intrinsic asthma.",
     "category": "respiratory system disease:bronchial disease",
-    "llm_ranking": "(1) SPEN, (2) RBPJ"
+    "llm_ranking": [
+      {
+        "entity_name": "SPEN",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "RBPJ",
+        "llm-average": 10.79
+      }
+    ]
   },
   {
     "question_number": 119,
     "qid": 857,
     "text": "List the proteins that are associated with lower respiratory tract disease and are subunits of Exon junction complex.",
     "category": "respiratory system disease:lower respiratory tract disease",
-    "llm_ranking": "(1) UPF3B, (2) UPF2, (3) RNPS1, (4) RBM8A, (5) ALYREF, (6) NXF1, (7) SRRM1"
+    "llm_ranking": [
+      {
+        "entity_name": "UPF3B",
+        "llm-average": 17.89
+      },
+      {
+        "entity_name": "RNPS1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "UPF2",
+        "llm-average": 14.93
+      },
+      {
+        "entity_name": "RBM8A",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "ALYREF",
+        "llm-average": 8.7
+      },
+      {
+        "entity_name": "NXF1",
+        "llm-average": 8.11
+      },
+      {
+        "entity_name": "SRRM1",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 120,
     "qid": 865,
     "text": "List the proteins that are associated with Charcot-Marie-Tooth disease and are curated as interacting with GPN3.",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) VAPB, (2) SCN2B, (3) CHRM3"
+    "llm_ranking": [
+      {
+        "entity_name": "VAPB",
+        "llm-average": 16.09
+      },
+      {
+        "entity_name": "SCN2B",
+        "llm-average": 9.92
+      },
+      {
+        "entity_name": "CHRM3",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 121,
     "qid": 872,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-21:0/i-24:0/i-13:0) and are associated with optic atrophy.",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) PTPMT1, (2) CRLS1, (3) GPD1, (4) PGS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 13.24
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.23
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 8.19
+      }
+    ]
   },
   {
     "question_number": 122,
     "qid": 875,
     "text": "List the proteins that are associated with poliomyelitis and are subunits of ABCB1-ANXA2-RACK1-SRC complex.",
     "category": "nervous system disease:peripheral nervous system disease",
-    "llm_ranking": "(1) SRC, (2) ANXA2, (3) RACK1"
+    "llm_ranking": [
+      {
+        "entity_name": "ANXA2",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "SRC",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "RACK1",
+        "llm-average": 9.83
+      }
+    ]
   },
   {
     "question_number": 123,
     "qid": 879,
     "text": "List the proteins that are associated with squamous cell carcinoma and are subunits of Stat1-alpha-dimer-CBP DNA-protein complex.",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) CREBBP, (2) STAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "CREBBP",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "STAT1",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 124,
     "qid": 885,
     "text": "List the drugs that are indicated for Photophobia and interact with Aprepitant.",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Diclofenac, (2) Acetylsalicylic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Diclofenac",
+        "llm-average": 7.57
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 125,
     "qid": 890,
     "text": "List the drugs that interact with Pheniprazine and have the side effect Facial palsy.",
     "category": "Abnormality of the nervous system:Abnormal cranial nerve physiology",
-    "llm_ranking": "(1) Methyldopa, (2) Cyclobenzaprine, (3) Ziprasidone, (4) Escitalopram, (5) Citalopram"
+    "llm_ranking": [
+      {
+        "entity_name": "Methyldopa",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Cyclobenzaprine",
+        "llm-average": 9.81
+      },
+      {
+        "entity_name": "Escitalopram",
+        "llm-average": 9.23
+      },
+      {
+        "entity_name": "Ziprasidone",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Citalopram",
+        "llm-average": 8.3
+      }
+    ]
   },
   {
     "question_number": 126,
     "qid": 895,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-12:0/i-20:0/a-21:0/i-13:0) and are associated with cancer.",
     "category": "cancer:None",
-    "llm_ranking": "(1) AGPAT5, (2) PTPMT1, (3) CRLS1, (4) GPAM, (5) PGS1, (6) CDS2, (7) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 18.93
+      },
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 16.38
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 16.02
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "CDS2",
+        "llm-average": 10.9
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 127,
     "qid": 900,
     "text": "List the proteins that are subunits of EARP complex and are associated with amyotrophic lateral sclerosis type 18.",
     "category": "nervous system disease:neurodegenerative disease",
-    "llm_ranking": "(1) VPS51, (2) VPS52, (3) VPS53"
+    "llm_ranking": [
+      {
+        "entity_name": "VPS51",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "VPS52",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "VPS53",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 128,
     "qid": 901,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-12:0/18:2(9Z,11Z)/i-21:0/i-22:0) and are associated with neuropathy.",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) PTPMT1, (2) CRLS1, (3) GPD1, (4) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 9.21
+      }
+    ]
   },
   {
     "question_number": 129,
     "qid": 903,
     "text": "List the drugs that interact with Dopamine and are indicated for Tension-type headache.",
     "category": "Abnormality of the nervous system:Headache",
-    "llm_ranking": "(1) Diazepam, (2) Ibuprofen, (3) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Diazepam",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "Ibuprofen",
+        "llm-average": 1.98
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 1.14
+      }
+    ]
   },
   {
     "question_number": 130,
     "qid": 905,
     "text": "List the proteins that are associated with lung benign neoplasm and are compiled as interacting with NTN4.",
     "category": "respiratory system disease:respiratory system benign neoplasm",
-    "llm_ranking": "(1) SEMA3F, (2) DRAXIN, (3) PTPN11"
+    "llm_ranking": [
+      {
+        "entity_name": "SEMA3F",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "DRAXIN",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "PTPN11",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 131,
     "qid": 907,
     "text": "List the proteins that are subunits of ESR1-RELA-BCL3-NCOA3 complex and are associated with chronic fatigue syndrome.",
     "category": "chronic fatigue syndrome:None",
-    "llm_ranking": "(1) ESR1, (2) RELA"
+    "llm_ranking": [
+      {
+        "entity_name": "ESR1",
+        "llm-average": 13.65
+      },
+      {
+        "entity_name": "RELA",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 132,
     "qid": 909,
     "text": "List the proteins that act on SRF and are associated with cardiomyopathy.",
     "category": "cardiovascular system disease:cardiomyopathy",
-    "llm_ranking": "(1) SPI1, (2) HDAC4, (3) CSNK2A1, (4) MAPK14, (5) FGF2, (6) GATA5, (7) HNF1A, (8) MYOD1"
+    "llm_ranking": [
+      {
+        "entity_name": "HDAC4",
+        "llm-average": 14.54
+      },
+      {
+        "entity_name": "SPI1",
+        "llm-average": 14.2
+      },
+      {
+        "entity_name": "CSNK2A1",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "MAPK14",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "FGF2",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "GATA5",
+        "llm-average": 10.3
+      },
+      {
+        "entity_name": "HNF1A",
+        "llm-average": 9.72
+      },
+      {
+        "entity_name": "MYOD1",
+        "llm-average": 6.26
+      }
+    ]
   },
   {
     "question_number": 133,
     "qid": 912,
     "text": "List the proteins that are associated with alternating hemiplegia of childhood and are compiled as interacting with MGA.",
     "category": "nervous system disease:hemiplegia",
-    "llm_ranking": "(1) EHMT1, (2) HCFC1, (3) SMG1, (4) TAF1"
+    "llm_ranking": [
+      {
+        "entity_name": "EHMT1",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "SMG1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "HCFC1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "TAF1",
+        "llm-average": 8.93
+      }
+    ]
   },
   {
     "question_number": 134,
     "qid": 914,
     "text": "List the proteins that act on SHC1 and are associated with corneal deposit.",
     "category": "nervous system disease:eye disease",
-    "llm_ranking": "(1) NGF, (2) MAPK8, (3) TGFB1"
+    "llm_ranking": [
+      {
+        "entity_name": "NGF",
+        "llm-average": 14.68
+      },
+      {
+        "entity_name": "MAPK8",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "TGFB1",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 135,
     "qid": 916,
     "text": "List the proteins that are associated with central nervous system disease and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(a-25:0/18:0/i-13:0).",
     "category": "nervous system disease:central nervous system disease",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPAM, (4) GPD1, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 15.75
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 14.63
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 9.72
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 136,
     "qid": 919,
     "text": "List the proteins that are associated with pancytopenia and are subunits of ADAM12-alphaVbeta3-integrin-MMP-14 complex.",
     "category": "hematopoietic system disease:pancytopenia",
-    "llm_ranking": "(1) ITGB3, (2) ITGAV"
+    "llm_ranking": [
+      {
+        "entity_name": "ITGB3",
+        "llm-average": 11.71
+      },
+      {
+        "entity_name": "ITGAV",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 137,
     "qid": 927,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(20:2(11Z,14Z)/22:5(7Z,10Z,13Z,16Z,19Z)/20:3(8Z,11Z,14Z)) and are associated with eye disease.",
     "category": "nervous system disease:eye disease",
-    "llm_ranking": "(1) GPAM, (2) GPD1, (3) LPIN1, (4) DGAT1, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 10.99
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 138,
     "qid": 931,
     "text": "List the proteins that are subunits of Apoptosome-procaspase 9 complex and are associated with high grade glioma.",
     "category": "cancer:cell type cancer",
-    "llm_ranking": "(1) APAF1, (2) CYCS, (3) CASP9"
+    "llm_ranking": [
+      {
+        "entity_name": "APAF1",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "CYCS",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "CASP9",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 139,
     "qid": 948,
     "text": "List the proteins that are associated with head and neck carcinoma and are subunits of CSA-POLIIa complex.",
     "category": "cancer:head and neck cancer",
-    "llm_ranking": "(1) COPS3, (2) COPS5, (3) RBX1, (4) DDB1, (5) POLR2A"
+    "llm_ranking": [
+      {
+        "entity_name": "COPS3",
+        "llm-average": 15.46
+      },
+      {
+        "entity_name": "COPS5",
+        "llm-average": 14.61
+      },
+      {
+        "entity_name": "RBX1",
+        "llm-average": 9.81
+      },
+      {
+        "entity_name": "DDB1",
+        "llm-average": 9.48
+      },
+      {
+        "entity_name": "POLR2A",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 140,
     "qid": 952,
     "text": "List the drugs that have the side effect Hemoglobinuria and interact with Gabapentin enacarbil.",
     "category": "Abnormality of the genitourinary system:Abnormality of the urinary system physiology",
-    "llm_ranking": "(1) Deferiprone, (2) Quinidine, (3) Quinine, (4) Doxepin, (5) Sertraline"
+    "llm_ranking": [
+      {
+        "entity_name": "Deferiprone",
+        "llm-average": 14.59
+      },
+      {
+        "entity_name": "Quinidine",
+        "llm-average": 13.71
+      },
+      {
+        "entity_name": "Quinine",
+        "llm-average": 11.95
+      },
+      {
+        "entity_name": "Doxepin",
+        "llm-average": 7.02
+      },
+      {
+        "entity_name": "Sertraline",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 141,
     "qid": 958,
     "text": "List the drugs that are indicated for Glioma and interact with Vitamin D.",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) Topotecan, (2) Irinotecan"
+    "llm_ranking": [
+      {
+        "entity_name": "Topotecan",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "Irinotecan",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 142,
     "qid": 960,
     "text": "List the proteins that are associated with pancreatic signet ring cell adenocarcinoma and are compiled as interacting with TYMS.",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) KRAS, (2) HRAS, (3) TP53"
+    "llm_ranking": [
+      {
+        "entity_name": "KRAS",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "HRAS",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 143,
     "qid": 961,
     "text": "List the proteins that are associated with influenza and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(18:0/22:6(4Z,7Z,10Z,13Z,16Z,19Z)/22:2(13Z,16Z)).",
     "category": "respiratory system disease:None",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 12.42
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.54
+      }
+    ]
   },
   {
     "question_number": 144,
     "qid": 972,
     "text": "List the proteins that are associated with adrenal cortex cancer and act on TFAM.",
     "category": "cancer:endocrine gland cancer",
-    "llm_ranking": "(1) GABPA, (2) CYCS, (3) TP53"
+    "llm_ranking": [
+      {
+        "entity_name": "GABPA",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "CYCS",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.87
+      }
+    ]
   },
   {
     "question_number": 145,
     "qid": 973,
     "text": "List the proteins that are curated as interacting with NVL and are associated with focal dystonia.",
     "category": "nervous system disease:brain disease",
-    "llm_ranking": "(1) MNDA, (2) CLCN2, (3) MECP2"
+    "llm_ranking": [
+      {
+        "entity_name": "MNDA",
+        "llm-average": 15.62
+      },
+      {
+        "entity_name": "MECP2",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "CLCN2",
+        "llm-average": 9.28
+      }
+    ]
   },
   {
     "question_number": 146,
     "qid": 975,
     "text": "List the proteins that are annotated in the pathway ADP signalling through P2Y purinoceptor 1 and are associated with neonatal period electroclinical syndrome.",
     "category": "nervous system disease:brain disease",
-    "llm_ranking": "(1) GNB1, (2) GNAQ, (3) GNA15, (4) GNA11"
+    "llm_ranking": [
+      {
+        "entity_name": "GNB1",
+        "llm-average": 14.59
+      },
+      {
+        "entity_name": "GNAQ",
+        "llm-average": 12.13
+      },
+      {
+        "entity_name": "GNA11",
+        "llm-average": 8.7
+      },
+      {
+        "entity_name": "GNA15",
+        "llm-average": 8.62
+      }
+    ]
   },
   {
     "question_number": 147,
     "qid": 977,
     "text": "List the proteins that are subunits of Spliceosome and are associated with autoimmune disease of eyes, ear, nose and throat.",
     "category": "nervous system disease:sensory system disease",
-    "llm_ranking": "(1) SART1, (2) CD2BP2"
+    "llm_ranking": [
+      {
+        "entity_name": "SART1",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "CD2BP2",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 148,
     "qid": 980,
     "text": "List the proteins that are annotated in the pathway Integrin cell surface interactions and are associated with cystoid macular edema.",
     "category": "nervous system disease:eye disease",
-    "llm_ranking": "(1) THBS1, (2) COL18A1, (3) KDR, (4) ICAM1, (5) ITGAM"
+    "llm_ranking": [
+      {
+        "entity_name": "THBS1",
+        "llm-average": 14.67
+      },
+      {
+        "entity_name": "COL18A1",
+        "llm-average": 9.81
+      },
+      {
+        "entity_name": "KDR",
+        "llm-average": 9.76
+      },
+      {
+        "entity_name": "ICAM1",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "ITGAM",
+        "llm-average": 8.4
+      }
+    ]
   },
   {
     "question_number": 149,
     "qid": 981,
     "text": "List the proteins that are associated with motor peripheral neuropathy and act on TGFBR2.",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) DYNLRB1, (2) RAC2, (3) HSPB8, (4) OCLN, (5) EMP3, (6) IL1B, (7) CTNNB1, (8) EGF"
+    "llm_ranking": [
+      {
+        "entity_name": "DYNLRB1",
+        "llm-average": 18.42
+      },
+      {
+        "entity_name": "RAC2",
+        "llm-average": 15.25
+      },
+      {
+        "entity_name": "HSPB8",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "OCLN",
+        "llm-average": 11.65
+      },
+      {
+        "entity_name": "IL1B",
+        "llm-average": 11.36
+      },
+      {
+        "entity_name": "EMP3",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "CTNNB1",
+        "llm-average": 9.76
+      },
+      {
+        "entity_name": "EGF",
+        "llm-average": 5.78
+      }
+    ]
   },
   {
     "question_number": 150,
     "qid": 983,
     "text": "List the proteins that are associated with acute pancreatitis and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(24:0/20:2(11Z,14Z)/20:4(5Z,8Z,11Z,14Z)).",
     "category": "endocrine system disease:pancreatitis",
-    "llm_ranking": "(1) DGAT1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 151,
     "qid": 985,
     "text": "List the proteins that are curated as interacting with FRAS1 and are associated with amyotrophic lateral sclerosis type 9.",
     "category": "nervous system disease:neurodegenerative disease",
-    "llm_ranking": "(1) GPHA2, (2) ST8SIA4"
+    "llm_ranking": [
+      {
+        "entity_name": "GPHA2",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "ST8SIA4",
+        "llm-average": 8.85
+      }
+    ]
   },
   {
     "question_number": 152,
     "qid": 989,
     "text": "List the proteins that are associated with pulmonary emphysema and act on C8B.",
     "category": "respiratory system disease:lung disease",
-    "llm_ranking": "(1) VTN, (2) CD34"
+    "llm_ranking": [
+      {
+        "entity_name": "VTN",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "CD34",
+        "llm-average": 13.08
+      }
+    ]
   },
   {
     "question_number": 153,
     "qid": 991,
     "text": "List the proteins that are subunits of BHC complex and are associated with lung squamous cell carcinoma.",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) KDM1A, (2) HDAC2, (3) HDAC1"
+    "llm_ranking": [
+      {
+        "entity_name": "KDM1A",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "HDAC2",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "HDAC1",
+        "llm-average": 8.93
+      }
+    ]
   },
   {
     "question_number": 154,
     "qid": 995,
     "text": "List the proteins that are associated with gastric signet ring cell adenocarcinoma and are compiled as interacting with PMPCB.",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) FH, (2) FXN"
+    "llm_ranking": [
+      {
+        "entity_name": "FH",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "FXN",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 155,
     "qid": 1000,
     "text": "List the drugs that are indicated for Lymphoma and have the side effect Proteinuria.",
     "category": "Abnormality of the genitourinary system:Abnormality of the urinary system physiology",
-    "llm_ranking": "(1) 2-Fluoroadenosine, (2) Tacrolimus, (3) Ifosfamide, (4) Acitretin, (5) Fludarabine, (6) Gemcitabine, (7) Mitoxantrone, (8) Methotrexate"
+    "llm_ranking": [
+      {
+        "entity_name": "2-Fluoroadenosine",
+        "llm-average": 16.04
+      },
+      {
+        "entity_name": "Tacrolimus",
+        "llm-average": 11.01
+      },
+      {
+        "entity_name": "Ifosfamide",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "Fludarabine",
+        "llm-average": 9.43
+      },
+      {
+        "entity_name": "Acitretin",
+        "llm-average": 9.34
+      },
+      {
+        "entity_name": "Gemcitabine",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "Mitoxantrone",
+        "llm-average": 7.39
+      },
+      {
+        "entity_name": "Methotrexate",
+        "llm-average": 4.42
+      }
+    ]
   },
   {
     "question_number": 156,
     "qid": 1001,
     "text": "List the drugs that are indicated for Cerebral palsy and interact with Alverine.",
     "category": "Abnormality of the nervous system:Abnormal central motor function",
-    "llm_ranking": "(1) Dantrolene, (2) Cyclobenzaprine, (3) Baclofen, (4) Diazepam"
+    "llm_ranking": [
+      {
+        "entity_name": "Dantrolene",
+        "llm-average": 13.01
+      },
+      {
+        "entity_name": "Cyclobenzaprine",
+        "llm-average": 8.19
+      },
+      {
+        "entity_name": "Baclofen",
+        "llm-average": 7.03
+      },
+      {
+        "entity_name": "Diazepam",
+        "llm-average": 4.66
+      }
+    ]
   },
   {
     "question_number": 157,
     "qid": 1005,
     "text": "List the proteins that are subunits of HNRNPD(p45)-ZFP36L1 complex and are associated with central nervous system disease.",
     "category": "nervous system disease:central nervous system disease",
-    "llm_ranking": "(1) ZFP36L1, (2) HNRNPD"
+    "llm_ranking": [
+      {
+        "entity_name": "ZFP36L1",
+        "llm-average": 11.86
+      },
+      {
+        "entity_name": "HNRNPD",
+        "llm-average": 8.42
+      }
+    ]
   },
   {
     "question_number": 158,
     "qid": 1007,
     "text": "List the proteins that are compiled as interacting with EFNA2 and are associated with constrictive pericarditis.",
     "category": "cardiovascular system disease:pericarditis",
-    "llm_ranking": "(1) FLT4, (2) EPO, (3) ERBB2, (4) VEGFA, (5) FN1"
+    "llm_ranking": [
+      {
+        "entity_name": "FLT4",
+        "llm-average": 14.67
+      },
+      {
+        "entity_name": "EPO",
+        "llm-average": 9.81
+      },
+      {
+        "entity_name": "VEGFA",
+        "llm-average": 9.23
+      },
+      {
+        "entity_name": "ERBB2",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "FN1",
+        "llm-average": 8.93
+      }
+    ]
   },
   {
     "question_number": 159,
     "qid": 1009,
     "text": "List the proteins that are compiled as interacting with SEMA4F and are associated with hypertensive heart disease.",
     "category": "cardiovascular system disease:hypertensive heart disease",
-    "llm_ranking": "(1) ADORA2B, (2) AKT1, (3) RHOA, (4) MYC, (5) VEGFA, (6) FN1, (7) TP53, (8) GAPDH"
+    "llm_ranking": [
+      {
+        "entity_name": "ADORA2B",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "RHOA",
+        "llm-average": 11.55
+      },
+      {
+        "entity_name": "VEGFA",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 10.3
+      },
+      {
+        "entity_name": "FN1",
+        "llm-average": 9.62
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.69
+      },
+      {
+        "entity_name": "GAPDH",
+        "llm-average": 4.02
+      }
+    ]
   },
   {
     "question_number": 160,
     "qid": 1012,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-13:0/i-15:0/i-22:0/i-24:0) and are associated with arteriosclerosis.",
     "category": "cardiovascular system disease:artery disease",
-    "llm_ranking": "(1) GPAM, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 161,
     "qid": 1015,
     "text": "List the drugs that act on CYP20A1 and have the side effect Dysphonia.",
     "category": "Abnormality of the nervous system:Abnormality of higher mental function",
-    "llm_ranking": "(1) Itraconazole, (2) Epitestosterone, (3) Posaconazole, (4) Paroxetine, (5) Testosterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Itraconazole",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "Posaconazole",
+        "llm-average": 10.0
+      },
+      {
+        "entity_name": "Epitestosterone",
+        "llm-average": 9.84
+      },
+      {
+        "entity_name": "Paroxetine",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 4.12
+      }
+    ]
   },
   {
     "question_number": 162,
     "qid": 1017,
     "text": "List the proteins that are associated with fundus dystrophy and act on NFATC2IP.",
     "category": "nervous system disease:eye disease",
-    "llm_ranking": "(1) REL, (2) EP300, (3) RANBP2, (4) ATM"
+    "llm_ranking": [
+      {
+        "entity_name": "REL",
+        "llm-average": 14.61
+      },
+      {
+        "entity_name": "EP300",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "ATM",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "RANBP2",
+        "llm-average": 13.24
+      }
+    ]
   },
   {
     "question_number": 163,
     "qid": 1019,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-13:0/i-22:0/i-14:0/18:2(9Z,11Z)) and are associated with optic atrophy.",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) PTPMT1, (2) CRLS1, (3) GPD1, (4) PGS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 16.95
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 12.39
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 10.3
+      }
+    ]
   },
   {
     "question_number": 164,
     "qid": 1033,
     "text": "List the proteins that are annotated in the pathway Activated point mutants of FGFR2 and are associated with granular cell carcinoma.",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) FGF9, (2) FGF18, (3) FGF3, (4) FGFR2, (5) FGF7, (6) FGF2, (7) FGF1"
+    "llm_ranking": [
+      {
+        "entity_name": "FGF9",
+        "llm-average": 12.84
+      },
+      {
+        "entity_name": "FGF18",
+        "llm-average": 12.1
+      },
+      {
+        "entity_name": "FGFR2",
+        "llm-average": 9.17
+      },
+      {
+        "entity_name": "FGF3",
+        "llm-average": 9.03
+      },
+      {
+        "entity_name": "FGF7",
+        "llm-average": 7.04
+      },
+      {
+        "entity_name": "FGF2",
+        "llm-average": 3.6
+      },
+      {
+        "entity_name": "FGF1",
+        "llm-average": 2.91
+      }
+    ]
   },
   {
     "question_number": 165,
     "qid": 1034,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(a-25:0/a-15:0/16:0) and are associated with sarcoma.",
     "category": "cancer:sarcoma",
-    "llm_ranking": "(1) LPIN1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 166,
     "qid": 1035,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(a-21:0/i-24:0/22:0) and are associated with acute pancreatitis.",
     "category": "endocrine system disease:pancreatitis",
-    "llm_ranking": "(1) DGAT1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 167,
     "qid": 1044,
     "text": "List the proteins that are associated with laryngeal squamous cell carcinoma and are compiled as interacting with WNK2.",
     "category": "cancer:carcinoma",
-    "llm_ranking": "(1) CKAP4, (2) WNK1, (3) UBC"
+    "llm_ranking": [
+      {
+        "entity_name": "CKAP4",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "WNK1",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "UBC",
+        "llm-average": 9.29
+      }
+    ]
   },
   {
     "question_number": 168,
     "qid": 1045,
     "text": "List the proteins that are compiled as interacting with MGAT2 and are associated with pseudobulbar palsy.",
     "category": "nervous system disease:brain disease",
-    "llm_ranking": "(1) SLC35A1, (2) SRD5A3, (3) SLC35C1"
+    "llm_ranking": [
+      {
+        "entity_name": "SLC35A1",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "SRD5A3",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "SLC35C1",
+        "llm-average": 9.28
+      }
+    ]
   },
   {
     "question_number": 169,
     "qid": 1050,
     "text": "List the proteins that are detected in pathology samples of ovarian cancer and are subunits of IL1RAP-IL1RL1-KIT complex.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) IL1RL1, (2) IL1RAP, (3) KIT"
+    "llm_ranking": [
+      {
+        "entity_name": "IL1RL1",
+        "llm-average": 14.3
+      },
+      {
+        "entity_name": "IL1RAP",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "KIT",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 170,
     "qid": 1052,
     "text": "List the drugs that interact with Anastrozole and have the side effect Corneal opacity.",
     "category": "Abnormality of the eye:Abnormal anterior eye segment morphology",
-    "llm_ranking": "(1) Chloroquine, (2) Rabeprazole, (3) Diclofenac, (4) Naproxen"
+    "llm_ranking": [
+      {
+        "entity_name": "Chloroquine",
+        "llm-average": 17.71
+      },
+      {
+        "entity_name": "Rabeprazole",
+        "llm-average": 10.3
+      },
+      {
+        "entity_name": "Diclofenac",
+        "llm-average": 7.36
+      },
+      {
+        "entity_name": "Naproxen",
+        "llm-average": 5.95
+      }
+    ]
   },
   {
     "question_number": 171,
     "qid": 1054,
     "text": "List the drugs that interact with Tocopherylquinone and have the side effect Osteomalacia.",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) Ifosfamide, (2) Carbamazepine"
+    "llm_ranking": [
+      {
+        "entity_name": "Carbamazepine",
+        "llm-average": 9.38
+      },
+      {
+        "entity_name": "Ifosfamide",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 172,
     "qid": 1059,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:1(13Z)/22:5(4Z,7Z,10Z,13Z,16Z)/22:5(7Z,10Z,13Z,16Z,19Z)) and are associated with optic nerve disease.",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) LPIN1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 15.07
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 13.65
+      }
+    ]
   },
   {
     "question_number": 173,
     "qid": 1060,
     "text": "List the proteins that are associated with Alzheimer's disease 14 and are subunits of NOS3-HSP90 complex, VEGF induced.",
     "category": "nervous system disease:neurodegenerative disease",
-    "llm_ranking": "(1) NOS3, (2) HSP90AA1"
+    "llm_ranking": [
+      {
+        "entity_name": "NOS3",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "HSP90AA1",
+        "llm-average": 9.38
+      }
+    ]
   },
   {
     "question_number": 174,
     "qid": 1061,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(14:0/14:0/18:3(9Z,12Z,15Z)) and are associated with cranial nerve disease.",
     "category": "nervous system disease:neuropathy",
-    "llm_ranking": "(1) LPIN1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 15.07
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 13.65
+      }
+    ]
   },
   {
     "question_number": 175,
     "qid": 1111,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of cervical cancer.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) MTOR, (2) MYC, (3) TP53, (4) CRK, (5) GRB2, (6) RPS6KB1, (7) JAK2, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 12.83
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 12.61
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 9.76
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 9.29
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.59
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 6.95
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 5.93
+      }
+    ]
   },
   {
     "question_number": 176,
     "qid": 1125,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with mixed glioma, and are compiled as interacting with RAC3.",
     "category": "cancer:cell type cancer",
-    "llm_ranking": "(1) PIK3R1, (2) SOS1, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 19.25
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 177,
     "qid": 1147,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of head and neck cancer.",
     "category": "cancer:head and neck cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 178,
     "qid": 1213,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of pancreatic cancer.",
     "category": "cancer:endocrine gland cancer",
-    "llm_ranking": "(1) MYC, (2) JAK2, (3) TP53, (4) MTOR, (5) CRK, (6) GRB2, (7) RPS6KB1, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 13.52
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.56
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 6.68
+      }
+    ]
   },
   {
     "question_number": 179,
     "qid": 1259,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of endometrial cancer.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) JAK2, (2) MYC, (3) RPS6KB1, (4) TP53, (5) CRK, (6) MTOR, (7) GRB2, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 15.02
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 9.84
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 9.37
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 8.49
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 7.57
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      }
+    ]
   },
   {
     "question_number": 180,
     "qid": 1279,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of ovarian cancer.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 181,
     "qid": 1282,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of testicular cancer.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) MYC, (2) JAK2, (3) MTOR, (4) TP53, (5) RPS6KB1, (6) CRK, (7) GRB2, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 13.7
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 9.01
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 7.13
+      }
+    ]
   },
   {
     "question_number": 182,
     "qid": 1300,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of endometrial cancer.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 183,
     "qid": 1301,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of testicular cancer.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.63
+      }
+    ]
   },
   {
     "question_number": 184,
     "qid": 1317,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of cervical cancer.",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 185,
     "qid": 1349,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with glomerulosclerosis, and are detected in pathology samples of head and neck cancer.",
     "category": "cancer:head and neck cancer",
-    "llm_ranking": "(1) MYC, (2) JAK2, (3) TP53, (4) MTOR, (5) CRK, (6) GRB2, (7) RPS6KB1, (8) CDKN1B"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 13.52
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.56
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.04
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 6.68
+      }
+    ]
   },
   {
     "question_number": 186,
     "qid": 1497,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are detected in pathology samples of pancreatic cancer.",
     "category": "cancer:endocrine gland cancer",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.11
+      }
+    ]
   },
   {
     "question_number": 187,
     "qid": 248,
     "text": "Which pathways are annotated with EPHB3, which Vatalanib acts on?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) EPH-ephrin mediated repulsion of cells, (2) EPHB-mediated forward signaling, (3) Ephrin signaling, (4) EPH-Ephrin signaling"
+    "llm_ranking": [
+      {
+        "entity_name": "EPH-ephrin mediated repulsion of cells",
+        "llm-average": 9.73
+      },
+      {
+        "entity_name": "EPHB-mediated forward signaling",
+        "llm-average": 5.65
+      },
+      {
+        "entity_name": "Ephrin signaling",
+        "llm-average": 5.13
+      },
+      {
+        "entity_name": "EPH-Ephrin signaling",
+        "llm-average": 2.54
+      }
+    ]
   },
   {
     "question_number": 188,
     "qid": 260,
     "text": "List the proteins that are acted on by Fosfomycin, which Trametinib interacts with.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) MCEE, (2) CRP"
+    "llm_ranking": [
+      {
+        "entity_name": "MCEE",
+        "llm-average": 13.13
+      },
+      {
+        "entity_name": "CRP",
+        "llm-average": 5.89
+      }
+    ]
   },
   {
     "question_number": 189,
     "qid": 273,
     "text": "Which biological processes are associated with EBP that Raloxifene acts on?",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) skeletal system development, (2) cholesterol biosynthetic process via lathosterol, (3) xenobiotic transport, (4) cholesterol biosynthetic process via desmosterol, (5) sterol biosynthetic process, (6) cholesterol biosynthetic process, (7) cholesterol metabolic process"
+    "llm_ranking": [
+      {
+        "entity_name": "skeletal system development",
+        "llm-average": 16.39
+      },
+      {
+        "entity_name": "cholesterol biosynthetic process via lathosterol",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "xenobiotic transport",
+        "llm-average": 10.28
+      },
+      {
+        "entity_name": "cholesterol biosynthetic process via desmosterol",
+        "llm-average": 9.27
+      },
+      {
+        "entity_name": "sterol biosynthetic process",
+        "llm-average": 6.67
+      },
+      {
+        "entity_name": "cholesterol metabolic process",
+        "llm-average": 4.8
+      },
+      {
+        "entity_name": "cholesterol biosynthetic process",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 190,
     "qid": 275,
     "text": "Which proteins are curated as targets of 7,8-Dichloro-1,2,3,4-tetrahydroisoquinoline, which Atomoxetine interacts with?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) PNMT, (2) ADRA2A, (3) ADRA2C, (4) MAOB, (5) MAOA"
+    "llm_ranking": [
+      {
+        "entity_name": "PNMT",
+        "llm-average": 12.64
+      },
+      {
+        "entity_name": "ADRA2A",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "ADRA2C",
+        "llm-average": 6.95
+      },
+      {
+        "entity_name": "MAOA",
+        "llm-average": 6.03
+      },
+      {
+        "entity_name": "MAOB",
+        "llm-average": 5.66
+      }
+    ]
   },
   {
     "question_number": 191,
     "qid": 276,
     "text": "Which proteins are acted on by TMPRSS11D, which Gadodiamide acts on?",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) F2RL1, (2) F2R, (3) F2RL2"
+    "llm_ranking": [
+      {
+        "entity_name": "F2RL1",
+        "llm-average": 7.97
+      },
+      {
+        "entity_name": "F2R",
+        "llm-average": 5.89
+      },
+      {
+        "entity_name": "F2RL2",
+        "llm-average": 5.38
+      }
+    ]
   },
   {
     "question_number": 192,
     "qid": 279,
     "text": "List the proteins that are curated as targets of Adefovir dipivoxil, which Nabumetone interacts with.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) SGCB, (2) CYP2C9, (3) CYP3A4"
+    "llm_ranking": [
+      {
+        "entity_name": "SGCB",
+        "llm-average": 12.57
+      },
+      {
+        "entity_name": "CYP2C9",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "CYP3A4",
+        "llm-average": 5.5
+      }
+    ]
   },
   {
     "question_number": 193,
     "qid": 280,
     "text": "List the proteins that are acted on by Adefovir dipivoxil, which Nabumetone interacts with.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) CYP2C9, (2) CYP3A4"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP2C9",
+        "llm-average": 6.82
+      },
+      {
+        "entity_name": "CYP3A4",
+        "llm-average": 5.65
+      }
+    ]
   },
   {
     "question_number": 194,
     "qid": 281,
     "text": "List the proteins that are acted on by PRSS12, which Gadodiamide acts on.",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) DOCK8, (2) FIBCD1, (3) F2RL2, (4) F2R, (5) CHRNA2, (6) CHRNA4"
+    "llm_ranking": [
+      {
+        "entity_name": "FIBCD1",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "DOCK8",
+        "llm-average": 12.31
+      },
+      {
+        "entity_name": "F2RL2",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "F2R",
+        "llm-average": 9.26
+      },
+      {
+        "entity_name": "CHRNA4",
+        "llm-average": 7.9
+      },
+      {
+        "entity_name": "CHRNA2",
+        "llm-average": 7.83
+      }
+    ]
   },
   {
     "question_number": 195,
     "qid": 285,
     "text": "Which proteins are curated as targets of Tiludronic acid, which Atomoxetine interacts with?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) PTPN1, (2) ATP6V1A, (3) MMP27, (4) MMP13, (5) MMP8, (6) MMP3, (7) MMP1, (8) MMP10"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPN1",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "ATP6V1A",
+        "llm-average": 12.22
+      },
+      {
+        "entity_name": "MMP13",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "MMP27",
+        "llm-average": 8.92
+      },
+      {
+        "entity_name": "MMP8",
+        "llm-average": 6.01
+      },
+      {
+        "entity_name": "MMP3",
+        "llm-average": 2.78
+      },
+      {
+        "entity_name": "MMP1",
+        "llm-average": 2.07
+      },
+      {
+        "entity_name": "MMP10",
+        "llm-average": 1.55
+      }
+    ]
   },
   {
     "question_number": 196,
     "qid": 297,
     "text": "List the proteins that are acted on by Cabazitaxel, which Trametinib interacts with.",
     "category": "Abnormality of the genitourinary system:Abnormal reproductive system morphology",
-    "llm_ranking": "(1) TUBB1, (2) TUBA4A, (3) AR"
+    "llm_ranking": [
+      {
+        "entity_name": "TUBA4A",
+        "llm-average": 11.53
+      },
+      {
+        "entity_name": "TUBB1",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "AR",
+        "llm-average": 9.38
+      }
+    ]
   },
   {
     "question_number": 197,
     "qid": 301,
     "text": "List the pathways that are annotated with PDGFRB, which is compiled as a target of Pazopanib.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) PIP3 activates AKT signaling, (2) PI5P, PP2A and IER3 Regulate PI3K/AKT Signaling, (3) Constitutive Signaling by Aberrant PI3K in Cancer, (4) Signaling by PDGF, (5) RAF/MAP kinase cascade, (6) Downstream signal transduction"
+    "llm_ranking": [
+      {
+        "entity_name": "PIP3 activates AKT signaling",
+        "llm-average": 12.57
+      },
+      {
+        "entity_name": "PI5P, PP2A and IER3 Regulate PI3K/AKT Signaling",
+        "llm-average": 12.24
+      },
+      {
+        "entity_name": "Constitutive Signaling by Aberrant PI3K in Cancer",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Signaling by PDGF",
+        "llm-average": 10.19
+      },
+      {
+        "entity_name": "RAF/MAP kinase cascade",
+        "llm-average": 6.03
+      },
+      {
+        "entity_name": "Downstream signal transduction",
+        "llm-average": 3.44
+      }
+    ]
   },
   {
     "question_number": 198,
     "qid": 306,
     "text": "List the pathways that are annotated with CYP2A7, which is compiled as a target of Fluconazole.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) CYP2E1 reactions, (2) Xenobiotics, (3) Vitamin A Deficiency, (4) Retinol Metabolism, (5) Fatty acids"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP2E1 reactions",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "Xenobiotics",
+        "llm-average": 11.35
+      },
+      {
+        "entity_name": "Vitamin A Deficiency",
+        "llm-average": 6.54
+      },
+      {
+        "entity_name": "Retinol Metabolism",
+        "llm-average": 5.65
+      },
+      {
+        "entity_name": "Fatty acids",
+        "llm-average": 0.78
+      }
+    ]
   },
   {
     "question_number": 199,
     "qid": 307,
     "text": "List the proteins that are curated as targets of Fenproporex, which Nabumetone interacts with.",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) CYP2B6, (2) CYP3A4, (3) CYP2D6, (4) CYP1A2"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP2B6",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "CYP3A4",
+        "llm-average": 5.91
+      },
+      {
+        "entity_name": "CYP2D6",
+        "llm-average": 5.39
+      },
+      {
+        "entity_name": "CYP1A2",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 200,
     "qid": 311,
     "text": "Which proteins are acted on by CYP8B1, which is compiled as a target of Fluconazole?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) MAFG, (2) TBXAS1, (3) CYP17A1, (4) CYP21A2, (5) CYP2R1, (6) INS"
+    "llm_ranking": [
+      {
+        "entity_name": "MAFG",
+        "llm-average": 14.88
+      },
+      {
+        "entity_name": "CYP17A1",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "TBXAS1",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CYP21A2",
+        "llm-average": 5.17
+      },
+      {
+        "entity_name": "CYP2R1",
+        "llm-average": 4.66
+      },
+      {
+        "entity_name": "INS",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 201,
     "qid": 325,
     "text": "Which proteins are acted on by Paramethadione, which Atomoxetine interacts with?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) CACNA1I, (2) CACNA1G"
+    "llm_ranking": [
+      {
+        "entity_name": "CACNA1I",
+        "llm-average": 9.4
+      },
+      {
+        "entity_name": "CACNA1G",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 202,
     "qid": 333,
     "text": "List the proteins that are curated as targets of Nalidixic acid, which Atomoxetine interacts with.",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) TOP2A, (2) TOP2B, (3) NPL"
+    "llm_ranking": [
+      {
+        "entity_name": "TOP2A",
+        "llm-average": 13.29
+      },
+      {
+        "entity_name": "TOP2B",
+        "llm-average": 12.12
+      },
+      {
+        "entity_name": "NPL",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 203,
     "qid": 334,
     "text": "Which genes are curated as targets of Erdafitinib, which Nabumetone interacts with?",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) fibroblast growth factor receptor 3, (2) epidermal growth factor receptor, (3) fibroblast growth factor receptor 2, (4) KRAS proto-oncogene, GTPase, (5) fibroblast growth factor receptor 4, (6) fibroblast growth factor receptor 1, (7) kinase insert domain receptor"
+    "llm_ranking": [
+      {
+        "entity_name": "fibroblast growth factor receptor 3",
+        "llm-average": 14.83
+      },
+      {
+        "entity_name": "fibroblast growth factor receptor 2",
+        "llm-average": 12.89
+      },
+      {
+        "entity_name": "fibroblast growth factor receptor 1",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "epidermal growth factor receptor",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "fibroblast growth factor receptor 4",
+        "llm-average": 12.26
+      },
+      {
+        "entity_name": "KRAS proto-oncogene, GTPase",
+        "llm-average": 11.96
+      },
+      {
+        "entity_name": "kinase insert domain receptor",
+        "llm-average": 8.21
+      }
+    ]
   },
   {
     "question_number": 204,
     "qid": 335,
     "text": "List the proteins that are acted on by CYP2A7, which is compiled as a target of Fluconazole.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) CYP2D6, (2) CYP1A2, (3) CYP4V2, (4) ACSF3, (5) R3HDM4"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP2D6",
+        "llm-average": 12.37
+      },
+      {
+        "entity_name": "CYP1A2",
+        "llm-average": 7.97
+      },
+      {
+        "entity_name": "CYP4V2",
+        "llm-average": 6.16
+      },
+      {
+        "entity_name": "ACSF3",
+        "llm-average": 3.83
+      },
+      {
+        "entity_name": "R3HDM4",
+        "llm-average": 2.66
+      }
+    ]
   },
   {
     "question_number": 205,
     "qid": 355,
     "text": "Which proteins are acted on by MST1, which Streptozocin acts on?",
     "category": "Abnormality of the nervous system:Abnormal peripheral nervous system morphology",
-    "llm_ranking": "(1) ITGAM, (2) VEGFA, (3) AKT1"
+    "llm_ranking": [
+      {
+        "entity_name": "ITGAM",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "VEGFA",
+        "llm-average": 13.78
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 9.12
+      }
+    ]
   },
   {
     "question_number": 206,
     "qid": 373,
     "text": "List the pathways that are annotated with TRPC5, which is compiled as a target of Gadodiamide.",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) TRP channels, (2) Role of second messengers in netrin-1 signaling"
+    "llm_ranking": [
+      {
+        "entity_name": "TRP channels",
+        "llm-average": 13.47
+      },
+      {
+        "entity_name": "Role of second messengers in netrin-1 signaling",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 207,
     "qid": 380,
     "text": "Which proteins are acted on by Hexobarbital, which Atomoxetine interacts with?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) CHRFAM7A, (2) CYP2C19, (3) GRIK2, (4) GABRA4, (5) CHRNA4, (6) GABRA5, (7) GABRA6"
+    "llm_ranking": [
+      {
+        "entity_name": "CHRFAM7A",
+        "llm-average": 17.53
+      },
+      {
+        "entity_name": "CYP2C19",
+        "llm-average": 16.51
+      },
+      {
+        "entity_name": "GRIK2",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "GABRA4",
+        "llm-average": 10.57
+      },
+      {
+        "entity_name": "GABRA5",
+        "llm-average": 8.88
+      },
+      {
+        "entity_name": "CHRNA4",
+        "llm-average": 8.74
+      },
+      {
+        "entity_name": "GABRA6",
+        "llm-average": 7.56
+      }
+    ]
   },
   {
     "question_number": 208,
     "qid": 2,
     "text": "Which proteins are compiled as targets of Lisdexamfetamine?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) WTAP, (2) ADRA1B, (3) SLC6A3"
+    "llm_ranking": [
+      {
+        "entity_name": "WTAP",
+        "llm-average": 14.97
+      },
+      {
+        "entity_name": "ADRA1B",
+        "llm-average": 13.22
+      },
+      {
+        "entity_name": "SLC6A3",
+        "llm-average": 9.14
+      }
+    ]
   },
   {
     "question_number": 209,
     "qid": 3,
     "text": "Which phenotypes is Sitagliptin indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Type II diabetes mellitus, (2) Pancreatitis, (3) Renal insufficiency, (4) Reactive hypoglycemia, (5) Diabetic ketoacidosis, (6) Type I diabetes mellitus, (7) Hypoglycemia"
+    "llm_ranking": [
+      {
+        "entity_name": "Type II diabetes mellitus",
+        "llm-average": 12.21
+      },
+      {
+        "entity_name": "Pancreatitis",
+        "llm-average": 9.43
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 7.47
+      },
+      {
+        "entity_name": "Reactive hypoglycemia",
+        "llm-average": 6.78
+      },
+      {
+        "entity_name": "Diabetic ketoacidosis",
+        "llm-average": 5.31
+      },
+      {
+        "entity_name": "Type I diabetes mellitus",
+        "llm-average": 1.94
+      },
+      {
+        "entity_name": "Hypoglycemia",
+        "llm-average": 1.24
+      }
+    ]
   },
   {
     "question_number": 210,
     "qid": 8,
     "text": "What phenotypes is Goserelin indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormal reproductive system morphology",
-    "llm_ranking": "(1) Uterine leiomyoma, (2) Endometriosis, (3) Prostate cancer, (4) Metrorrhagia, (5) Menorrhagia, (6) Anemia, (7) Neoplasm, (8) Pain"
+    "llm_ranking": [
+      {
+        "entity_name": "Uterine leiomyoma",
+        "llm-average": 11.41
+      },
+      {
+        "entity_name": "Endometriosis",
+        "llm-average": 11.08
+      },
+      {
+        "entity_name": "Prostate cancer",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "Metrorrhagia",
+        "llm-average": 9.44
+      },
+      {
+        "entity_name": "Menorrhagia",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "Anemia",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 6.26
+      },
+      {
+        "entity_name": "Pain",
+        "llm-average": 2.86
+      }
+    ]
   },
   {
     "question_number": 211,
     "qid": 13,
     "text": "List the phenotypes that Bleomycin are indicated for.",
     "category": "Abnormality of the genitourinary system:Abnormality of the genital system",
-    "llm_ranking": "(1) Pleural effusion, (2) Choriocarcinoma, (3) Squamous cell carcinoma, (4) Hodgkin lymphoma, (5) Lymphoma, (6) Non-Hodgkin lymphoma, (7) Neoplasm"
+    "llm_ranking": [
+      {
+        "entity_name": "Pleural effusion",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "Choriocarcinoma",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Squamous cell carcinoma",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Hodgkin lymphoma",
+        "llm-average": 6.97
+      },
+      {
+        "entity_name": "Lymphoma",
+        "llm-average": 6.08
+      },
+      {
+        "entity_name": "Non-Hodgkin lymphoma",
+        "llm-average": 5.53
+      },
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 2.33
+      }
+    ]
   },
   {
     "question_number": 212,
     "qid": 14,
     "text": "Which genes are curated as targets of Glipizide?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) ATP binding cassette subfamily C member 8, (2) potassium inwardly rectifying channel subfamily J member 11, (3) potassium inwardly rectifying channel subfamily J member 10, (4) potassium inwardly rectifying channel subfamily J member 1, (5) glucose-6-phosphate dehydrogenase, (6) solute carrier family 2 member 4"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP binding cassette subfamily C member 8",
+        "llm-average": 15.52
+      },
+      {
+        "entity_name": "potassium inwardly rectifying channel subfamily J member 11",
+        "llm-average": 14.97
+      },
+      {
+        "entity_name": "potassium inwardly rectifying channel subfamily J member 10",
+        "llm-average": 12.47
+      },
+      {
+        "entity_name": "potassium inwardly rectifying channel subfamily J member 1",
+        "llm-average": 11.94
+      },
+      {
+        "entity_name": "glucose-6-phosphate dehydrogenase",
+        "llm-average": 11.09
+      },
+      {
+        "entity_name": "solute carrier family 2 member 4",
+        "llm-average": 11.06
+      }
+    ]
   },
   {
     "question_number": 213,
     "qid": 15,
     "text": "Which phenotypes is Dabrafenib indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Cutaneous melanoma, (2) Renal insufficiency, (3) Pneumonia, (4) Abnormal pulmonary Interstitial morphology"
+    "llm_ranking": [
+      {
+        "entity_name": "Cutaneous melanoma",
+        "llm-average": 13.09
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 7.27
+      },
+      {
+        "entity_name": "Abnormal pulmonary Interstitial morphology",
+        "llm-average": 4.96
+      },
+      {
+        "entity_name": "Pneumonia",
+        "llm-average": 4.27
+      }
+    ]
   },
   {
     "question_number": 214,
     "qid": 17,
     "text": "List the genes that are curated as targets of Leflunomide.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) dihydroorotate dehydrogenase (quinone), (2) C-X-C motif chemokine ligand 8, (3) matrix metallopeptidase 1"
+    "llm_ranking": [
+      {
+        "entity_name": "dihydroorotate dehydrogenase (quinone)",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "C-X-C motif chemokine ligand 8",
+        "llm-average": 9.63
+      },
+      {
+        "entity_name": "matrix metallopeptidase 1",
+        "llm-average": 8.22
+      }
+    ]
   },
   {
     "question_number": 215,
     "qid": 19,
     "text": "What phenotypes is Temozolomide indicated for?",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) Glioblastoma multiforme, (2) Astrocytoma, (3) Glioma, (4) Cutaneous melanoma, (5) Neoplasm"
+    "llm_ranking": [
+      {
+        "entity_name": "Glioblastoma multiforme",
+        "llm-average": 17.85
+      },
+      {
+        "entity_name": "Astrocytoma",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "Glioma",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Cutaneous melanoma",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 2.5
+      }
+    ]
   },
   {
     "question_number": 216,
     "qid": 23,
     "text": "What phenotypes is gamma-Hydroxybutyric acid indicated for?",
     "category": "Abnormality of the nervous system:Abnormal central motor function",
-    "llm_ranking": "(1) Narcolepsy, (2) Cataplexy"
+    "llm_ranking": [
+      {
+        "entity_name": "Narcolepsy",
+        "llm-average": 10.37
+      },
+      {
+        "entity_name": "Cataplexy",
+        "llm-average": 9.99
+      }
+    ]
   },
   {
     "question_number": 217,
     "qid": 24,
     "text": "List the phenotypes that Isocarboxazid are indicated for.",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Agitation, (2) Hypersomnia, (3) Insomnia, (4) Anxiety, (5) Fatigue"
+    "llm_ranking": [
+      {
+        "entity_name": "Agitation",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "Hypersomnia",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "Insomnia",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "Anxiety",
+        "llm-average": 6.26
+      },
+      {
+        "entity_name": "Fatigue",
+        "llm-average": 6.06
+      }
+    ]
   },
   {
     "question_number": 218,
     "qid": 27,
     "text": "What phenotypes is Tapentadol indicated for?",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) Low back pain, (2) Chronic pain, (3) Osteoarthritis, (4) Pain"
+    "llm_ranking": [
+      {
+        "entity_name": "Low back pain",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "Chronic pain",
+        "llm-average": 8.59
+      },
+      {
+        "entity_name": "Osteoarthritis",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Pain",
+        "llm-average": 4.83
+      }
+    ]
   },
   {
     "question_number": 219,
     "qid": 28,
     "text": "Which genes are curated as targets of Glimepiride?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) potassium inwardly rectifying channel subfamily J member 11, (2) ATP binding cassette subfamily C member 8, (3) potassium inwardly rectifying channel subfamily J member 1, (4) cholecystokinin A receptor, (5) insulin receptor substrate 1, (6) glucose-6-phosphate dehydrogenase, (7) tumor necrosis factor"
+    "llm_ranking": [
+      {
+        "entity_name": "potassium inwardly rectifying channel subfamily J member 11",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "ATP binding cassette subfamily C member 8",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "potassium inwardly rectifying channel subfamily J member 1",
+        "llm-average": 13.92
+      },
+      {
+        "entity_name": "cholecystokinin A receptor",
+        "llm-average": 11.42
+      },
+      {
+        "entity_name": "insulin receptor substrate 1",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "glucose-6-phosphate dehydrogenase",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "tumor necrosis factor",
+        "llm-average": 5.36
+      }
+    ]
   },
   {
     "question_number": 220,
     "qid": 31,
     "text": "List the diseases of which CALCA serve as a biomarker.",
     "category": "cancer:None",
-    "llm_ranking": "(1) cancer, (2) thyroid gland disease"
+    "llm_ranking": [
+      {
+        "entity_name": "cancer",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "thyroid gland disease",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 221,
     "qid": 33,
     "text": "Which genes are curated as targets of Itraconazole?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) high mobility group box 1, (2) NAD(P)H quinone dehydrogenase 1, (3) luteinizing hormone/choriogonadotropin receptor, (4) interleukin 2, (5) ATP binding cassette subfamily G member 2 (Junior blood group), (6) ATP binding cassette subfamily B member 1"
+    "llm_ranking": [
+      {
+        "entity_name": "high mobility group box 1",
+        "llm-average": 18.56
+      },
+      {
+        "entity_name": "NAD(P)H quinone dehydrogenase 1",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "luteinizing hormone/choriogonadotropin receptor",
+        "llm-average": 13.74
+      },
+      {
+        "entity_name": "interleukin 2",
+        "llm-average": 13.19
+      },
+      {
+        "entity_name": "ATP binding cassette subfamily G member 2 (Junior blood group)",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "ATP binding cassette subfamily B member 1",
+        "llm-average": 10.72
+      }
+    ]
   },
   {
     "question_number": 222,
     "qid": 35,
     "text": "Which phenotypes is Fosphenytoin indicated for?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) Status epilepticus, (2) Seizure, (3) Encephalopathy, (4) Psychosis, (5) Confusion, (6) Elevated hepatic transaminase, (7) Hyperglycemia"
+    "llm_ranking": [
+      {
+        "entity_name": "Status epilepticus",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "Seizure",
+        "llm-average": 18.05
+      },
+      {
+        "entity_name": "Encephalopathy",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "Psychosis",
+        "llm-average": 5.69
+      },
+      {
+        "entity_name": "Confusion",
+        "llm-average": 5.35
+      },
+      {
+        "entity_name": "Elevated hepatic transaminase",
+        "llm-average": 2.67
+      },
+      {
+        "entity_name": "Hyperglycemia",
+        "llm-average": 0.17
+      }
+    ]
   },
   {
     "question_number": 223,
     "qid": 36,
     "text": "What phenotypes is Tetrabenazine indicated for?",
     "category": "Abnormality of the nervous system:Abnormality of movement",
-    "llm_ranking": "(1) Tardive dyskinesia, (2) Hemiballismus, (3) Chorea, (4) Abnormality of movement"
+    "llm_ranking": [
+      {
+        "entity_name": "Tardive dyskinesia",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "Hemiballismus",
+        "llm-average": 9.63
+      },
+      {
+        "entity_name": "Chorea",
+        "llm-average": 8.06
+      },
+      {
+        "entity_name": "Abnormality of movement",
+        "llm-average": 3.05
+      }
+    ]
   },
   {
     "question_number": 224,
     "qid": 38,
     "text": "What genes is Cholecalciferol curated to target?",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) glutamate metabotropic receptor 2, (2) Fas cell surface death receptor, (3) Fc fragment of IgG receptor IIIb, (4) vitamin D receptor"
+    "llm_ranking": [
+      {
+        "entity_name": "glutamate metabotropic receptor 2",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "Fas cell surface death receptor",
+        "llm-average": 14.1
+      },
+      {
+        "entity_name": "Fc fragment of IgG receptor IIIb",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "vitamin D receptor",
+        "llm-average": 9.15
+      }
+    ]
   },
   {
     "question_number": 225,
     "qid": 40,
     "text": "Which phenotypes is Haloperidol indicated for?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Hyperkinetic movements, (2) Behavioral abnormality, (3) Mood changes, (4) Schizophrenia, (5) Psychosis"
+    "llm_ranking": [
+      {
+        "entity_name": "Hyperkinetic movements",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "Behavioral abnormality",
+        "llm-average": 9.63
+      },
+      {
+        "entity_name": "Mood changes",
+        "llm-average": 8.72
+      },
+      {
+        "entity_name": "Schizophrenia",
+        "llm-average": 8.06
+      },
+      {
+        "entity_name": "Psychosis",
+        "llm-average": 8.05
+      }
+    ]
   },
   {
     "question_number": 226,
     "qid": 42,
     "text": "List the genes that are curated as targets of Oxaprozin.",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) carnitine palmitoyltransferase 2, (2) prostaglandin-endoperoxide synthase 1, (3) prostaglandin-endoperoxide synthase 2"
+    "llm_ranking": [
+      {
+        "entity_name": "carnitine palmitoyltransferase 2",
+        "llm-average": 13.74
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 1",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 2",
+        "llm-average": 8.06
+      }
+    ]
   },
   {
     "question_number": 227,
     "qid": 45,
     "text": "Which phenotypes is Citric acid indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Gout, (2) Nephrolithiasis, (3) Renal tubular acidosis, (4) Nephropathy, (5) Agitation, (6) Metabolic acidosis, (7) Alkalosis, (8) Acidosis"
+    "llm_ranking": [
+      {
+        "entity_name": "Gout",
+        "llm-average": 16.42
+      },
+      {
+        "entity_name": "Nephrolithiasis",
+        "llm-average": 16.41
+      },
+      {
+        "entity_name": "Nephropathy",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "Renal tubular acidosis",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "Agitation",
+        "llm-average": 6.76
+      },
+      {
+        "entity_name": "Metabolic acidosis",
+        "llm-average": 6.26
+      },
+      {
+        "entity_name": "Alkalosis",
+        "llm-average": 5.35
+      },
+      {
+        "entity_name": "Acidosis",
+        "llm-average": 4.12
+      }
+    ]
   },
   {
     "question_number": 228,
     "qid": 48,
     "text": "Which phenotypes is Clorazepic acid indicated for?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) Focal-onset seizure, (2) Anxiety, (3) Seizure"
+    "llm_ranking": [
+      {
+        "entity_name": "Focal-onset seizure",
+        "llm-average": 9.99
+      },
+      {
+        "entity_name": "Anxiety",
+        "llm-average": 8.6
+      },
+      {
+        "entity_name": "Seizure",
+        "llm-average": 7.14
+      }
+    ]
   },
   {
     "question_number": 229,
     "qid": 52,
     "text": "List the diseases of which ALPL serve as a biomarker.",
     "category": "cancer:None",
-    "llm_ranking": "(1) hepatic veno-occlusive disease, (2) cancer, (3) liver disease"
+    "llm_ranking": [
+      {
+        "entity_name": "hepatic veno-occlusive disease",
+        "llm-average": 13.18
+      },
+      {
+        "entity_name": "cancer",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "liver disease",
+        "llm-average": 10.73
+      }
+    ]
   },
   {
     "question_number": 230,
     "qid": 56,
     "text": "What phenotypes is Glipizide indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Type II diabetes mellitus, (2) Nephropathy, (3) Peripheral neuropathy, (4) Ketosis, (5) Hyperglycemia, (6) Obesity, (7) Diabetes mellitus, (8) Type I diabetes mellitus"
+    "llm_ranking": [
+      {
+        "entity_name": "Type II diabetes mellitus",
+        "llm-average": 13.6
+      },
+      {
+        "entity_name": "Nephropathy",
+        "llm-average": 10.66
+      },
+      {
+        "entity_name": "Peripheral neuropathy",
+        "llm-average": 10.13
+      },
+      {
+        "entity_name": "Ketosis",
+        "llm-average": 8.16
+      },
+      {
+        "entity_name": "Obesity",
+        "llm-average": 7.63
+      },
+      {
+        "entity_name": "Hyperglycemia",
+        "llm-average": 7.34
+      },
+      {
+        "entity_name": "Diabetes mellitus",
+        "llm-average": 6.28
+      },
+      {
+        "entity_name": "Type I diabetes mellitus",
+        "llm-average": 5.68
+      }
+    ]
   },
   {
     "question_number": 231,
     "qid": 64,
     "text": "What diseases is ALPL a biomarker of?",
     "category": "cancer:None",
-    "llm_ranking": "(1) hepatic veno-occlusive disease, (2) cancer, (3) liver disease"
+    "llm_ranking": [
+      {
+        "entity_name": "hepatic veno-occlusive disease",
+        "llm-average": 13.18
+      },
+      {
+        "entity_name": "cancer",
+        "llm-average": 10.21
+      },
+      {
+        "entity_name": "liver disease",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 232,
     "qid": 65,
     "text": "What phenotypes is Linagliptin indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Type II diabetes mellitus, (2) Renal insufficiency, (3) Pancreatitis, (4) Diabetic ketoacidosis, (5) Type I diabetes mellitus"
+    "llm_ranking": [
+      {
+        "entity_name": "Type II diabetes mellitus",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "Pancreatitis",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "Diabetic ketoacidosis",
+        "llm-average": 5.69
+      },
+      {
+        "entity_name": "Type I diabetes mellitus",
+        "llm-average": 4.27
+      }
+    ]
   },
   {
     "question_number": 233,
     "qid": 67,
     "text": "List the diseases of which LDHA serve as a biomarker.",
     "category": "cancer:None",
-    "llm_ranking": "(1) cancer, (2) ischemia"
+    "llm_ranking": [
+      {
+        "entity_name": "cancer",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "ischemia",
+        "llm-average": 7.14
+      }
+    ]
   },
   {
     "question_number": 234,
     "qid": 70,
     "text": "Which phenotypes is Aztreonam indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the lower urinary tract",
-    "llm_ranking": "(1) Pyelonephritis, (2) Recurrent lower respiratory tract infections, (3) Meningitis, (4) Sepsis, (5) Peritonitis, (6) Pneumonia, (7) Urinary bladder inflammation, (8) Bronchitis"
+    "llm_ranking": [
+      {
+        "entity_name": "Pyelonephritis",
+        "llm-average": 12.51
+      },
+      {
+        "entity_name": "Recurrent lower respiratory tract infections",
+        "llm-average": 11.46
+      },
+      {
+        "entity_name": "Meningitis",
+        "llm-average": 11.42
+      },
+      {
+        "entity_name": "Sepsis",
+        "llm-average": 9.84
+      },
+      {
+        "entity_name": "Peritonitis",
+        "llm-average": 7.86
+      },
+      {
+        "entity_name": "Pneumonia",
+        "llm-average": 5.9
+      },
+      {
+        "entity_name": "Urinary bladder inflammation",
+        "llm-average": 5.52
+      },
+      {
+        "entity_name": "Bronchitis",
+        "llm-average": 3.94
+      }
+    ]
   },
   {
     "question_number": 235,
     "qid": 76,
     "text": "What genes is Trimethadione curated to target?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) calcium voltage-gated channel subunit alpha1 H, (2) calcium voltage-gated channel subunit alpha1 I, (3) calcium voltage-gated channel subunit alpha1 G"
+    "llm_ranking": [
+      {
+        "entity_name": "calcium voltage-gated channel subunit alpha1 H",
+        "llm-average": 11.61
+      },
+      {
+        "entity_name": "calcium voltage-gated channel subunit alpha1 I",
+        "llm-average": 10.0
+      },
+      {
+        "entity_name": "calcium voltage-gated channel subunit alpha1 G",
+        "llm-average": 9.99
+      }
+    ]
   },
   {
     "question_number": 236,
     "qid": 84,
     "text": "Which diseases have AFP as a biomarker?",
     "category": "cancer:None",
-    "llm_ranking": "(1) testicular cancer, (2) liver cancer, (3) cancer"
+    "llm_ranking": [
+      {
+        "entity_name": "testicular cancer",
+        "llm-average": 17.33
+      },
+      {
+        "entity_name": "liver cancer",
+        "llm-average": 12.86
+      },
+      {
+        "entity_name": "cancer",
+        "llm-average": 5.55
+      }
+    ]
   },
   {
     "question_number": 237,
     "qid": 87,
     "text": "List the phenotypes that Alendronic acid are indicated for.",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Osteopenia, (2) Generalized osteoporosis, (3) Vertebral compression fractures, (4) Neoplasm, (5) Abnormality of the gastrointestinal tract, (6) Renal insufficiency, (7) Peptic ulcer"
+    "llm_ranking": [
+      {
+        "entity_name": "Osteopenia",
+        "llm-average": 14.1
+      },
+      {
+        "entity_name": "Generalized osteoporosis",
+        "llm-average": 12.87
+      },
+      {
+        "entity_name": "Vertebral compression fractures",
+        "llm-average": 12.86
+      },
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 11.74
+      },
+      {
+        "entity_name": "Abnormality of the gastrointestinal tract",
+        "llm-average": 5.89
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 4.99
+      },
+      {
+        "entity_name": "Peptic ulcer",
+        "llm-average": 4.64
+      }
+    ]
   },
   {
     "question_number": 238,
     "qid": 93,
     "text": "List the phenotypes that D-arginine are indicated for.",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) Acrocyanosis, (2) Growth hormone excess, (3) Craniopharyngioma, (4) Panhypopituitarism, (5) Pituitary dwarfism"
+    "llm_ranking": [
+      {
+        "entity_name": "Acrocyanosis",
+        "llm-average": 10.66
+      },
+      {
+        "entity_name": "Growth hormone excess",
+        "llm-average": 9.43
+      },
+      {
+        "entity_name": "Craniopharyngioma",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "Panhypopituitarism",
+        "llm-average": 4.63
+      },
+      {
+        "entity_name": "Pituitary dwarfism",
+        "llm-average": 4.47
+      }
+    ]
   },
   {
     "question_number": 239,
     "qid": 97,
     "text": "Which phenotypes is Sorbitol indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Fructose intolerance, (2) Cerebral edema, (3) Ocular hypertension, (4) Asthma, (5) Acute kidney injury"
+    "llm_ranking": [
+      {
+        "entity_name": "Fructose intolerance",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "Cerebral edema",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "Ocular hypertension",
+        "llm-average": 9.27
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 4.83
+      },
+      {
+        "entity_name": "Acute kidney injury",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 240,
     "qid": 98,
     "text": "Which phenotypes is Tetracycline indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Recurrent lower respiratory tract infections, (2) Renal insufficiency"
+    "llm_ranking": [
+      {
+        "entity_name": "Recurrent lower respiratory tract infections",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 241,
     "qid": 102,
     "text": "Which phenotypes is Folic acid indicated for?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) Megaloblastic anemia, (2) Reduced blood folate concentration, (3) Gluten intolerance, (4) Seizure, (5) Anemia"
+    "llm_ranking": [
+      {
+        "entity_name": "Reduced blood folate concentration",
+        "llm-average": 8.94
+      },
+      {
+        "entity_name": "Megaloblastic anemia",
+        "llm-average": 8.79
+      },
+      {
+        "entity_name": "Gluten intolerance",
+        "llm-average": 8.35
+      },
+      {
+        "entity_name": "Seizure",
+        "llm-average": 6.4
+      },
+      {
+        "entity_name": "Anemia",
+        "llm-average": 4.83
+      }
+    ]
   },
   {
     "question_number": 242,
     "qid": 103,
     "text": "List the phenotypes that Cyclobenzaprine are indicated for.",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) Cerebral palsy, (2) Hyperkinetic movements, (3) Spasticity, (4) Myelopathy, (5) Pain, (6) Morphological central nervous system abnormality"
+    "llm_ranking": [
+      {
+        "entity_name": "Cerebral palsy",
+        "llm-average": 12.49
+      },
+      {
+        "entity_name": "Hyperkinetic movements",
+        "llm-average": 12.47
+      },
+      {
+        "entity_name": "Spasticity",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "Myelopathy",
+        "llm-average": 9.27
+      },
+      {
+        "entity_name": "Pain",
+        "llm-average": 6.98
+      },
+      {
+        "entity_name": "Morphological central nervous system abnormality",
+        "llm-average": 4.63
+      }
+    ]
   },
   {
     "question_number": 243,
     "qid": 106,
     "text": "Which phenotypes is Alendronic acid indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Vertebral compression fractures, (2) Neoplasm, (3) Generalized osteoporosis, (4) Osteopenia, (5) Renal insufficiency, (6) Abnormality of the gastrointestinal tract, (7) Peptic ulcer"
+    "llm_ranking": [
+      {
+        "entity_name": "Vertebral compression fractures",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 10.13
+      },
+      {
+        "entity_name": "Generalized osteoporosis",
+        "llm-average": 8.43
+      },
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 7.99
+      },
+      {
+        "entity_name": "Osteopenia",
+        "llm-average": 7.7
+      },
+      {
+        "entity_name": "Abnormality of the gastrointestinal tract",
+        "llm-average": 5.35
+      },
+      {
+        "entity_name": "Peptic ulcer",
+        "llm-average": 4.81
+      }
+    ]
   },
   {
     "question_number": 244,
     "qid": 107,
     "text": "Which phenotypes is Solifenacin indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the lower urinary tract",
-    "llm_ranking": "(1) Pollakisuria, (2) Urinary urgency"
+    "llm_ranking": [
+      {
+        "entity_name": "Pollakisuria",
+        "llm-average": 7.51
+      },
+      {
+        "entity_name": "Urinary urgency",
+        "llm-average": 7.14
+      }
+    ]
   },
   {
     "question_number": 245,
     "qid": 120,
     "text": "What phenotypes is Ethosuximide indicated for?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) Typical absence seizure, (2) Seizure"
+    "llm_ranking": [
+      {
+        "entity_name": "Typical absence seizure",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "Seizure",
+        "llm-average": 3.75
+      }
+    ]
   },
   {
     "question_number": 246,
     "qid": 123,
     "text": "What diseases is LDHA a biomarker of?",
     "category": "cancer:None",
-    "llm_ranking": "(1) cancer, (2) ischemia"
+    "llm_ranking": [
+      {
+        "entity_name": "cancer",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "ischemia",
+        "llm-average": 7.14
+      }
+    ]
   },
   {
     "question_number": 247,
     "qid": 126,
     "text": "List the proteins that are compiled as targets of Pralidoxime.",
     "category": "Abnormality of the musculoskeletal system:Abnormal muscle physiology",
-    "llm_ranking": "(1) ACVR1, (2) TTK, (3) PON1, (4) ACVRL1, (5) ACHE, (6) BCHE"
+    "llm_ranking": [
+      {
+        "entity_name": "TTK",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "ACVR1",
+        "llm-average": 12.3
+      },
+      {
+        "entity_name": "PON1",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "ACVRL1",
+        "llm-average": 10.51
+      },
+      {
+        "entity_name": "ACHE",
+        "llm-average": 9.49
+      },
+      {
+        "entity_name": "BCHE",
+        "llm-average": 7.86
+      }
+    ]
   },
   {
     "question_number": 248,
     "qid": 130,
     "text": "What phenotypes is Nizatidine indicated for?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Renal insufficiency, (2) Duodenal ulcer, (3) Gastric ulcer, (4) Gastroesophageal reflux, (5) Esophagitis"
+    "llm_ranking": [
+      {
+        "entity_name": "Renal insufficiency",
+        "llm-average": 13.54
+      },
+      {
+        "entity_name": "Duodenal ulcer",
+        "llm-average": 9.63
+      },
+      {
+        "entity_name": "Gastric ulcer",
+        "llm-average": 8.56
+      },
+      {
+        "entity_name": "Gastroesophageal reflux",
+        "llm-average": 7.87
+      },
+      {
+        "entity_name": "Esophagitis",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 249,
     "qid": 133,
     "text": "Which phenotypes is Vilazodone indicated for?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Increased body weight, (2) Agitation, (3) Hypersomnia, (4) Fatigue, (5) Insomnia"
+    "llm_ranking": [
+      {
+        "entity_name": "Increased body weight",
+        "llm-average": 10.31
+      },
+      {
+        "entity_name": "Agitation",
+        "llm-average": 8.19
+      },
+      {
+        "entity_name": "Hypersomnia",
+        "llm-average": 6.91
+      },
+      {
+        "entity_name": "Fatigue",
+        "llm-average": 3.55
+      },
+      {
+        "entity_name": "Insomnia",
+        "llm-average": 1.24
+      }
+    ]
   },
   {
     "question_number": 250,
     "qid": 135,
     "text": "Which genes are curated as targets of Phentermine?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) N-acetyltransferase 1, (2) solute carrier family 6 member 2, (3) solute carrier family 6 member 3, (4) solute carrier family 6 member 4"
+    "llm_ranking": [
+      {
+        "entity_name": "N-acetyltransferase 1",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "solute carrier family 6 member 2",
+        "llm-average": 10.36
+      },
+      {
+        "entity_name": "solute carrier family 6 member 3",
+        "llm-average": 7.86
+      },
+      {
+        "entity_name": "solute carrier family 6 member 4",
+        "llm-average": 6.8
+      }
+    ]
   },
   {
     "question_number": 251,
     "qid": 136,
     "text": "List the diseases of which AFP serve as a biomarker.",
     "category": "cancer:None",
-    "llm_ranking": "(1) testicular cancer, (2) liver cancer, (3) cancer"
+    "llm_ranking": [
+      {
+        "entity_name": "testicular cancer",
+        "llm-average": 17.33
+      },
+      {
+        "entity_name": "liver cancer",
+        "llm-average": 12.86
+      },
+      {
+        "entity_name": "cancer",
+        "llm-average": 5.55
+      }
+    ]
   },
   {
     "question_number": 252,
     "qid": 139,
     "text": "Which diseases have ALPL as a biomarker?",
     "category": "cancer:None",
-    "llm_ranking": "(1) hepatic veno-occlusive disease, (2) cancer, (3) liver disease"
+    "llm_ranking": [
+      {
+        "entity_name": "hepatic veno-occlusive disease",
+        "llm-average": 13.18
+      },
+      {
+        "entity_name": "cancer",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "liver disease",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 253,
     "qid": 146,
     "text": "Which phenotypes is Lurasidone indicated for?",
     "category": "Abnormality of the nervous system:Abnormality of higher mental function",
-    "llm_ranking": "(1) Schizophrenia, (2) Bipolar affective disorder, (3) Mania, (4) Dementia"
+    "llm_ranking": [
+      {
+        "entity_name": "Schizophrenia",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "Bipolar affective disorder",
+        "llm-average": 13.94
+      },
+      {
+        "entity_name": "Mania",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Dementia",
+        "llm-average": 2.67
+      }
+    ]
   },
   {
     "question_number": 254,
     "qid": 151,
     "text": "List the genes that are curated as targets of Phentermine.",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) N-acetyltransferase 1, (2) solute carrier family 6 member 4, (3) solute carrier family 6 member 2, (4) solute carrier family 6 member 3"
+    "llm_ranking": [
+      {
+        "entity_name": "N-acetyltransferase 1",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "solute carrier family 6 member 4",
+        "llm-average": 14.81
+      },
+      {
+        "entity_name": "solute carrier family 6 member 2",
+        "llm-average": 10.72
+      },
+      {
+        "entity_name": "solute carrier family 6 member 3",
+        "llm-average": 10.35
+      }
+    ]
   },
   {
     "question_number": 255,
     "qid": 156,
     "text": "What drugs are indicated for Menorrhagia?",
     "category": "Abnormality of the genitourinary system:Abnormality of reproductive system physiology",
-    "llm_ranking": "(1) Tranexamic acid, (2) Danazol, (3) Desmopressin, (4) Mefenamic acid, (5) Levonorgestrel, (6) Goserelin"
+    "llm_ranking": [
+      {
+        "entity_name": "Tranexamic acid",
+        "llm-average": 15.44
+      },
+      {
+        "entity_name": "Danazol",
+        "llm-average": 13.3
+      },
+      {
+        "entity_name": "Desmopressin",
+        "llm-average": 12.99
+      },
+      {
+        "entity_name": "Mefenamic acid",
+        "llm-average": 11.71
+      },
+      {
+        "entity_name": "Levonorgestrel",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Goserelin",
+        "llm-average": 10.29
+      }
+    ]
   },
   {
     "question_number": 256,
     "qid": 158,
     "text": "What proteins are biomarkers of the disease cardiovascular system disease?",
     "category": "cardiovascular system disease:None",
-    "llm_ranking": "(1) TNNI3, (2) TNNT2, (3) NPPB"
+    "llm_ranking": [
+      {
+        "entity_name": "TNNI3",
+        "llm-average": 15.44
+      },
+      {
+        "entity_name": "TNNT2",
+        "llm-average": 14.46
+      },
+      {
+        "entity_name": "NPPB",
+        "llm-average": 10.49
+      }
+    ]
   },
   {
     "question_number": 257,
     "qid": 159,
     "text": "What drugs are indicated for Photophobia?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Sumatriptan, (2) Almotriptan, (3) Diclofenac, (4) Acetylsalicylic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Sumatriptan",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "Almotriptan",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "Diclofenac",
+        "llm-average": 7.1
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 4.33
+      }
+    ]
   },
   {
     "question_number": 258,
     "qid": 161,
     "text": "What proteins are biomarkers of the disease pituitary gland disease?",
     "category": "endocrine system disease:pituitary gland disease",
-    "llm_ranking": "(1) INHBA, (2) TRH, (3) IGF1, (4) FSHB, (5) SHBG, (6) PRL"
+    "llm_ranking": [
+      {
+        "entity_name": "INHBA",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "TRH",
+        "llm-average": 9.81
+      },
+      {
+        "entity_name": "IGF1",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "FSHB",
+        "llm-average": 7.65
+      },
+      {
+        "entity_name": "SHBG",
+        "llm-average": 7.35
+      },
+      {
+        "entity_name": "PRL",
+        "llm-average": 6.44
+      }
+    ]
   },
   {
     "question_number": 259,
     "qid": 164,
     "text": "What drugs have FUS as a compiled target?",
     "category": "Abnormality of the nervous system:Morphological central nervous system abnormality",
-    "llm_ranking": "(1) Riluzole, (2) Gadoteridol, (3) Gadodiamide"
+    "llm_ranking": [
+      {
+        "entity_name": "Riluzole",
+        "llm-average": 10.58
+      },
+      {
+        "entity_name": "Gadoteridol",
+        "llm-average": 9.6
+      },
+      {
+        "entity_name": "Gadodiamide",
+        "llm-average": 9.03
+      }
+    ]
   },
   {
     "question_number": 260,
     "qid": 168,
     "text": "What drugs are indicated for Abnormality of extrapyramidal motor function?",
     "category": "Abnormality of the nervous system:Abnormal central motor function",
-    "llm_ranking": "(1) Olanzapine, (2) Quetiapine, (3) Trihexyphenidyl, (4) Benzatropine"
+    "llm_ranking": [
+      {
+        "entity_name": "Olanzapine",
+        "llm-average": 12.22
+      },
+      {
+        "entity_name": "Quetiapine",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "Trihexyphenidyl",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Benzatropine",
+        "llm-average": 9.83
+      }
+    ]
   },
   {
     "question_number": 261,
     "qid": 169,
     "text": "What drugs have natriuretic peptide receptor 2 as a curated target?",
     "category": "Abnormality of the genitourinary system:Abnormality of reproductive system physiology",
-    "llm_ranking": "(1) Nesiritide, (2) Erythrityl tetranitrate, (3) Ketoprofen"
+    "llm_ranking": [
+      {
+        "entity_name": "Nesiritide",
+        "llm-average": 17.92
+      },
+      {
+        "entity_name": "Erythrityl tetranitrate",
+        "llm-average": 11.68
+      },
+      {
+        "entity_name": "Ketoprofen",
+        "llm-average": 4.33
+      }
+    ]
   },
   {
     "question_number": 262,
     "qid": 173,
     "text": "What drugs are indicated for Excessive daytime somnolence?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Mirtazapine, (2) Valproic acid, (3) Gabapentin"
+    "llm_ranking": [
+      {
+        "entity_name": "Mirtazapine",
+        "llm-average": 8.58
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 5.74
+      },
+      {
+        "entity_name": "Gabapentin",
+        "llm-average": 5.71
+      }
+    ]
   },
   {
     "question_number": 263,
     "qid": 174,
     "text": "What drugs are indicated for Stillbirth?",
     "category": "Age of death:Stillbirth",
-    "llm_ranking": "(1) Mifepristone, (2) Dinoprost tromethamine, (3) Dinoprostone, (4) Cabergoline, (5) Bromocriptine"
+    "llm_ranking": [
+      {
+        "entity_name": "Mifepristone",
+        "llm-average": 14.31
+      },
+      {
+        "entity_name": "Dinoprost tromethamine",
+        "llm-average": 10.52
+      },
+      {
+        "entity_name": "Dinoprostone",
+        "llm-average": 9.96
+      },
+      {
+        "entity_name": "Cabergoline",
+        "llm-average": 8.9
+      },
+      {
+        "entity_name": "Bromocriptine",
+        "llm-average": 5.71
+      }
+    ]
   },
   {
     "question_number": 264,
     "qid": 181,
     "text": "What drugs are indicated for Agoraphobia?",
     "category": "Abnormality of the nervous system:Behavioral abnormality",
-    "llm_ranking": "(1) Venlafaxine, (2) Paroxetine, (3) (S)-Fluoxetine, (4) (R)-Fluoxetine, (5) Fluoxetine, (6) Clonazepam, (7) Sertraline, (8) Alprazolam"
+    "llm_ranking": [
+      {
+        "entity_name": "Venlafaxine",
+        "llm-average": 13.1
+      },
+      {
+        "entity_name": "Paroxetine",
+        "llm-average": 12.66
+      },
+      {
+        "entity_name": "(S)-Fluoxetine",
+        "llm-average": 11.68
+      },
+      {
+        "entity_name": "(R)-Fluoxetine",
+        "llm-average": 11.12
+      },
+      {
+        "entity_name": "Fluoxetine",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Sertraline",
+        "llm-average": 10.11
+      },
+      {
+        "entity_name": "Clonazepam",
+        "llm-average": 10.08
+      },
+      {
+        "entity_name": "Alprazolam",
+        "llm-average": 9.4
+      }
+    ]
   },
   {
     "question_number": 265,
     "qid": 183,
     "text": "What drugs are indicated for Encephalopathy?",
     "category": "Abnormality of the nervous system:Encephalopathy",
-    "llm_ranking": "(1) (3-Carboxy-2-(R)-Hydroxy-Propyl)-Trimethyl-Ammonium, (2) Thiamine, (3) Edetic acid, (4) Ifosfamide, (5) Levocarnitine, (6) Magnesium cation, (7) Fosphenytoin, (8) Minoxidil"
+    "llm_ranking": [
+      {
+        "entity_name": "(3-Carboxy-2-(R)-Hydroxy-Propyl)-Trimethyl-Ammonium",
+        "llm-average": 19.1
+      },
+      {
+        "entity_name": "Thiamine",
+        "llm-average": 15.58
+      },
+      {
+        "entity_name": "Edetic acid",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "Ifosfamide",
+        "llm-average": 13.2
+      },
+      {
+        "entity_name": "Levocarnitine",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 10.39
+      },
+      {
+        "entity_name": "Fosphenytoin",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Minoxidil",
+        "llm-average": 5.81
+      }
+    ]
   },
   {
     "question_number": 266,
     "qid": 186,
     "text": "What drugs are indicated for Tetany?",
     "category": "Abnormality of the musculoskeletal system:Abnormal muscle physiology",
-    "llm_ranking": "(1) Calcium, (2) Magnesium cation, (3) Magnesium sulfate, (4) Erythromycin"
+    "llm_ranking": [
+      {
+        "entity_name": "Calcium",
+        "llm-average": 18.9
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 15.44
+      },
+      {
+        "entity_name": "Magnesium sulfate",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "Erythromycin",
+        "llm-average": 1.25
+      }
+    ]
   },
   {
     "question_number": 267,
     "qid": 187,
     "text": "What drugs are indicated for Nephrolithiasis?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Topiramate, (2) Citric acid, (3) Norfloxacin"
+    "llm_ranking": [
+      {
+        "entity_name": "Topiramate",
+        "llm-average": 17.52
+      },
+      {
+        "entity_name": "Citric acid",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Norfloxacin",
+        "llm-average": 4.52
+      }
+    ]
   },
   {
     "question_number": 268,
     "qid": 189,
     "text": "What drugs are indicated for Cryptorchidism?",
     "category": "Abnormality of the genitourinary system:Abnormal reproductive system morphology",
-    "llm_ranking": "(1) Fluoxymesterone, (2) Epitestosterone, (3) Methyltestosterone, (4) Testosterone"
+    "llm_ranking": [
+      {
+        "entity_name": "Fluoxymesterone",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "Epitestosterone",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "Methyltestosterone",
+        "llm-average": 9.2
+      },
+      {
+        "entity_name": "Testosterone",
+        "llm-average": 8.38
+      }
+    ]
   },
   {
     "question_number": 269,
     "qid": 190,
     "text": "What drugs have mitochondrially encoded NADH:ubiquinone oxidoreductase core subunit 1 as a curated target?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) Sevoflurane, (2) Desflurane, (3) Enflurane"
+    "llm_ranking": [
+      {
+        "entity_name": "Desflurane",
+        "llm-average": 12.35
+      },
+      {
+        "entity_name": "Sevoflurane",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "Enflurane",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 270,
     "qid": 201,
     "text": "What drugs are indicated for Retinopathy?",
     "category": "Abnormality of the eye:Abnormal posterior eye segment morphology",
-    "llm_ranking": "(1) Epicaptopril, (2) Captopril, (3) Atorvastatin, (4) Minoxidil, (5) Repaglinide, (6) Glimepiride"
+    "llm_ranking": [
+      {
+        "entity_name": "Epicaptopril",
+        "llm-average": 14.52
+      },
+      {
+        "entity_name": "Captopril",
+        "llm-average": 11.61
+      },
+      {
+        "entity_name": "Atorvastatin",
+        "llm-average": 11.31
+      },
+      {
+        "entity_name": "Minoxidil",
+        "llm-average": 9.89
+      },
+      {
+        "entity_name": "Repaglinide",
+        "llm-average": 6.27
+      },
+      {
+        "entity_name": "Glimepiride",
+        "llm-average": 5.71
+      }
+    ]
   },
   {
     "question_number": 271,
     "qid": 208,
     "text": "What drugs are indicated for Chronic kidney disease?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Cinacalcet, (2) Ramipril, (3) Sevelamer, (4) Paricalcitol, (5) Ezetimibe, (6) Hydrochlorothiazide"
+    "llm_ranking": [
+      {
+        "entity_name": "Cinacalcet",
+        "llm-average": 15.38
+      },
+      {
+        "entity_name": "Ramipril",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Sevelamer",
+        "llm-average": 14.06
+      },
+      {
+        "entity_name": "Paricalcitol",
+        "llm-average": 13.72
+      },
+      {
+        "entity_name": "Ezetimibe",
+        "llm-average": 13.06
+      },
+      {
+        "entity_name": "Hydrochlorothiazide",
+        "llm-average": 6.99
+      }
+    ]
   },
   {
     "question_number": 272,
     "qid": 214,
     "text": "What drugs have deoxycytidine kinase as a curated target?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) Cladribine, (2) Fludarabine, (3) Camptothecin, (4) 2'-Deoxycytidine"
+    "llm_ranking": [
+      {
+        "entity_name": "Cladribine",
+        "llm-average": 14.17
+      },
+      {
+        "entity_name": "Fludarabine",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "Camptothecin",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "2'-Deoxycytidine",
+        "llm-average": 7.55
+      }
+    ]
   },
   {
     "question_number": 273,
     "qid": 215,
     "text": "What drugs act on AGRP?",
     "category": "Abnormality of the nervous system:Abnormal peripheral nervous system morphology",
-    "llm_ranking": "(1) Streptozocin, (2) Rosiglitazone"
+    "llm_ranking": [
+      {
+        "entity_name": "Streptozocin",
+        "llm-average": 10.77
+      },
+      {
+        "entity_name": "Rosiglitazone",
+        "llm-average": 10.02
+      }
+    ]
   },
   {
     "question_number": 274,
     "qid": 222,
     "text": "What drugs are indicated for Typical absence seizure?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) Ethosuximide, (2) Trimethadione, (3) Methsuximide, (4) Valproic acid, (5) Clonazepam, (6) Acetazolamide, (7) Carbamazepine"
+    "llm_ranking": [
+      {
+        "entity_name": "Ethosuximide",
+        "llm-average": 14.29
+      },
+      {
+        "entity_name": "Trimethadione",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "Methsuximide",
+        "llm-average": 11.68
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 9.83
+      },
+      {
+        "entity_name": "Clonazepam",
+        "llm-average": 8.9
+      },
+      {
+        "entity_name": "Acetazolamide",
+        "llm-average": 7.91
+      },
+      {
+        "entity_name": "Carbamazepine",
+        "llm-average": 3.14
+      }
+    ]
   },
   {
     "question_number": 275,
     "qid": 229,
     "text": "What drugs are indicated for Iritis?",
     "category": "Abnormality of the eye:Abnormal uvea morphology",
-    "llm_ranking": "(1) Hydroxy-Phenyl-Acetic Acid 8-Methyl-8-Aza-Bicyclo[3.2.1]Oct-3-Yl Ester, (2) Travoprost, (3) Dexamethasone, (4) Prednisolone, (5) Betamethasone, (6) Methylprednisolone, (7) Prednisone, (8) Hydrocortisone"
+    "llm_ranking": [
+      {
+        "entity_name": "Hydroxy-Phenyl-Acetic Acid 8-Methyl-8-Aza-Bicyclo[3.2.1]Oct-3-Yl Ester",
+        "llm-average": 18.9
+      },
+      {
+        "entity_name": "Travoprost",
+        "llm-average": 10.88
+      },
+      {
+        "entity_name": "Dexamethasone",
+        "llm-average": 8.25
+      },
+      {
+        "entity_name": "Prednisolone",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "Betamethasone",
+        "llm-average": 5.94
+      },
+      {
+        "entity_name": "Prednisone",
+        "llm-average": 5.72
+      },
+      {
+        "entity_name": "Methylprednisolone",
+        "llm-average": 5.71
+      },
+      {
+        "entity_name": "Hydrocortisone",
+        "llm-average": 4.45
+      }
+    ]
   },
   {
     "question_number": 276,
     "qid": 230,
     "text": "What drugs have 4-aminobutyrate aminotransferase as a curated target?",
     "category": "Abnormality of the nervous system:Seizure",
-    "llm_ranking": "(1) Vigabatrin, (2) Valproic acid, (3) Tiagabine, (4) Pyridoxal phosphate, (5) Pyruvic acid, (6) Alanine"
+    "llm_ranking": [
+      {
+        "entity_name": "Vigabatrin",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 16.54
+      },
+      {
+        "entity_name": "Tiagabine",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "Pyridoxal phosphate",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "Pyruvic acid",
+        "llm-average": 6.37
+      },
+      {
+        "entity_name": "Alanine",
+        "llm-average": 4.55
+      }
+    ]
   },
   {
     "question_number": 277,
     "qid": 390,
     "text": "Which genes are curated as targets of Citric acid, which acts on ABCF1 that is curated as interacting with PCSK4?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 1, (2) polycystin 2 like 1, transient receptor potential cation channel, (3) cholinergic receptor muscarinic 4, (4) sigma non-opioid intracellular receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "polycystin 2 like 1, transient receptor potential cation channel",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 4",
+        "llm-average": 7.92
+      },
+      {
+        "entity_name": "sigma non-opioid intracellular receptor 1",
+        "llm-average": 7.1
+      }
+    ]
   },
   {
     "question_number": 278,
     "qid": 393,
     "text": "Which pathways are annotated with GPR31, which acts on ADORA1 that is detected in pathology samples of head and neck cancer?",
     "category": "cancer:head and neck cancer",
-    "llm_ranking": "(1) G alpha (i) signalling events, (2) Free fatty acid receptors"
+    "llm_ranking": [
+      {
+        "entity_name": "Free fatty acid receptors",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "G alpha (i) signalling events",
+        "llm-average": 6.63
+      }
+    ]
   },
   {
     "question_number": 279,
     "qid": 396,
     "text": "Which biological processes are associated with ADGRG5, which is curated as interacting with ACVR1B that is detected in pathology samples of cervical cancer?",
     "category": "cancer:reproductive organ cancer",
-    "llm_ranking": "(1) adenylate cyclase-activating G protein-coupled receptor signaling pathway, (2) G protein-coupled receptor signaling pathway, (3) cell surface receptor signaling pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "adenylate cyclase-activating G protein-coupled receptor signaling pathway",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "G protein-coupled receptor signaling pathway",
+        "llm-average": 5.64
+      },
+      {
+        "entity_name": "cell surface receptor signaling pathway",
+        "llm-average": 4.32
+      }
+    ]
   },
   {
     "question_number": 280,
     "qid": 397,
     "text": "Which biological processes are associated with GPR31, which acts on ADORA1 that is detected in pathology samples of head and neck cancer?",
     "category": "cancer:head and neck cancer",
-    "llm_ranking": "(1) negative regulation of inflammatory response, (2) response to acidic pH, (3) response to molecule of bacterial origin, (4) G protein-coupled receptor signaling pathway, (5) lipid metabolic process"
+    "llm_ranking": [
+      {
+        "entity_name": "negative regulation of inflammatory response",
+        "llm-average": 12.67
+      },
+      {
+        "entity_name": "response to acidic pH",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "response to molecule of bacterial origin",
+        "llm-average": 11.32
+      },
+      {
+        "entity_name": "G protein-coupled receptor signaling pathway",
+        "llm-average": 7.95
+      },
+      {
+        "entity_name": "lipid metabolic process",
+        "llm-average": 5.81
+      }
+    ]
   },
   {
     "question_number": 281,
     "qid": 410,
     "text": "Which genes are curated as targets of Acyclovir, which acts on HAAO that is annotated in pathway Disulfiram Action Pathway?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) ABL proto-oncogene 1, non-receptor tyrosine kinase, (2) interleukin 10, (3) solute carrier family 15 member 1, (4) DNA nucleotidylexotransferase"
+    "llm_ranking": [
+      {
+        "entity_name": "ABL proto-oncogene 1, non-receptor tyrosine kinase",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "interleukin 10",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "solute carrier family 15 member 1",
+        "llm-average": 9.31
+      },
+      {
+        "entity_name": "DNA nucleotidylexotransferase",
+        "llm-average": 4.46
+      }
+    ]
   },
   {
     "question_number": 282,
     "qid": 417,
     "text": "Which genes are curated as targets of Citric acid, which acts on AMZ1 that is curated as interacting with CYFIP1?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 1, (2) polycystin 2 like 1, transient receptor potential cation channel, (3) cholinergic receptor muscarinic 4, (4) sigma non-opioid intracellular receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "polycystin 2 like 1, transient receptor potential cation channel",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 4",
+        "llm-average": 7.52
+      },
+      {
+        "entity_name": "sigma non-opioid intracellular receptor 1",
+        "llm-average": 6.7
+      }
+    ]
   },
   {
     "question_number": 283,
     "qid": 419,
     "text": "Which biological processes are associated with PGAM4, which acts on ENO2 that is the biomarker of disease cancer?",
     "category": "cancer:None",
-    "llm_ranking": "(1) positive regulation of flagellated sperm motility, (2) glycolytic process"
+    "llm_ranking": [
+      {
+        "entity_name": "positive regulation of flagellated sperm motility",
+        "llm-average": 15.74
+      },
+      {
+        "entity_name": "glycolytic process",
+        "llm-average": 5.21
+      }
+    ]
   },
   {
     "question_number": 284,
     "qid": 430,
     "text": "Which genes are curated as targets of Ketamine, which acts on AGT that is annotated in pathway Quinapril Action Pathway?",
     "category": "Abnormality of the eye:Glaucoma",
-    "llm_ranking": "(1) glutamate ionotropic receptor NMDA type subunit 2C, (2) glutamate ionotropic receptor NMDA type subunit 2B, (3) glutamate ionotropic receptor NMDA type subunit 2A, (4) glutamate ionotropic receptor NMDA type subunit 3A"
+    "llm_ranking": [
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
+        "llm-average": 15.51
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
+        "llm-average": 13.66
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
+        "llm-average": 12.87
+      },
+      {
+        "entity_name": "glutamate ionotropic receptor NMDA type subunit 3A",
+        "llm-average": 10.5
+      }
+    ]
   },
   {
     "question_number": 285,
     "qid": 433,
     "text": "Which biological processes are associated with UQCRC1, which acts on APOBEC3D that is detected in pathology samples of pancreatic cancer?",
     "category": "cancer:endocrine gland cancer",
-    "llm_ranking": "(1) oxidative phosphorylation, (2) mitochondrial electron transport, ubiquinol to cytochrome c, (3) aerobic respiration, (4) response to activity, (5) response to alkaloid"
+    "llm_ranking": [
+      {
+        "entity_name": "response to activity",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "response to alkaloid",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "oxidative phosphorylation",
+        "llm-average": 8.15
+      },
+      {
+        "entity_name": "mitochondrial electron transport, ubiquinol to cytochrome c",
+        "llm-average": 7.0
+      },
+      {
+        "entity_name": "aerobic respiration",
+        "llm-average": 5.91
+      }
+    ]
   },
   {
     "question_number": 286,
     "qid": 438,
     "text": "Which genes are curated as targets of Citric acid, which acts on ACOT12 that is curated as interacting with ACOT7?",
     "category": "Abnormality of the genitourinary system:Abnormality of the upper urinary tract",
-    "llm_ranking": "(1) cholinergic receptor muscarinic 1, (2) polycystin 2 like 1, transient receptor potential cation channel, (3) sigma non-opioid intracellular receptor 1, (4) cholinergic receptor muscarinic 4"
+    "llm_ranking": [
+      {
+        "entity_name": "cholinergic receptor muscarinic 1",
+        "llm-average": 11.75
+      },
+      {
+        "entity_name": "polycystin 2 like 1, transient receptor potential cation channel",
+        "llm-average": 10.1
+      },
+      {
+        "entity_name": "sigma non-opioid intracellular receptor 1",
+        "llm-average": 7.69
+      },
+      {
+        "entity_name": "cholinergic receptor muscarinic 4",
+        "llm-average": 6.44
+      }
+    ]
   },
   {
     "question_number": 287,
     "qid": 440,
     "text": "Which genes are curated as targets of Afimoxifene, which acts on PGRMC1 that is the subunit of PGRMC1-SCAP complex?",
     "category": "Abnormality of the genitourinary system:Abnormality of reproductive system physiology",
-    "llm_ranking": "(1) estrogen receptor 2, (2) estrogen receptor 1, (3) fibroblast growth factor receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "estrogen receptor 2",
+        "llm-average": 14.16
+      },
+      {
+        "entity_name": "estrogen receptor 1",
+        "llm-average": 12.08
+      },
+      {
+        "entity_name": "fibroblast growth factor receptor 1",
+        "llm-average": 4.32
+      }
+    ]
   },
   {
     "question_number": 288,
     "qid": 441,
     "text": "Which genes are curated as targets of Piroxicam, which acts on PPP2R1B that is curated as interacting with CDK1?",
     "category": "Abnormality of the musculoskeletal system:Abnormality of skeletal morphology",
-    "llm_ranking": "(1) phospholipase A2 group IIA, (2) carnitine palmitoyltransferase 2, (3) gamma-glutamyltransferase 1, (4) cytochrome P450 family 2 subfamily C member 9, (5) prostaglandin-endoperoxide synthase 2, (6) prostaglandin-endoperoxide synthase 1"
+    "llm_ranking": [
+      {
+        "entity_name": "phospholipase A2 group IIA",
+        "llm-average": 13.17
+      },
+      {
+        "entity_name": "carnitine palmitoyltransferase 2",
+        "llm-average": 9.7
+      },
+      {
+        "entity_name": "gamma-glutamyltransferase 1",
+        "llm-average": 9.34
+      },
+      {
+        "entity_name": "cytochrome P450 family 2 subfamily C member 9",
+        "llm-average": 7.69
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 2",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "prostaglandin-endoperoxide synthase 1",
+        "llm-average": 4.49
+      }
+    ]
   },
   {
     "question_number": 289,
     "qid": 445,
     "text": "Which pathways are annotated with MYO3B, which acts on ACTG2 that is detected in pathology samples of pancreatic cancer?",
     "category": "cancer:endocrine gland cancer",
-    "llm_ranking": "(1) Sensory processing of sound by outer hair cells of the cochlea, (2) Sensory processing of sound by inner hair cells of the cochlea"
+    "llm_ranking": [
+      {
+        "entity_name": "Sensory processing of sound by outer hair cells of the cochlea",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Sensory processing of sound by inner hair cells of the cochlea",
+        "llm-average": 8.02
+      }
+    ]
   }
 ]

--- a/lib/batches/batch5.ts
+++ b/lib/batches/batch5.ts
@@ -6,2022 +6,6467 @@ export const batch5: Question[] = [
     "qid": 566,
     "text": "Which proteins act on PHC2, which is annotated in pathway SUMOylation of chromatin organization proteins and is associated with bone disease?",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CBX7, (2) L3MBTL2, (3) SCML2, (4) MAPK14, (5) PCGF1, (6) RBX1"
+    "llm_ranking": [
+      {
+        "entity_name": "CBX7",
+        "llm-average": 15.42
+      },
+      {
+        "entity_name": "L3MBTL2",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "SCML2",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "MAPK14",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "PCGF1",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "RBX1",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 2,
     "qid": 571,
     "text": "Which drugs have SUPT6H as a compiled target, which is annotated in pathway RNA Polymerase II Pre-transcription Events and is associated with legume allergy?",
     "category": "immune system disease:gastrointestinal allergy",
-    "llm_ranking": "(1) Bufotenine, (2) 2-(N-morpholino)ethanesulfonic acid, (3) Balsalazide, (4) Meropenem, (5) Succinic acid, (6) Acetic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Bufotenine",
+        "llm-average": 12.94
+      },
+      {
+        "entity_name": "2-(N-morpholino)ethanesulfonic acid",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "Balsalazide",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Meropenem",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Succinic acid",
+        "llm-average": 8.1
+      },
+      {
+        "entity_name": "Acetic acid",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 3,
     "qid": 578,
     "text": "Which drugs act on TRA2B, which is annotated in pathway RHOBTB1 GTPase cycle and is associated with type 2 diabetes mellitus?",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) Ethinylestradiol, (2) Cyclosporine, (3) Acetylsalicylic acid"
+    "llm_ranking": [
+      {
+        "entity_name": "Ethinylestradiol",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Acetylsalicylic acid",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 4,
     "qid": 580,
     "text": "Which drugs act on ITGA11, which is annotated in pathway Integrin cell surface interactions and is associated with ovarian disease?",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) Dasatinib, (2) Cyclosporine, (3) Valproic acid, (4) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "Dasatinib",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 4.97
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 2.22
+      }
+    ]
   },
   {
     "question_number": 5,
     "qid": 583,
     "text": "Which drugs have TFDP2 as a compiled target, which is annotated in pathway Oncogene Induced Senescence and is associated with ovarian disease?",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) ATP, (2) Dihydrogenphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 7.06
+      }
+    ]
   },
   {
     "question_number": 6,
     "qid": 584,
     "text": "Which proteins are curated as interacting with TDGF1, which is annotated in pathway Signaling by NODAL and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) GPC1, (2) FBLN1, (3) FARSA, (4) AP2S1"
+    "llm_ranking": [
+      {
+        "entity_name": "GPC1",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "FBLN1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "FARSA",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "AP2S1",
+        "llm-average": 8.89
+      }
+    ]
   },
   {
     "question_number": 7,
     "qid": 587,
     "text": "Which drugs have RPS7 as a compiled target, which is annotated in pathway SRP-dependent cotranslational protein targeting to membrane and is associated with Griscelli syndrome type 2?",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) N\u03b1-[(2S)-2-{[(S)-[(1S)-1-{[(Benzyloxy)carbonyl]amino}-2-phenylethyl](hydroxy)phosphoryl]methyl}-5-phenylpentanoyl]-L-tryptophanamide, (2) Guanosine-5'-Triphosphate, (3) ATP, (4) Guanosine-5'-Diphosphate, (5) Magnesium cation, (6) Zinc, (7) Dihydrogenphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "N\u03b1-[(2S)-2-{[(S)-[(1S)-1-{[(Benzyloxy)carbonyl]amino}-2-phenylethyl](hydroxy)phosphoryl]methyl}-5-phenylpentanoyl]-L-tryptophanamide",
+        "llm-average": 18.43
+      },
+      {
+        "entity_name": "Guanosine-5'-Triphosphate",
+        "llm-average": 9.54
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 7.45
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate",
+        "llm-average": 6.14
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 3.4
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 2.88
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 2.75
+      }
+    ]
   },
   {
     "question_number": 8,
     "qid": 597,
     "text": "Which drugs have NUP188 as a compiled target, which is annotated in pathway SUMOylation of chromatin organization proteins and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) 7-methyl-5'-guanylic acid, (2) Guanosine-5'-Triphosphate, (3) Fructose -6-Phosphate, (4) D-glucitol 6-phosphate, (5) Beta-D-Glucose, (6) D-Allopyranose, (7) ATP"
+    "llm_ranking": [
+      {
+        "entity_name": "7-methyl-5'-guanylic acid",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Guanosine-5'-Triphosphate",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "Fructose -6-Phosphate",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "D-glucitol 6-phosphate",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "Beta-D-Glucose",
+        "llm-average": 5.1
+      },
+      {
+        "entity_name": "D-Allopyranose",
+        "llm-average": 4.97
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 4.05
+      }
+    ]
   },
   {
     "question_number": 9,
     "qid": 601,
     "text": "Which drugs act on CACNG3, which is annotated in pathway Trafficking of AMPA receptors and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) ATP, (2) Dihydrogenphosphate, (3) Calcium"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 3.79
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 3.66
+      }
+    ]
   },
   {
     "question_number": 10,
     "qid": 607,
     "text": "Which proteins are curated as interacting with GMPPB, which is annotated in pathway Fructosuria and is associated with bone disease?",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) TXNDC5, (2) GMPPA"
+    "llm_ranking": [
+      {
+        "entity_name": "TXNDC5",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "GMPPA",
+        "llm-average": 9.67
+      }
+    ]
   },
   {
     "question_number": 11,
     "qid": 608,
     "text": "Which functional regions are found in protein FLRT2, which is annotated in pathway Downstream signaling of activated FGFR1 and is associated with type 2 diabetes mellitus?",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) Leucine rich repeat C-terminal domain, (2) Leucine rich repeat"
+    "llm_ranking": [
+      {
+        "entity_name": "Leucine rich repeat C-terminal domain",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "Leucine rich repeat",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 12,
     "qid": 615,
     "text": "Which drugs act on ADAMTSL5, which is associated with geleophysic dysplasia and is compiled as interacting with NTN4?",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) Doramapimod, (2) Bisphenol A"
+    "llm_ranking": [
+      {
+        "entity_name": "Doramapimod",
+        "llm-average": 15.69
+      },
+      {
+        "entity_name": "Bisphenol A",
+        "llm-average": 14.51
+      }
+    ]
   },
   {
     "question_number": 13,
     "qid": 618,
     "text": "Which functional regions are found in protein SQLE, which is annotated in pathway Smith-Lemli-Opitz Syndrome (SLOS) and is associated with Griscelli syndrome type 2?",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) NAD(P)-binding Rossmann-like domain, (2) Squalene epoxidase"
+    "llm_ranking": [
+      {
+        "entity_name": "Squalene epoxidase",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "NAD(P)-binding Rossmann-like domain",
+        "llm-average": 6.67
+      }
+    ]
   },
   {
     "question_number": 14,
     "qid": 633,
     "text": "Which proteins are curated as interacting with HOPX, which is annotated in pathway Hop Pathway in Cardiac Development and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) PICK1, (2) TCF12, (3) ZSCAN1, (4) PTGER4, (5) INTS13"
+    "llm_ranking": [
+      {
+        "entity_name": "PICK1",
+        "llm-average": 19.08
+      },
+      {
+        "entity_name": "TCF12",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "ZSCAN1",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "PTGER4",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "INTS13",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 15,
     "qid": 636,
     "text": "Which drugs act on LMOD1, which is annotated in pathway Smooth Muscle Contraction and is associated with distal arthrogryposis type 2B?",
     "category": "musculoskeletal system disease:muscle tissue disease",
-    "llm_ranking": "(1) Dasatinib, (2) Atrazine, (3) Progesterone, (4) ATP, (5) Zinc, (6) Vitamin E, (7) Calcium, (8) Dihydrogenphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Dasatinib",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Progesterone",
+        "llm-average": 11.76
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 6.8
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 3.92
+      },
+      {
+        "entity_name": "Vitamin E",
+        "llm-average": 3.4
+      },
+      {
+        "entity_name": "Calcium",
+        "llm-average": 2.88
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 2.35
+      }
+    ]
   },
   {
     "question_number": 16,
     "qid": 645,
     "text": "Which proteins are curated as interacting with KCNJ10, which is annotated in pathway Activation of G protein gated Potassium channels and is associated with type 2 diabetes mellitus?",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) SIAH1, (2) KCNJ16"
+    "llm_ranking": [
+      {
+        "entity_name": "SIAH1",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "KCNJ16",
+        "llm-average": 13.59
+      }
+    ]
   },
   {
     "question_number": 17,
     "qid": 653,
     "text": "Which drugs act on L2HGDH, which is annotated in pathway Interconversion of 2-oxoglutarate and 2-hydroxyglutarate and is associated with combined D-2- and L-2-hydroxyglutaric aciduria?",
     "category": "genetic disease:amino acid metabolic disorder",
-    "llm_ranking": "(1) Cyclosporine, (2) Flavin-N7 protonated-adenine dinucleotide, (3) Flavin adenine dinucleotide, (4) Atrazine, (5) Estradiol, (6) D-tartaric acid, (7) NADH, (8) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 14.38
+      },
+      {
+        "entity_name": "Flavin-N7 protonated-adenine dinucleotide",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Flavin adenine dinucleotide",
+        "llm-average": 11.9
+      },
+      {
+        "entity_name": "Atrazine",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "D-tartaric acid",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "NADH",
+        "llm-average": 8.76
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 18,
     "qid": 654,
     "text": "Which drugs have PLEKHA8 as a compiled target, which is annotated in pathway Synthesis of PIPs at the plasma membrane and is associated with oculocerebrorenal syndrome?",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) N-Dimethyl-Lysine, (2) Capric acid, (3) Codeine"
+    "llm_ranking": [
+      {
+        "entity_name": "N-Dimethyl-Lysine",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Capric acid",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Codeine",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 19,
     "qid": 659,
     "text": "Which drugs act on DYNLRB1, which is annotated in pathway Intraflagellar transport and is associated with ovarian disease?",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) Valproic acid, (2) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "Valproic acid",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 10.2
+      }
+    ]
   },
   {
     "question_number": 20,
     "qid": 662,
     "text": "Which proteins are curated as interacting with MAG, which is annotated in pathway Axonal growth inhibition (RHOA activation) and is associated with PCWH syndrome?",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) PRNP, (2) IQCB1"
+    "llm_ranking": [
+      {
+        "entity_name": "PRNP",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "IQCB1",
+        "llm-average": 13.59
+      }
+    ]
   },
   {
     "question_number": 21,
     "qid": 685,
     "text": "Which functional regions are found in protein KPNA7, which is annotated in pathway ISG15 antiviral mechanism and is associated with ovarian disease?",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) Importin beta binding domain, (2) Atypical Arm repeat, (3) Armadillo/beta-catenin-like repeat"
+    "llm_ranking": [
+      {
+        "entity_name": "Importin beta binding domain",
+        "llm-average": 18.43
+      },
+      {
+        "entity_name": "Atypical Arm repeat",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Armadillo/beta-catenin-like repeat",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 22,
     "qid": 690,
     "text": "Which proteins act on IL1RL2, which is annotated in pathway Interleukin-38 signaling and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) IL36B, (2) IL36G, (3) IL36A, (4) IL2"
+    "llm_ranking": [
+      {
+        "entity_name": "IL36B",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "IL36G",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "IL36A",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "IL2",
+        "llm-average": 3.4
+      }
+    ]
   },
   {
     "question_number": 23,
     "qid": 698,
     "text": "Which metabolites are associated with B4GALT3, which is annotated in pathway N-Glycan antennae elongation and is associated with ovarian disease?",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) N-Acetyllactosamine, (2) Uridine diphosphategalactose, (3) N-Acetyl-D-glucosamine, (4) Uridine 5'-diphosphate, (5) Manganese"
+    "llm_ranking": [
+      {
+        "entity_name": "N-Acetyllactosamine",
+        "llm-average": 18.3
+      },
+      {
+        "entity_name": "Uridine diphosphategalactose",
+        "llm-average": 17.25
+      },
+      {
+        "entity_name": "N-Acetyl-D-glucosamine",
+        "llm-average": 10.72
+      },
+      {
+        "entity_name": "Uridine 5'-diphosphate",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Manganese",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 24,
     "qid": 705,
     "text": "Which metabolites are associated with MTMR1, which is annotated in pathway Synthesis of PIPs at the plasma membrane and is associated with oculocerebrorenal syndrome?",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) N-Acetyl-D-mannosamine 6-phosphate, (2) Beta-D-Fructose 2-phosphate, (3) N-Acetylmannosamine, (4) Phosphate, (5) D-Fructose, (6) NADP, (7) NAD, (8) Water"
+    "llm_ranking": [
+      {
+        "entity_name": "N-Acetyl-D-mannosamine 6-phosphate",
+        "llm-average": 12.16
+      },
+      {
+        "entity_name": "Beta-D-Fructose 2-phosphate",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "N-Acetylmannosamine",
+        "llm-average": 10.59
+      },
+      {
+        "entity_name": "Phosphate",
+        "llm-average": 4.97
+      },
+      {
+        "entity_name": "D-Fructose",
+        "llm-average": 4.84
+      },
+      {
+        "entity_name": "NADP",
+        "llm-average": 4.44
+      },
+      {
+        "entity_name": "NAD",
+        "llm-average": 3.4
+      },
+      {
+        "entity_name": "Water",
+        "llm-average": 0.26
+      }
+    ]
   },
   {
     "question_number": 25,
     "qid": 707,
     "text": "Which drugs have DEPDC1B as a compiled target, which is annotated in pathway RND1 GTPase cycle and is associated with oculocerebrorenal syndrome?",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) Guanosine-5'-Triphosphate, (2) Guanosine-5'-Diphosphate, (3) Dihydrogenphosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Guanosine-5'-Triphosphate",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "Dihydrogenphosphate",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 26,
     "qid": 718,
     "text": "Which proteins are curated as interacting with SRD5A1, which is annotated in pathway Androgen biosynthesis and is associated with PCWH syndrome?",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) CCNDBP1, (2) ACTBL2"
+    "llm_ranking": [
+      {
+        "entity_name": "CCNDBP1",
+        "llm-average": 14.12
+      },
+      {
+        "entity_name": "ACTBL2",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 27,
     "qid": 723,
     "text": "Which proteins are curated as interacting with FMO1, which is annotated in pathway Tamoxifen Action Pathway and is associated with type 2 diabetes mellitus?",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) CREB3, (2) GRINA, (3) SLC10A6, (4) MFSD14B, (5) REEP4"
+    "llm_ranking": [
+      {
+        "entity_name": "CREB3",
+        "llm-average": 19.48
+      },
+      {
+        "entity_name": "GRINA",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "SLC10A6",
+        "llm-average": 14.25
+      },
+      {
+        "entity_name": "MFSD14B",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "REEP4",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 28,
     "qid": 725,
     "text": "Which proteins are curated as interacting with FUCA2, which is annotated in pathway Post-translational protein phosphorylation and is associated with geleophysic dysplasia?",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) WNT11, (2) CUL3, (3) GPR37, (4) GPRC5B, (5) MEOX2, (6) HSCB, (7) FUCA1"
+    "llm_ranking": [
+      {
+        "entity_name": "WNT11",
+        "llm-average": 19.08
+      },
+      {
+        "entity_name": "CUL3",
+        "llm-average": 14.9
+      },
+      {
+        "entity_name": "GPR37",
+        "llm-average": 11.11
+      },
+      {
+        "entity_name": "GPRC5B",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "MEOX2",
+        "llm-average": 10.85
+      },
+      {
+        "entity_name": "HSCB",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "FUCA1",
+        "llm-average": 5.75
+      }
+    ]
   },
   {
     "question_number": 29,
     "qid": 735,
     "text": "Which drugs have SRSF11 as a compiled target, which is annotated in pathway mRNA Splicing - Major Pathway and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) Bisphenol A, (2) ATP"
+    "llm_ranking": [
+      {
+        "entity_name": "Bisphenol A",
+        "llm-average": 10.2
+      },
+      {
+        "entity_name": "ATP",
+        "llm-average": 8.5
+      }
+    ]
   },
   {
     "question_number": 30,
     "qid": 740,
     "text": "Which proteins act on TRAT1, which is annotated in pathway PI5P, PP2A and IER3 Regulate PI3K/AKT Signaling and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) PIK3R2, (2) PIK3CB, (3) PIK3CA, (4) LGALS3, (5) ZAP70, (6) CD4"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R2",
+        "llm-average": 15.29
+      },
+      {
+        "entity_name": "PIK3CB",
+        "llm-average": 13.99
+      },
+      {
+        "entity_name": "PIK3CA",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "LGALS3",
+        "llm-average": 10.98
+      },
+      {
+        "entity_name": "ZAP70",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "CD4",
+        "llm-average": 6.93
+      }
+    ]
   },
   {
     "question_number": 31,
     "qid": 745,
     "text": "Which drugs have FTMT as a compiled target, which is annotated in pathway Hereditary Coproporphyria (HCP) and is associated with Griscelli syndrome type 2?",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) 5-(5-CHLORO-2,4-DIHYDROXYPHENYL)-N-ETHYL-4-(4-METHOXYPHENYL)ISOXAZOLE-3-CARBOXAMIDE, (2) Doxycycline, (3) Lacosamide, (4) Iron, (5) Isopropyl alcohol, (6) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "5-(5-CHLORO-2,4-DIHYDROXYPHENYL)-N-ETHYL-4-(4-METHOXYPHENYL)ISOXAZOLE-3-CARBOXAMIDE",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "Doxycycline",
+        "llm-average": 9.15
+      },
+      {
+        "entity_name": "Lacosamide",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Iron",
+        "llm-average": 2.88
+      },
+      {
+        "entity_name": "Isopropyl alcohol",
+        "llm-average": 2.61
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 1.44
+      }
+    ]
   },
   {
     "question_number": 32,
     "qid": 748,
     "text": "Which functional regions are found in protein PLXNA1, which is annotated in pathway RND1 GTPase cycle and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) Plexin cytoplasmic RasGAP domain, (2) Sema domain, (3) Plexin repeat"
+    "llm_ranking": [
+      {
+        "entity_name": "Plexin cytoplasmic RasGAP domain",
+        "llm-average": 18.43
+      },
+      {
+        "entity_name": "Sema domain",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "Plexin repeat",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 33,
     "qid": 767,
     "text": "Which proteins act on LOXL1, which is annotated in pathway Elastic fibre formation and is associated with type 2 diabetes mellitus?",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) PCOLCE, (2) TLL1, (3) LOX, (4) LOXL4"
+    "llm_ranking": [
+      {
+        "entity_name": "TLL1",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "PCOLCE",
+        "llm-average": 12.55
+      },
+      {
+        "entity_name": "LOX",
+        "llm-average": 12.03
+      },
+      {
+        "entity_name": "LOXL4",
+        "llm-average": 9.67
+      }
+    ]
   },
   {
     "question_number": 34,
     "qid": 779,
     "text": "Which drugs have RAB33B as a compiled target, which is annotated in pathway TBC/RABGAPs and is associated with bone disease?",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) Phosphoaminophosphonic acid guanylate ester, (2) Guanosine-5'-Diphosphate, (3) N-Ethylmaleimide, (4) Tromethamine, (5) Palmitic Acid, (6) Magnesium cation"
+    "llm_ranking": [
+      {
+        "entity_name": "Phosphoaminophosphonic acid guanylate ester",
+        "llm-average": 13.73
+      },
+      {
+        "entity_name": "Guanosine-5'-Diphosphate",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "N-Ethylmaleimide",
+        "llm-average": 9.02
+      },
+      {
+        "entity_name": "Tromethamine",
+        "llm-average": 5.62
+      },
+      {
+        "entity_name": "Palmitic Acid",
+        "llm-average": 4.97
+      },
+      {
+        "entity_name": "Magnesium cation",
+        "llm-average": 3.4
+      }
+    ]
   },
   {
     "question_number": 35,
     "qid": 783,
     "text": "Which drugs have PTDSS1 as a compiled target, which is annotated in pathway Phosphatidylethanolamine Biosynthesis PE(22:4(7Z,10Z,13Z,16Z)/18:1(9Z)) and is associated with chromosomal deletion syndrome?",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) Phosphatidyl serine, (2) D-Serine, (3) Serine, (4) Choline"
+    "llm_ranking": [
+      {
+        "entity_name": "Phosphatidyl serine",
+        "llm-average": 15.56
+      },
+      {
+        "entity_name": "D-Serine",
+        "llm-average": 9.8
+      },
+      {
+        "entity_name": "Serine",
+        "llm-average": 8.37
+      },
+      {
+        "entity_name": "Choline",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 36,
     "qid": 785,
     "text": "Which drugs have TAF7L as a compiled target, which is annotated in pathway RNA Polymerase II Transcription Initiation And Promoter Clearance and is associated with X-linked dystonia-parkinsonism?",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) Arsenous acid, (2) Isobutyric acid, (3) Tromethamine, (4) Zinc"
+    "llm_ranking": [
+      {
+        "entity_name": "Arsenous acid",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Isobutyric acid",
+        "llm-average": 8.24
+      },
+      {
+        "entity_name": "Tromethamine",
+        "llm-average": 7.97
+      },
+      {
+        "entity_name": "Zinc",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 37,
     "qid": 788,
     "text": "Which proteins act on B4GALT2, which is annotated in pathway N-Glycan antennae elongation and is associated with ovarian disease?",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) ST3GAL3, (2) LALBA, (3) OGN, (4) LUM, (5) KERA"
+    "llm_ranking": [
+      {
+        "entity_name": "ST3GAL3",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "LALBA",
+        "llm-average": 13.33
+      },
+      {
+        "entity_name": "OGN",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "LUM",
+        "llm-average": 11.5
+      },
+      {
+        "entity_name": "KERA",
+        "llm-average": 10.98
+      }
+    ]
   },
   {
     "question_number": 38,
     "qid": 797,
     "text": "Which drugs act on RNF34, which is annotated in pathway Regulation of TP53 Degradation and is associated with bone disease?",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) 2-Amino-1-methyl-6-phenylimidazo(4,5-b)pyridine, (2) Vincristine, (3) Acetaminophen"
+    "llm_ranking": [
+      {
+        "entity_name": "2-Amino-1-methyl-6-phenylimidazo(4,5-b)pyridine",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "Vincristine",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "Acetaminophen",
+        "llm-average": 4.97
+      }
+    ]
   },
   {
     "question_number": 39,
     "qid": 1525,
     "text": "Find all proteins that are associated with retinitis pigmentosa 23 and act on BTF3L4, and also find the proteins that are associated with retinitis pigmentosa 23 and are curated as interacting with BTF3L4.",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) ESR1, (2) CNOT1"
+    "llm_ranking": [
+      {
+        "entity_name": "ESR1",
+        "llm-average": 15.28
+      },
+      {
+        "entity_name": "CNOT1",
+        "llm-average": 14.19
+      }
+    ]
   },
   {
     "question_number": 40,
     "qid": 1529,
     "text": "Find all drugs that are indicated for Pustule and interact with Chlorcyclizine, and also find the drugs that have the side effect Pustule and interact with Chlorcyclizine.",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Erlotinib, (2) Ketoconazole, (3) Metronidazole"
+    "llm_ranking": [
+      {
+        "entity_name": "Erlotinib",
+        "llm-average": 18.84
+      },
+      {
+        "entity_name": "Ketoconazole",
+        "llm-average": 12.27
+      },
+      {
+        "entity_name": "Metronidazole",
+        "llm-average": 6.51
+      }
+    ]
   },
   {
     "question_number": 41,
     "qid": 1530,
     "text": "Find all drugs that are indicated for Cutaneous T-cell lymphoma and interact with Gentamicin C1a, and also find the drugs that have the side effect Cutaneous T-cell lymphoma and interact with Gentamicin C1a.",
     "category": "Neoplasm:Hematological neoplasm",
-    "llm_ranking": "(1) Tacrolimus, (2) Methoxsalen, (3) Methotrexate"
+    "llm_ranking": [
+      {
+        "entity_name": "Tacrolimus",
+        "llm-average": 15.56
+      },
+      {
+        "entity_name": "Methoxsalen",
+        "llm-average": 14.37
+      },
+      {
+        "entity_name": "Methotrexate",
+        "llm-average": 6.51
+      }
+    ]
   },
   {
     "question_number": 42,
     "qid": 454,
     "text": "Which drugs are curated as targeting neurofibromin 2, which is translated into NF2, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Everolimus, (2) Selumetinib, (3) Temsirolimus, (4) Octreotide, (5) Erlotinib, (6) Lapatinib, (7) Carboplatin, (8) Imatinib"
+    "llm_ranking": [
+      {
+        "entity_name": "Selumetinib",
+        "llm-average": 12.86
+      },
+      {
+        "entity_name": "Everolimus",
+        "llm-average": 12.53
+      },
+      {
+        "entity_name": "Temsirolimus",
+        "llm-average": 10.78
+      },
+      {
+        "entity_name": "Octreotide",
+        "llm-average": 9.44
+      },
+      {
+        "entity_name": "Lapatinib",
+        "llm-average": 7.84
+      },
+      {
+        "entity_name": "Erlotinib",
+        "llm-average": 7.71
+      },
+      {
+        "entity_name": "Imatinib",
+        "llm-average": 6.45
+      },
+      {
+        "entity_name": "Carboplatin",
+        "llm-average": 6.23
+      }
+    ]
   },
   {
     "question_number": 43,
     "qid": 460,
     "text": "Which drugs are curated as targeting mitogen-activated protein kinase kinase 7, which is translated into MAP2K7, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Binimetinib, (2) Selumetinib"
+    "llm_ranking": [
+      {
+        "entity_name": "Binimetinib",
+        "llm-average": 11.98
+      },
+      {
+        "entity_name": "Selumetinib",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 44,
     "qid": 475,
     "text": "Which drugs interact with Ifosfamide, which is indicated for Acute lymphoblastic leukemia, and are compiled as targeting FTMT?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Doxycycline, (2) Lacosamide"
+    "llm_ranking": [
+      {
+        "entity_name": "Doxycycline",
+        "llm-average": 10.46
+      },
+      {
+        "entity_name": "Lacosamide",
+        "llm-average": 9.65
+      }
+    ]
   },
   {
     "question_number": 45,
     "qid": 482,
     "text": "Which drugs are curated as targeting membrane spanning 4-domains A1, which is translated into MS4A1, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Tositumomab, (2) Rituximab"
+    "llm_ranking": [
+      {
+        "entity_name": "Tositumomab",
+        "llm-average": 13.79
+      },
+      {
+        "entity_name": "Rituximab",
+        "llm-average": 11.16
+      }
+    ]
   },
   {
     "question_number": 46,
     "qid": 490,
     "text": "Which drugs are compiled as targeting BMP4, which is associated with fruit, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Sirolimus, (2) Flutamide, (3) Estradiol"
+    "llm_ranking": [
+      {
+        "entity_name": "Sirolimus",
+        "llm-average": 14.64
+      },
+      {
+        "entity_name": "Flutamide",
+        "llm-average": 13.35
+      },
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 7.19
+      }
+    ]
   },
   {
     "question_number": 47,
     "qid": 492,
     "text": "Which drugs interact with Nelarabine, which is indicated for Acute lymphoblastic leukemia, and act on PRDX4?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Vorinostat, (2) Cyclosporine, (3) Gallium nitrate"
+    "llm_ranking": [
+      {
+        "entity_name": "Vorinostat",
+        "llm-average": 15.92
+      },
+      {
+        "entity_name": "Gallium nitrate",
+        "llm-average": 8.57
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 8.52
+      }
+    ]
   },
   {
     "question_number": 48,
     "qid": 497,
     "text": "Which drugs are curated as targeting toll like receptor 4, which is translated into TLR4, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Infliximab, (2) Nelfinavir, (3) Ritonavir, (4) Saquinavir, (5) Ethanol"
+    "llm_ranking": [
+      {
+        "entity_name": "Infliximab",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "Nelfinavir",
+        "llm-average": 8.84
+      },
+      {
+        "entity_name": "Ritonavir",
+        "llm-average": 8.28
+      },
+      {
+        "entity_name": "Saquinavir",
+        "llm-average": 8.26
+      },
+      {
+        "entity_name": "Ethanol",
+        "llm-average": 5.49
+      }
+    ]
   },
   {
     "question_number": 49,
     "qid": 498,
     "text": "Which drugs act on HKDC1, which is associated with fruit, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Estradiol, (2) Glucosamine"
+    "llm_ranking": [
+      {
+        "entity_name": "Estradiol",
+        "llm-average": 10.39
+      },
+      {
+        "entity_name": "Glucosamine",
+        "llm-average": 9.04
+      }
+    ]
   },
   {
     "question_number": 50,
     "qid": 511,
     "text": "Which drugs interact with Epirubicin, which is indicated for Acute lymphoblastic leukemia, and act on PRDX4?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Vorinostat, (2) Cyclosporine, (3) Gallium nitrate"
+    "llm_ranking": [
+      {
+        "entity_name": "Vorinostat",
+        "llm-average": 15.78
+      },
+      {
+        "entity_name": "Cyclosporine",
+        "llm-average": 11.68
+      },
+      {
+        "entity_name": "Gallium nitrate",
+        "llm-average": 10.46
+      }
+    ]
   },
   {
     "question_number": 51,
     "qid": 512,
     "text": "Which drugs are compiled as targeting KIF17, which is associated with fruit, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Docetaxel, (2) Paclitaxel"
+    "llm_ranking": [
+      {
+        "entity_name": "Docetaxel",
+        "llm-average": 9.85
+      },
+      {
+        "entity_name": "Paclitaxel",
+        "llm-average": 9.04
+      }
+    ]
   },
   {
     "question_number": 52,
     "qid": 523,
     "text": "Which drugs are compiled as targeting PPIC, which is associated with fruit, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Rabeprazole, (2) Tacrolimus"
+    "llm_ranking": [
+      {
+        "entity_name": "Rabeprazole",
+        "llm-average": 13.27
+      },
+      {
+        "entity_name": "Tacrolimus",
+        "llm-average": 12.2
+      }
+    ]
   },
   {
     "question_number": 53,
     "qid": 537,
     "text": "Which drugs are curated as targeting potassium voltage-gated channel subfamily H member 1, which is translated into KCNH1, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Astemizole, (2) Dofetilide, (3) Terfenadine, (4) Haloperidol, (5) Imipramine"
+    "llm_ranking": [
+      {
+        "entity_name": "Astemizole",
+        "llm-average": 18.67
+      },
+      {
+        "entity_name": "Dofetilide",
+        "llm-average": 17.05
+      },
+      {
+        "entity_name": "Terfenadine",
+        "llm-average": 13.39
+      },
+      {
+        "entity_name": "Haloperidol",
+        "llm-average": 12.83
+      },
+      {
+        "entity_name": "Imipramine",
+        "llm-average": 8.04
+      }
+    ]
   },
   {
     "question_number": 54,
     "qid": 540,
     "text": "Which drugs are compiled as targeting IL21, which is associated with fruit, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Conjugated estrogens, (2) Estrone sulfate"
+    "llm_ranking": [
+      {
+        "entity_name": "Conjugated estrogens",
+        "llm-average": 6.89
+      },
+      {
+        "entity_name": "Estrone sulfate",
+        "llm-average": 6.45
+      }
+    ]
   },
   {
     "question_number": 55,
     "qid": 543,
     "text": "Which drugs are compiled as targeting DAD1, which is associated with fruit, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Haloperidol, (2) Cocaine, (3) Dopamine, (4) Dextroamphetamine"
+    "llm_ranking": [
+      {
+        "entity_name": "Haloperidol",
+        "llm-average": 13.87
+      },
+      {
+        "entity_name": "Cocaine",
+        "llm-average": 9.44
+      },
+      {
+        "entity_name": "Dopamine",
+        "llm-average": 6.81
+      },
+      {
+        "entity_name": "Dextroamphetamine",
+        "llm-average": 6.45
+      }
+    ]
   },
   {
     "question_number": 56,
     "qid": 555,
     "text": "Which drugs are curated as targeting SWI/SNF related, matrix associated, actin dependent regulator of chromatin, subfamily b, member 1, which is translated into SMARCB1, and interact with Anagrelide?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Vorinostat, (2) Panobinostat, (3) Palbociclib"
+    "llm_ranking": [
+      {
+        "entity_name": "Vorinostat",
+        "llm-average": 15.78
+      },
+      {
+        "entity_name": "Panobinostat",
+        "llm-average": 15.6
+      },
+      {
+        "entity_name": "Palbociclib",
+        "llm-average": 10.93
+      }
+    ]
   },
   {
     "question_number": 57,
     "qid": 803,
     "text": "List the proteins that are associated with dilated cardiomyopathy 1DD and are subunits of NOS3-HSP90 complex, VEGF induced.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) NOS3, (2) HSP90AA1"
+    "llm_ranking": [
+      {
+        "entity_name": "NOS3",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "HSP90AA1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 58,
     "qid": 804,
     "text": "List the proteins that are associated with Charcot-Marie-Tooth disease axonal type 2H and are subunits of CTNNB1-ESR1 complex.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) ESR1, (2) CTNNB1"
+    "llm_ranking": [
+      {
+        "entity_name": "CTNNB1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "ESR1",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 59,
     "qid": 806,
     "text": "List the proteins that are associated with dilated cardiomyopathy 1NN and are compiled as interacting with OR6C65.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) GRK3, (2) GRK2"
+    "llm_ranking": [
+      {
+        "entity_name": "GRK3",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "GRK2",
+        "llm-average": 8.85
+      }
+    ]
   },
   {
     "question_number": 60,
     "qid": 807,
     "text": "List the drugs that interact with Ceftibuten and have the side effect Chronic pain.",
     "category": "Constitutional symptom:Chronic pain",
-    "llm_ranking": "(1) Fentanyl, (2) Etoricoxib"
+    "llm_ranking": [
+      {
+        "entity_name": "Fentanyl",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "Etoricoxib",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 61,
     "qid": 808,
     "text": "List the proteins that are associated with hepatic vascular disease and are subunits of SERPINA1-CTSG complex.",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) CTSG, (2) SERPINA1"
+    "llm_ranking": [
+      {
+        "entity_name": "CTSG",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "SERPINA1",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 62,
     "qid": 820,
     "text": "List the proteins that are associated with skin disease and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(14:1(9Z)/22:6(4Z,7Z,10Z,13Z,16Z,19Z)/18:3(9Z,12Z,15Z)).",
     "category": "integumentary system disease:skin disease",
-    "llm_ranking": "(1) DGAT1, (2) GPAM, (3) GPD1, (4) LPIN1"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 14.61
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 12.71
+      }
+    ]
   },
   {
     "question_number": 63,
     "qid": 825,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(16:0/16:0/16:1(9Z)/18:1(9Z)) and are associated with familial hyperlipidemia.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) GPAM, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 64,
     "qid": 829,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-13:0/a-17:0/i-12:0) and are associated with glucose metabolism disease.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) PTPMT1, (2) CRLS1, (3) GPAM, (4) GPD1, (5) AGPAT5, (6) PGS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 16.83
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 14.2
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 11.34
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 65,
     "qid": 830,
     "text": "List the proteins that are annotated in the pathway RUNX1 regulates transcription of genes involved in differentiation of myeloid cells and are associated with cone-rod dystrophy 2.",
     "category": "genetic disease:monogenic disease",
-    "llm_ranking": "(1) CSF2, (2) LGALS3"
+    "llm_ranking": [
+      {
+        "entity_name": "LGALS3",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "CSF2",
+        "llm-average": 15.07
+      }
+    ]
   },
   {
     "question_number": 66,
     "qid": 831,
     "text": "List the proteins that are compiled as interacting with ELP3 and are associated with non-alcoholic fatty liver.",
     "category": "genetic disease:lysosomal storage disease",
-    "llm_ranking": "(1) SIRT2, (2) SIRT1, (3) SIRT3, (4) HDAC3, (5) H3-2"
+    "llm_ranking": [
+      {
+        "entity_name": "SIRT2",
+        "llm-average": 12.62
+      },
+      {
+        "entity_name": "SIRT1",
+        "llm-average": 11.75
+      },
+      {
+        "entity_name": "SIRT3",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "HDAC3",
+        "llm-average": 9.48
+      },
+      {
+        "entity_name": "H3-2",
+        "llm-average": 6.03
+      }
+    ]
   },
   {
     "question_number": 67,
     "qid": 832,
     "text": "List the proteins that are compiled as interacting with FAM186A and are associated with X-linked monogenic disease.",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) DIP2B, (2) PKD1L2, (3) SH2B3, (4) FER1L6"
+    "llm_ranking": [
+      {
+        "entity_name": "DIP2B",
+        "llm-average": 9.95
+      },
+      {
+        "entity_name": "PKD1L2",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "SH2B3",
+        "llm-average": 5.75
+      },
+      {
+        "entity_name": "FER1L6",
+        "llm-average": 4.89
+      }
+    ]
   },
   {
     "question_number": 68,
     "qid": 838,
     "text": "List the proteins that are compiled as interacting with TRHDE and are associated with bone structure disease.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) TRH, (2) BLMH, (3) ACE"
+    "llm_ranking": [
+      {
+        "entity_name": "TRH",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "ACE",
+        "llm-average": 10.82
+      },
+      {
+        "entity_name": "BLMH",
+        "llm-average": 10.81
+      }
+    ]
   },
   {
     "question_number": 69,
     "qid": 840,
     "text": "List the proteins that are associated with atrophic gastritis and are compiled as interacting with ANKRA2.",
     "category": "gastrointestinal system disease:gastritis",
-    "llm_ranking": "(1) CLIP4, (2) HDAC6, (3) ABL1"
+    "llm_ranking": [
+      {
+        "entity_name": "CLIP4",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "ABL1",
+        "llm-average": 10.82
+      },
+      {
+        "entity_name": "HDAC6",
+        "llm-average": 10.81
+      }
+    ]
   },
   {
     "question_number": 70,
     "qid": 845,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(20:1(11Z)/24:0/24:1(15Z)) and are associated with carnitine palmitoyltransferase II deficiency.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 7.66
+      }
+    ]
   },
   {
     "question_number": 71,
     "qid": 846,
     "text": "List the proteins that are associated with reading disorder and are curated as interacting with UBE2I.",
     "category": "disease of mental health:specific developmental disorder",
-    "llm_ranking": "(1) SETX, (2) ETV6, (3) BHLHE40, (4) ELK1"
+    "llm_ranking": [
+      {
+        "entity_name": "SETX",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "ETV6",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "BHLHE40",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "ELK1",
+        "llm-average": 10.01
+      }
+    ]
   },
   {
     "question_number": 72,
     "qid": 847,
     "text": "List the drugs that have the side effect Hordeolum and interact with Testosterone cypionate.",
     "category": "Abnormality of the integument:Abnormality of skin morphology",
-    "llm_ranking": "(1) Bortezomib, (2) Lenalidomide, (3) Pramipexole, (4) Bupropion, (5) Tramadol, (6) Clonazepam, (7) Ciprofloxacin"
+    "llm_ranking": [
+      {
+        "entity_name": "Bortezomib",
+        "llm-average": 13.54
+      },
+      {
+        "entity_name": "Lenalidomide",
+        "llm-average": 12.38
+      },
+      {
+        "entity_name": "Pramipexole",
+        "llm-average": 9.48
+      },
+      {
+        "entity_name": "Bupropion",
+        "llm-average": 8.69
+      },
+      {
+        "entity_name": "Tramadol",
+        "llm-average": 4.57
+      },
+      {
+        "entity_name": "Clonazepam",
+        "llm-average": 3.6
+      },
+      {
+        "entity_name": "Ciprofloxacin",
+        "llm-average": 3.29
+      }
+    ]
   },
   {
     "question_number": 73,
     "qid": 849,
     "text": "List the metabolites that are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-16:0/a-15:0/i-15:0) and are associated with Alzheimer's disease 1.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) Glycerol 3-phosphate, (2) Dihydroxyacetone phosphate, (3) Cytidine monophosphate"
+    "llm_ranking": [
+      {
+        "entity_name": "Glycerol 3-phosphate",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "Dihydroxyacetone phosphate",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Cytidine monophosphate",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 74,
     "qid": 854,
     "text": "List the proteins that are associated with endometriosis and are subunits of ITGA4-ITGB1-CD81 complex.",
     "category": "reproductive system disease:endometriosis",
-    "llm_ranking": "(1) CD81, (2) ITGB1, (3) ITGA4"
+    "llm_ranking": [
+      {
+        "entity_name": "CD81",
+        "llm-average": 13.1
+      },
+      {
+        "entity_name": "ITGB1",
+        "llm-average": 10.33
+      },
+      {
+        "entity_name": "ITGA4",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 75,
     "qid": 858,
     "text": "List the drugs that interact with Tucidinostat and have the side effect Erysipelas.",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Clarithromycin, (2) Escitalopram, (3) Citalopram"
+    "llm_ranking": [
+      {
+        "entity_name": "Clarithromycin",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "Escitalopram",
+        "llm-average": 7.01
+      },
+      {
+        "entity_name": "Citalopram",
+        "llm-average": 6.8
+      }
+    ]
   },
   {
     "question_number": 76,
     "qid": 860,
     "text": "List the proteins that are compiled as interacting with MSL3 and are associated with distal muscular dystrophy with anterior tibial onset.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) MAP3K7, (2) ACTB, (3) PRKDC, (4) HDAC1"
+    "llm_ranking": [
+      {
+        "entity_name": "MAP3K7",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "ACTB",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "PRKDC",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "HDAC1",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 77,
     "qid": 861,
     "text": "List the proteins that are associated with otosclerosis and act on CNTN1.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) NOTCH1, (2) ANKRD44"
+    "llm_ranking": [
+      {
+        "entity_name": "NOTCH1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "ANKRD44",
+        "llm-average": 10.77
+      }
+    ]
   },
   {
     "question_number": 78,
     "qid": 863,
     "text": "List the proteins that are curated as interacting with JAK2 and are associated with familial hyperinsulinemic hypoglycemia 5.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) CDKN1B, (2) SRC"
+    "llm_ranking": [
+      {
+        "entity_name": "CDKN1B",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "SRC",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 79,
     "qid": 864,
     "text": "List the proteins that are associated with mucopolysaccharidosis Ih and are compiled as interacting with PIGZ.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) DPM2, (2) PIGP, (3) PIGC"
+    "llm_ranking": [
+      {
+        "entity_name": "DPM2",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "PIGP",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "PIGC",
+        "llm-average": 5.5
+      }
+    ]
   },
   {
     "question_number": 80,
     "qid": 866,
     "text": "List the drugs that interact with Ubidecarenone and have the side effect Facial tics.",
     "category": "Abnormality of the head:Abnormal facial expression",
-    "llm_ranking": "(1) Citalopram, (2) Escitalopram"
+    "llm_ranking": [
+      {
+        "entity_name": "Citalopram",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "Escitalopram",
+        "llm-average": 8.47
+      }
+    ]
   },
   {
     "question_number": 81,
     "qid": 867,
     "text": "List the proteins that are associated with Griscelli syndrome and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(i-20:0/i-16:0/10:0).",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) GPAM, (2) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 8.85
+      }
+    ]
   },
   {
     "question_number": 82,
     "qid": 871,
     "text": "List the proteins that are associated with granulomatous gastritis and are compiled as interacting with POU5F1.",
     "category": "gastrointestinal system disease:gastritis",
-    "llm_ranking": "(1) HGF, (2) SMAD4, (3) SPP1, (4) KIT, (5) FUT4"
+    "llm_ranking": [
+      {
+        "entity_name": "HGF",
+        "llm-average": 16.41
+      },
+      {
+        "entity_name": "SMAD4",
+        "llm-average": 15.73
+      },
+      {
+        "entity_name": "SPP1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "KIT",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "FUT4",
+        "llm-average": 9.21
+      }
+    ]
   },
   {
     "question_number": 83,
     "qid": 876,
     "text": "List the proteins that are curated as interacting with HTT and are associated with postgastrectomy syndrome.",
     "category": "gastrointestinal system disease:functional gastric disease",
-    "llm_ranking": "(1) ADIPOQ, (2) PPARA, (3) MEAF6"
+    "llm_ranking": [
+      {
+        "entity_name": "ADIPOQ",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "PPARA",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "MEAF6",
+        "llm-average": 12.39
+      }
+    ]
   },
   {
     "question_number": 84,
     "qid": 877,
     "text": "List the proteins that are associated with Walker-Warburg syndrome and are compiled as interacting with CDH19.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) HAPLN2, (2) GFAP, (3) EGF"
+    "llm_ranking": [
+      {
+        "entity_name": "HAPLN2",
+        "llm-average": 16.09
+      },
+      {
+        "entity_name": "GFAP",
+        "llm-average": 9.92
+      },
+      {
+        "entity_name": "EGF",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 85,
     "qid": 878,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(24:1(15Z)/22:0/20:3(8Z,11Z,14Z)) and are associated with hepatobiliary disease.",
     "category": "gastrointestinal system disease:hepatobiliary disease",
-    "llm_ranking": "(1) LPIN1, (2) GPAM, (3) DGAT1, (4) GPD1, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 14.24
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 13.02
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 12.39
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 7.3
+      }
+    ]
   },
   {
     "question_number": 86,
     "qid": 880,
     "text": "List the proteins that are compiled as interacting with ULK4 and are associated with karyomegalic interstitial nephritis.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) KIF26A, (2) ZNF652"
+    "llm_ranking": [
+      {
+        "entity_name": "ZNF652",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "KIF26A",
+        "llm-average": 15.07
+      }
+    ]
   },
   {
     "question_number": 87,
     "qid": 882,
     "text": "List the proteins that are compiled as interacting with CYP39A1 and are associated with Jacobsen Syndrome.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) SC5D, (2) DHCR7, (3) ACP6"
+    "llm_ranking": [
+      {
+        "entity_name": "SC5D",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "DHCR7",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "ACP6",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 88,
     "qid": 883,
     "text": "List the proteins that are compiled as interacting with NR2F6 and are associated with fragile X syndrome.",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) PPARGC1A, (2) SERPINB3, (3) NCOR1, (4) NCKAP5L, (5) ASCL1, (6) PHOX2B"
+    "llm_ranking": [
+      {
+        "entity_name": "PPARGC1A",
+        "llm-average": 15.73
+      },
+      {
+        "entity_name": "SERPINB3",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "NCOR1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "NCKAP5L",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "ASCL1",
+        "llm-average": 9.46
+      },
+      {
+        "entity_name": "PHOX2B",
+        "llm-average": 9.25
+      }
+    ]
   },
   {
     "question_number": 89,
     "qid": 884,
     "text": "List the proteins that are associated with vulvovaginitis and act on RNF185.",
     "category": "reproductive system disease:vulvovaginitis",
-    "llm_ranking": "(1) SPATA5, (2) ACOT8"
+    "llm_ranking": [
+      {
+        "entity_name": "SPATA5",
+        "llm-average": 14.21
+      },
+      {
+        "entity_name": "ACOT8",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 90,
     "qid": 886,
     "text": "List the proteins that are associated with vitamin B12 deficiency and are compiled as interacting with UBE3D.",
     "category": "genetic disease:vitamin metabolic disorder",
-    "llm_ranking": "(1) PRKN, (2) TRIM21, (3) KBTBD6, (4) SNX14"
+    "llm_ranking": [
+      {
+        "entity_name": "PRKN",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "TRIM21",
+        "llm-average": 13.24
+      },
+      {
+        "entity_name": "SNX14",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "KBTBD6",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 91,
     "qid": 888,
     "text": "List the proteins that are associated with cholecystitis and are compiled as interacting with TRDN.",
     "category": "gastrointestinal system disease:biliary tract disease",
-    "llm_ranking": "(1) C1S, (2) GRN, (3) ACTA1"
+    "llm_ranking": [
+      {
+        "entity_name": "C1S",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "ACTA1",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "GRN",
+        "llm-average": 12.42
+      }
+    ]
   },
   {
     "question_number": 92,
     "qid": 891,
     "text": "List the proteins that are curated as interacting with FYN and are associated with Bardet-Biedl syndrome.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) HOXB5, (2) ACBD7"
+    "llm_ranking": [
+      {
+        "entity_name": "HOXB5",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "ACBD7",
+        "llm-average": 15.07
+      }
+    ]
   },
   {
     "question_number": 93,
     "qid": 892,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(8:0/i-16:0/12:0) and are associated with hypotrichosis.",
     "category": "integumentary system disease:hypotrichosis",
-    "llm_ranking": "(1) DGAT1, (2) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 94,
     "qid": 893,
     "text": "List the proteins that act on F3 and are associated with congenital muscular dystrophy due to LMNA mutation.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) PTX3, (2) FGF2"
+    "llm_ranking": [
+      {
+        "entity_name": "PTX3",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "FGF2",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 95,
     "qid": 898,
     "text": "List the proteins that are curated as interacting with KANK1 and are associated with Charcot-Marie-Tooth disease type 4A.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) KIF21A, (2) CTNNB1"
+    "llm_ranking": [
+      {
+        "entity_name": "KIF21A",
+        "llm-average": 15.07
+      },
+      {
+        "entity_name": "CTNNB1",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 96,
     "qid": 899,
     "text": "List the proteins that are associated with carnitine palmitoyltransferase II deficiency and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(16:1(9Z)/20:3(5Z,8Z,11Z)/20:1(11Z)).",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) LPIN1, (2) GPAM, (3) DGAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 97,
     "qid": 902,
     "text": "List the proteins that are associated with hereditary spastic paraplegia 4 and are subunits of ArPIKfyve-Sac3-Sph1 complex.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) FIG4, (2) PIKFYVE"
+    "llm_ranking": [
+      {
+        "entity_name": "FIG4",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "PIKFYVE",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 98,
     "qid": 908,
     "text": "List the proteins that are compiled as interacting with CLC and are associated with personality disorder.",
     "category": "disease of mental health:personality disorder",
-    "llm_ranking": "(1) ISYNA1, (2) ADH1A"
+    "llm_ranking": [
+      {
+        "entity_name": "ISYNA1",
+        "llm-average": 14.01
+      },
+      {
+        "entity_name": "ADH1A",
+        "llm-average": 13.65
+      }
+    ]
   },
   {
     "question_number": 99,
     "qid": 911,
     "text": "List the proteins that act on RAB33B and are associated with spinocerebellar ataxia type 11.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) RAB8A, (2) RAB10, (3) RAB11A, (4) RAB5A"
+    "llm_ranking": [
+      {
+        "entity_name": "RAB8A",
+        "llm-average": 6.93
+      },
+      {
+        "entity_name": "RAB10",
+        "llm-average": 5.1
+      },
+      {
+        "entity_name": "RAB11A",
+        "llm-average": 4.89
+      },
+      {
+        "entity_name": "RAB5A",
+        "llm-average": 1.98
+      }
+    ]
   },
   {
     "question_number": 100,
     "qid": 913,
     "text": "List the proteins that are associated with allergic disease and act on GLI1.",
     "category": "immune system disease:allergic disease",
-    "llm_ranking": "(1) SIRT1, (2) ITGB4, (3) PSMD5, (4) CCND1, (5) MMP2, (6) RPS6KB1"
+    "llm_ranking": [
+      {
+        "entity_name": "SIRT1",
+        "llm-average": 16.28
+      },
+      {
+        "entity_name": "ITGB4",
+        "llm-average": 12.39
+      },
+      {
+        "entity_name": "PSMD5",
+        "llm-average": 10.66
+      },
+      {
+        "entity_name": "MMP2",
+        "llm-average": 9.46
+      },
+      {
+        "entity_name": "CCND1",
+        "llm-average": 9.23
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 7.66
+      }
+    ]
   },
   {
     "question_number": 101,
     "qid": 915,
     "text": "List the proteins that are associated with RIDDLE syndrome and are curated as interacting with MOV10.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) BMI1, (2) PCGF2, (3) COPS5, (4) TP53, (5) RNF2, (6) CUL3"
+    "llm_ranking": [
+      {
+        "entity_name": "BMI1",
+        "llm-average": 13.13
+      },
+      {
+        "entity_name": "PCGF2",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "COPS5",
+        "llm-average": 11.93
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "RNF2",
+        "llm-average": 10.56
+      },
+      {
+        "entity_name": "CUL3",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 102,
     "qid": 917,
     "text": "List the drugs that have the side effect Lymphopenia and interact with Carfecillin.",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Mycophenolic acid, (2) Levofloxacin, (3) Ofloxacin"
+    "llm_ranking": [
+      {
+        "entity_name": "Mycophenolic acid",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "Levofloxacin",
+        "llm-average": 8.89
+      },
+      {
+        "entity_name": "Ofloxacin",
+        "llm-average": 8.15
+      }
+    ]
   },
   {
     "question_number": 103,
     "qid": 918,
     "text": "List the proteins that are associated with Loeys-Dietz syndrome 2 and are compiled as interacting with RYR3.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) PRKG1, (2) ATP2A1, (3) BCL2L1, (4) GAPDH"
+    "llm_ranking": [
+      {
+        "entity_name": "PRKG1",
+        "llm-average": 18.85
+      },
+      {
+        "entity_name": "ATP2A1",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 9.25
+      },
+      {
+        "entity_name": "GAPDH",
+        "llm-average": 7.0
+      }
+    ]
   },
   {
     "question_number": 104,
     "qid": 920,
     "text": "List the proteins that are associated with MELAS syndrome and are compiled as interacting with WDR77.",
     "category": "musculoskeletal system disease:muscle tissue disease",
-    "llm_ranking": "(1) CLP1, (2) SIRT7, (3) INTS11, (4) TOE1, (5) RBM5"
+    "llm_ranking": [
+      {
+        "entity_name": "CLP1",
+        "llm-average": 17.35
+      },
+      {
+        "entity_name": "SIRT7",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "INTS11",
+        "llm-average": 9.68
+      },
+      {
+        "entity_name": "TOE1",
+        "llm-average": 9.46
+      },
+      {
+        "entity_name": "RBM5",
+        "llm-average": 9.25
+      }
+    ]
   },
   {
     "question_number": 105,
     "qid": 921,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(18:0/22:5(7Z,10Z,13Z,16Z,19Z)/22:5(7Z,10Z,13Z,16Z,19Z)/16:1(9Z)) and are associated with leukoencephalopathy with vanishing white matter.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) CRLS1, (2) AGPAT5"
+    "llm_ranking": [
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 15.07
+      }
+    ]
   },
   {
     "question_number": 106,
     "qid": 924,
     "text": "List the proteins that are subunits of Ubiquitin E3 ligase (SMURF2, SMAD3) - SnoN complex, TGF(beta)-dependent and are associated with reproductive system disease.",
     "category": "reproductive system disease:None",
-    "llm_ranking": "(1) SKIL, (2) SMURF2, (3) SMAD3"
+    "llm_ranking": [
+      {
+        "entity_name": "SKIL",
+        "llm-average": 14.68
+      },
+      {
+        "entity_name": "SMURF2",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "SMAD3",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 107,
     "qid": 929,
     "text": "List the proteins that are subunits of ATR-HDAC2-CHD4 complex and are associated with neuronal ceroid lipofuscinosis.",
     "category": "genetic disease:lysosomal storage disease",
-    "llm_ranking": "(1) ATR, (2) HDAC2"
+    "llm_ranking": [
+      {
+        "entity_name": "ATR",
+        "llm-average": 14.59
+      },
+      {
+        "entity_name": "HDAC2",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 108,
     "qid": 933,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-16:0/a-17:0/i-16:0) and are associated with genetic disease.",
     "category": "genetic disease:None",
-    "llm_ranking": "(1) PTPMT1, (2) CRLS1, (3) GPAM, (4) GPD1, (5) AGPAT5, (6) PGS1, (7) CDS2"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 17.59
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 16.02
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 14.03
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 12.1
+      },
+      {
+        "entity_name": "PGS1",
+        "llm-average": 10.91
+      },
+      {
+        "entity_name": "CDS2",
+        "llm-average": 10.43
+      }
+    ]
   },
   {
     "question_number": 109,
     "qid": 934,
     "text": "List the proteins that are associated with split hand-foot malformation 2 and act on HLA-E.",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) MID1, (2) IRF6"
+    "llm_ranking": [
+      {
+        "entity_name": "MID1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "IRF6",
+        "llm-average": 8.39
+      }
+    ]
   },
   {
     "question_number": 110,
     "qid": 936,
     "text": "List the proteins that are associated with muscle tissue disease and are annotated in the pathway Cardiolipin Biosynthesis CL(i-12:0/i-14:0/a-17:0/18:2(9Z,11Z)).",
     "category": "musculoskeletal system disease:muscle tissue disease",
-    "llm_ranking": "(1) PTPMT1, (2) CRLS1, (3) GPD1, (4) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 16.83
+      },
+      {
+        "entity_name": "CRLS1",
+        "llm-average": 12.39
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 12.13
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.82
+      }
+    ]
   },
   {
     "question_number": 111,
     "qid": 938,
     "text": "List the drugs that interact with Epitizide and have the side effect Immunodeficiency.",
     "category": "Abnormality of the immune system:Immunodeficiency",
-    "llm_ranking": "(1) Methotrexate, (2) Saxagliptin, (3) Zonisamide, (4) Fluconazole"
+    "llm_ranking": [
+      {
+        "entity_name": "Methotrexate",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "Saxagliptin",
+        "llm-average": 13.24
+      },
+      {
+        "entity_name": "Zonisamide",
+        "llm-average": 12.89
+      },
+      {
+        "entity_name": "Fluconazole",
+        "llm-average": 8.15
+      }
+    ]
   },
   {
     "question_number": 112,
     "qid": 939,
     "text": "List the proteins that are associated with hyperinsulinism and are annotated in the pathway Cardiolipin Biosynthesis CL(i-13:0/a-15:0/i-15:0/a-17:0).",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) GPD1, (2) CDS2, (3) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "CDS2",
+        "llm-average": 11.44
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.39
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.81
+      }
+    ]
   },
   {
     "question_number": 113,
     "qid": 940,
     "text": "List the proteins that act on ICOSLG and are associated with paracoccidioidomycosis.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CD40LG, (2) CTLA4, (3) CD28, (4) TNF"
+    "llm_ranking": [
+      {
+        "entity_name": "CD40LG",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "CTLA4",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "CD28",
+        "llm-average": 8.4
+      },
+      {
+        "entity_name": "TNF",
+        "llm-average": 6.03
+      }
+    ]
   },
   {
     "question_number": 114,
     "qid": 941,
     "text": "List the proteins that act on VAV3 and are associated with anal fistula.",
     "category": "gastrointestinal system disease:rectal disease",
-    "llm_ranking": "(1) ERAS, (2) KRAS"
+    "llm_ranking": [
+      {
+        "entity_name": "KRAS",
+        "llm-average": 12.6
+      },
+      {
+        "entity_name": "ERAS",
+        "llm-average": 12.42
+      }
+    ]
   },
   {
     "question_number": 115,
     "qid": 944,
     "text": "List the proteins that are subunits of CD44-ERK1-ERK2-RHAMM complex and are associated with intrahepatic cholestasis.",
     "category": "gastrointestinal system disease:biliary tract disease",
-    "llm_ranking": "(1) CD44, (2) MAPK3"
+    "llm_ranking": [
+      {
+        "entity_name": "CD44",
+        "llm-average": 15.33
+      },
+      {
+        "entity_name": "MAPK3",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 116,
     "qid": 945,
     "text": "List the proteins that are associated with progeria and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(18:1(11Z)/14:0/18:3(6Z,9Z,12Z)).",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) LPIN1, (2) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 16.89
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 13.45
+      }
+    ]
   },
   {
     "question_number": 117,
     "qid": 947,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(8:0/14:0/16:0) and are associated with hyperlipoproteinemia type IV.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 10.01
+      }
+    ]
   },
   {
     "question_number": 118,
     "qid": 951,
     "text": "List the proteins that are associated with glucose metabolism disease and are curated as interacting with TPD52L1.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) PSMC3, (2) AZIN2"
+    "llm_ranking": [
+      {
+        "entity_name": "PSMC3",
+        "llm-average": 10.44
+      },
+      {
+        "entity_name": "AZIN2",
+        "llm-average": 9.19
+      }
+    ]
   },
   {
     "question_number": 119,
     "qid": 954,
     "text": "List the proteins that are annotated in the pathway Tat-mediated HIV elongation arrest and recovery and are associated with colorectal adenoma.",
     "category": "gastrointestinal system disease:intestinal disease",
-    "llm_ranking": "(1) NELFCD, (2) TCEA1, (3) ELOA3P, (4) POLR2A"
+    "llm_ranking": [
+      {
+        "entity_name": "NELFCD",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "TCEA1",
+        "llm-average": 13.71
+      },
+      {
+        "entity_name": "ELOA3P",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "POLR2A",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 120,
     "qid": 956,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(16:1(9Z)/16:1(9Z)/18:0) and are associated with congenital generalized lipodystrophy type 1.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) LPIN1, (2) AGPAT1, (3) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 13.71
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 121,
     "qid": 957,
     "text": "List the proteins that are subunits of CD20-LCK-LYN-FYN-p75/80 complex, (Raji human B cell line) and are associated with type 2 diabetes mellitus.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) FYN, (2) MS4A1, (3) LYN, (4) LCK"
+    "llm_ranking": [
+      {
+        "entity_name": "FYN",
+        "llm-average": 15.11
+      },
+      {
+        "entity_name": "MS4A1",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "LYN",
+        "llm-average": 12.05
+      },
+      {
+        "entity_name": "LCK",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 122,
     "qid": 959,
     "text": "List the proteins that are associated with hematopoietic cell line and are biomarkers of the disease genetic disease.",
     "category": "genetic disease:None",
-    "llm_ranking": "(1) C4A, (2) C3"
+    "llm_ranking": [
+      {
+        "entity_name": "C4A",
+        "llm-average": 7.77
+      },
+      {
+        "entity_name": "C3",
+        "llm-average": 7.03
+      }
+    ]
   },
   {
     "question_number": 123,
     "qid": 962,
     "text": "List the proteins that are associated with warfarin sensitivity and are compiled as interacting with ARFGAP2.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) NHLRC1, (2) KIF6"
+    "llm_ranking": [
+      {
+        "entity_name": "NHLRC1",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "KIF6",
+        "llm-average": 10.22
+      }
+    ]
   },
   {
     "question_number": 124,
     "qid": 966,
     "text": "List the proteins that are associated with complement component 3 deficiency and are compiled as interacting with FST.",
     "category": "immune system disease:complement deficiency",
-    "llm_ranking": "(1) MTOR, (2) TGFB2, (3) IL6, (4) VEGFA, (5) AKT1, (6) FGF2, (7) CTSL"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 15.66
+      },
+      {
+        "entity_name": "TGFB2",
+        "llm-average": 12.0
+      },
+      {
+        "entity_name": "IL6",
+        "llm-average": 9.95
+      },
+      {
+        "entity_name": "VEGFA",
+        "llm-average": 9.52
+      },
+      {
+        "entity_name": "AKT1",
+        "llm-average": 8.55
+      },
+      {
+        "entity_name": "FGF2",
+        "llm-average": 7.04
+      },
+      {
+        "entity_name": "CTSL",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 125,
     "qid": 969,
     "text": "List the proteins that are associated with factor VIII deficiency and are compiled as interacting with RANGAP1.",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) SENP6, (2) SUMO1"
+    "llm_ranking": [
+      {
+        "entity_name": "SENP6",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "SUMO1",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 126,
     "qid": 970,
     "text": "List the proteins that are associated with hypersensitivity reaction disease and act on CCN4.",
     "category": "immune system disease:hypersensitivity reaction disease",
-    "llm_ranking": "(1) MMP2, (2) DCN, (3) RPS6KB1"
+    "llm_ranking": [
+      {
+        "entity_name": "MMP2",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "DCN",
+        "llm-average": 13.06
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 127,
     "qid": 971,
     "text": "List the proteins that are subunits of ITGA4-ITGB1-EMILIN1 complex and are associated with inflammatory bowel disease.",
     "category": "gastrointestinal system disease:inflammatory bowel disease",
-    "llm_ranking": "(1) EMILIN1, (2) ITGB1, (3) ITGA4"
+    "llm_ranking": [
+      {
+        "entity_name": "EMILIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "ITGB1",
+        "llm-average": 6.63
+      },
+      {
+        "entity_name": "ITGA4",
+        "llm-average": 6.27
+      }
+    ]
   },
   {
     "question_number": 128,
     "qid": 978,
     "text": "List the proteins that are subunits of BRCA1-cABL complex and are associated with SHORT syndrome.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) ABL1, (2) BRCA1"
+    "llm_ranking": [
+      {
+        "entity_name": "ABL1",
+        "llm-average": 13.65
+      },
+      {
+        "entity_name": "BRCA1",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 129,
     "qid": 979,
     "text": "List the proteins that are annotated in the pathway Phosphatidylethanolamine Biosynthesis PE(22:4(7Z,10Z,13Z,16Z)/18:3(9Z,12Z,15Z)) and are associated with prostate disease.",
     "category": "reproductive system disease:prostate disease",
-    "llm_ranking": "(1) PTDSS1, (2) CHKA"
+    "llm_ranking": [
+      {
+        "entity_name": "PTDSS1",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "CHKA",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 130,
     "qid": 982,
     "text": "List the proteins that are associated with cocaine abuse and are subunits of ESR1-TRAP/Mediator coactivator-complex.",
     "category": "disease of mental health:substance abuse",
-    "llm_ranking": "(1) EP300, (2) ESR1"
+    "llm_ranking": [
+      {
+        "entity_name": "ESR1",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "EP300",
+        "llm-average": 13.45
+      }
+    ]
   },
   {
     "question_number": 131,
     "qid": 988,
     "text": "List the proteins that are associated with cryptosporidiosis and are compiled as interacting with CRMP1.",
     "category": "gastrointestinal system disease:cryptosporidiosis",
-    "llm_ranking": "(1) CDK5R1, (2) CAD"
+    "llm_ranking": [
+      {
+        "entity_name": "CDK5R1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "CAD",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 132,
     "qid": 993,
     "text": "List the proteins that act on PDZD2 and are associated with Charcot-Marie-Tooth disease type 1D.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) RHOT2, (2) RHOT1, (3) BAG3, (4) DMPK, (5) RIPK3"
+    "llm_ranking": [
+      {
+        "entity_name": "RHOT2",
+        "llm-average": 11.71
+      },
+      {
+        "entity_name": "RHOT1",
+        "llm-average": 10.19
+      },
+      {
+        "entity_name": "BAG3",
+        "llm-average": 9.92
+      },
+      {
+        "entity_name": "DMPK",
+        "llm-average": 6.44
+      },
+      {
+        "entity_name": "RIPK3",
+        "llm-average": 5.18
+      }
+    ]
   },
   {
     "question_number": 133,
     "qid": 994,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(i-24:0/i-21:0/12:0) and are associated with colonic disease.",
     "category": "gastrointestinal system disease:colonic disease",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPAM, (4) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 134,
     "qid": 997,
     "text": "List the proteins that are associated with type 1 diabetes mellitus 23 and act on NEURL1B.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) NOTCH3, (2) NOTCH2"
+    "llm_ranking": [
+      {
+        "entity_name": "NOTCH3",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "NOTCH2",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 135,
     "qid": 999,
     "text": "List the proteins that are compiled as interacting with PDE1C and are associated with branched-chain keto acid dehydrogenase kinase deficiency.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) ITPR1, (2) ADSL"
+    "llm_ranking": [
+      {
+        "entity_name": "ADSL",
+        "llm-average": 13.46
+      },
+      {
+        "entity_name": "ITPR1",
+        "llm-average": 13.45
+      }
+    ]
   },
   {
     "question_number": 136,
     "qid": 1002,
     "text": "List the proteins that are associated with Charcot-Marie-Tooth disease X-linked recessive 5 and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(16:1(9Z)/18:3(9Z,12Z,15Z)/18:4(6Z,9Z,12Z,15Z)).",
     "category": "genetic disease:X-linked monogenic disease",
-    "llm_ranking": "(1) LPIN1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 14.3
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 12.89
+      }
+    ]
   },
   {
     "question_number": 137,
     "qid": 1004,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(16:0/22:5(7Z,10Z,13Z,16Z,19Z)/18:1(11Z)) and are associated with skin disease.",
     "category": "integumentary system disease:skin disease",
-    "llm_ranking": "(1) GPAM, (2) DGAT1, (3) LPIN1, (4) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "GPAM",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 14.61
+      },
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 12.71
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 138,
     "qid": 1006,
     "text": "List the proteins that are associated with complete generalized lipodystrophy and are annotated in the pathway Cardiolipin Biosynthesis CL(i-12:0/a-13:0/i-14:0/i-15:0).",
     "category": "musculoskeletal system disease:lipodystrophy",
-    "llm_ranking": "(1) AGPAT5, (2) GPAM, (3) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "AGPAT5",
+        "llm-average": 15.62
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 10.73
+      }
+    ]
   },
   {
     "question_number": 139,
     "qid": 1008,
     "text": "List the drugs that interact with Eldecalcitol and are indicated for Patchy alopecia.",
     "category": "Abnormality of the integument:Abnormal hair morphology",
-    "llm_ranking": "(1) Triamcinolone, (2) Dexamethasone, (3) Betamethasone, (4) Methylprednisolone"
+    "llm_ranking": [
+      {
+        "entity_name": "Triamcinolone",
+        "llm-average": 11.25
+      },
+      {
+        "entity_name": "Dexamethasone",
+        "llm-average": 7.26
+      },
+      {
+        "entity_name": "Betamethasone",
+        "llm-average": 7.04
+      },
+      {
+        "entity_name": "Methylprednisolone",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 140,
     "qid": 1010,
     "text": "List the proteins that are annotated in the pathway Intrinsic Pathway of Fibrin Clot Formation and are associated with homocystinuria.",
     "category": "genetic disease:amino acid metabolic disorder",
-    "llm_ranking": "(1) SERPIND1, (2) PROC, (3) F12, (4) F2, (5) F8, (6) SERPINC1, (7) VWF, (8) KNG1"
+    "llm_ranking": [
+      {
+        "entity_name": "SERPIND1",
+        "llm-average": 15.75
+      },
+      {
+        "entity_name": "PROC",
+        "llm-average": 14.24
+      },
+      {
+        "entity_name": "F12",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "F2",
+        "llm-average": 9.81
+      },
+      {
+        "entity_name": "SERPINC1",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "F8",
+        "llm-average": 9.04
+      },
+      {
+        "entity_name": "VWF",
+        "llm-average": 5.74
+      },
+      {
+        "entity_name": "KNG1",
+        "llm-average": 4.76
+      }
+    ]
   },
   {
     "question_number": 141,
     "qid": 1011,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:1(13Z)/20:5(5Z,8Z,11Z,14Z,17Z)/22:6(4Z,7Z,10Z,13Z,16Z,19Z)) and are associated with lipodystrophy.",
     "category": "musculoskeletal system disease:lipodystrophy",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPD1, (4) GPAM, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 18.71
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 12.98
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 8.93
+      }
+    ]
   },
   {
     "question_number": 142,
     "qid": 1013,
     "text": "List the proteins that are compiled as interacting with NCAPH2 and are associated with polymyositis.",
     "category": "musculoskeletal system disease:None",
-    "llm_ranking": "(1) STAG1, (2) CD69, (3) STAG2, (4) H2AC20, (5) H2BC21"
+    "llm_ranking": [
+      {
+        "entity_name": "STAG1",
+        "llm-average": 10.69
+      },
+      {
+        "entity_name": "CD69",
+        "llm-average": 10.28
+      },
+      {
+        "entity_name": "STAG2",
+        "llm-average": 9.95
+      },
+      {
+        "entity_name": "H2AC20",
+        "llm-average": 7.16
+      },
+      {
+        "entity_name": "H2BC21",
+        "llm-average": 3.6
+      }
+    ]
   },
   {
     "question_number": 143,
     "qid": 1014,
     "text": "List the proteins that are associated with hyperphosphatemic familial tumoral calcinosis and are QC markers in the tissue blood plasma.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) HSPA8, (2) GAPDH, (3) ACTB"
+    "llm_ranking": [
+      {
+        "entity_name": "HSPA8",
+        "llm-average": 7.66
+      },
+      {
+        "entity_name": "GAPDH",
+        "llm-average": 7.56
+      },
+      {
+        "entity_name": "ACTB",
+        "llm-average": 6.25
+      }
+    ]
   },
   {
     "question_number": 144,
     "qid": 1016,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-13:0/i-21:0/i-14:0/a-15:0) and are associated with Bartter disease.",
     "category": "genetic disease:monogenic disease",
-    "llm_ranking": "(1) PTPMT1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "PTPMT1",
+        "llm-average": 16.09
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 10.3
+      }
+    ]
   },
   {
     "question_number": 145,
     "qid": 1020,
     "text": "List the proteins that are associated with autosomal genetic disease and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(20:1(11Z)/20:1(11Z)/20:4(8Z,11Z,14Z,17Z)).",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) LPIN1, (2) GPAM, (3) GPD1, (4) DGAT1, (5) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 15.3
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 10.81
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 146,
     "qid": 1022,
     "text": "List the drugs that are indicated for Excessive salivation and interact with MK-212.",
     "category": "Abnormality of the head:Abnormality of the mouth",
-    "llm_ranking": "(1) Hyoscyamine, (2) Atropine"
+    "llm_ranking": [
+      {
+        "entity_name": "Hyoscyamine",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "Atropine",
+        "llm-average": 11.5
+      }
+    ]
   },
   {
     "question_number": 147,
     "qid": 1023,
     "text": "List the proteins that are associated with non-alcoholic steatohepatitis and are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(a-25:0/i-18:0/a-21:0).",
     "category": "genetic disease:lysosomal storage disease",
-    "llm_ranking": "(1) DGAT1, (2) LPIN1, (3) GPAM, (4) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 12.72
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 7.09
+      }
+    ]
   },
   {
     "question_number": 148,
     "qid": 1024,
     "text": "List the proteins that are associated with distal muscular dystrophy with anterior tibial onset and are annotated in the pathway Cardiolipin Biosynthesis CL(a-13:0/i-19:0/a-13:0/a-15:0).",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) GPD1, (2) CDS2"
+    "llm_ranking": [
+      {
+        "entity_name": "CDS2",
+        "llm-average": 15.27
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 15.07
+      }
+    ]
   },
   {
     "question_number": 149,
     "qid": 1025,
     "text": "List the proteins that act on ZAP70 and are associated with extrahepatic cholestasis.",
     "category": "gastrointestinal system disease:biliary tract disease",
-    "llm_ranking": "(1) LIFR, (2) MAPK14, (3) MAPK1"
+    "llm_ranking": [
+      {
+        "entity_name": "LIFR",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "MAPK14",
+        "llm-average": 11.16
+      },
+      {
+        "entity_name": "MAPK1",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 150,
     "qid": 1026,
     "text": "List the proteins that act on DAAM2 and are associated with primary autosomal recessive microcephaly.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) CIT, (2) DVL3, (3) DVL2"
+    "llm_ranking": [
+      {
+        "entity_name": "CIT",
+        "llm-average": 14.98
+      },
+      {
+        "entity_name": "DVL3",
+        "llm-average": 9.19
+      },
+      {
+        "entity_name": "DVL2",
+        "llm-average": 8.85
+      }
+    ]
   },
   {
     "question_number": 151,
     "qid": 1032,
     "text": "List the proteins that are associated with gastroparesis and are curated as interacting with H3-4.",
     "category": "gastrointestinal system disease:functional gastric disease",
-    "llm_ranking": "(1) HTR7, (2) CREB1, (3) JUN"
+    "llm_ranking": [
+      {
+        "entity_name": "HTR7",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "CREB1",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "JUN",
+        "llm-average": 10.3
+      }
+    ]
   },
   {
     "question_number": 152,
     "qid": 1047,
     "text": "List the proteins that are annotated in the pathway Cardiolipin Biosynthesis CL(i-14:0/i-12:0/i-22:0/i-24:0) and are associated with Griscelli syndrome type 2.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) PGS1, (2) GPAM"
+    "llm_ranking": [
+      {
+        "entity_name": "PGS1",
+        "llm-average": 14.51
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 10.3
+      }
+    ]
   },
   {
     "question_number": 153,
     "qid": 1048,
     "text": "List the proteins that are associated with autosomal recessive hypercholesterolemia and are annotated in the pathway VxPx cargo-targeting to cilium.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) RHO, (2) RAB8A, (3) RAB11A, (4) EXOC7, (5) EXOC5, (6) EXOC4"
+    "llm_ranking": [
+      {
+        "entity_name": "RAB8A",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "RHO",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "RAB11A",
+        "llm-average": 10.38
+      },
+      {
+        "entity_name": "EXOC7",
+        "llm-average": 8.86
+      },
+      {
+        "entity_name": "EXOC5",
+        "llm-average": 8.47
+      },
+      {
+        "entity_name": "EXOC4",
+        "llm-average": 7.64
+      }
+    ]
   },
   {
     "question_number": 154,
     "qid": 1049,
     "text": "List the proteins that are curated as interacting with SIK3 and are associated with schizoaffective disorder.",
     "category": "disease of mental health:psychotic disorder",
-    "llm_ranking": "(1) YWHAH, (2) MAPT, (3) PPP3CC"
+    "llm_ranking": [
+      {
+        "entity_name": "YWHAH",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "MAPT",
+        "llm-average": 14.61
+      },
+      {
+        "entity_name": "PPP3CC",
+        "llm-average": 11.83
+      }
+    ]
   },
   {
     "question_number": 155,
     "qid": 1053,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(10:0/a-13:0/17:0) and are associated with non-alcoholic steatohepatitis.",
     "category": "genetic disease:lysosomal storage disease",
-    "llm_ranking": "(1) LPIN1, (2) DGAT1, (3) GPAM, (4) AGPAT1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 18.38
+      },
+      {
+        "entity_name": "DGAT1",
+        "llm-average": 17.27
+      },
+      {
+        "entity_name": "GPAM",
+        "llm-average": 11.83
+      },
+      {
+        "entity_name": "AGPAT1",
+        "llm-average": 7.85
+      }
+    ]
   },
   {
     "question_number": 156,
     "qid": 1055,
     "text": "List the proteins that are annotated in the pathway Non-integrin membrane-ECM interactions and are associated with dilated cardiomyopathy 2A.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) LAMA2, (2) DDR1, (3) DMD, (4) FN1"
+    "llm_ranking": [
+      {
+        "entity_name": "LAMA2",
+        "llm-average": 15.65
+      },
+      {
+        "entity_name": "DDR1",
+        "llm-average": 12.48
+      },
+      {
+        "entity_name": "FN1",
+        "llm-average": 9.94
+      },
+      {
+        "entity_name": "DMD",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 157,
     "qid": 1056,
     "text": "List the proteins that are subunits of NOS3-CAV1-NOSTRIN complex and are associated with mood disorder.",
     "category": "disease of mental health:mood disorder",
-    "llm_ranking": "(1) NOS3, (2) CAV1"
+    "llm_ranking": [
+      {
+        "entity_name": "NOS3",
+        "llm-average": 17.24
+      },
+      {
+        "entity_name": "CAV1",
+        "llm-average": 9.68
+      }
+    ]
   },
   {
     "question_number": 158,
     "qid": 1058,
     "text": "List the proteins that are annotated in the pathway De Novo Triacylglycerol Biosynthesis TG(22:0/i-13:0/i-15:0) and are associated with glycogen storage disease V.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) LPIN1, (2) GPD1"
+    "llm_ranking": [
+      {
+        "entity_name": "LPIN1",
+        "llm-average": 13.45
+      },
+      {
+        "entity_name": "GPD1",
+        "llm-average": 9.38
+      }
+    ]
   },
   {
     "question_number": 159,
     "qid": 1070,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are curated as interacting with PRAG1.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CRKL, (2) CRK, (3) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 11.88
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 160,
     "qid": 1071,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and act on LPXN.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 161,
     "qid": 1078,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and act on FGFR3.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CBL, (2) CRK, (3) MDM2"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 18.13
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "MDM2",
+        "llm-average": 10.01
+      }
+    ]
   },
   {
     "question_number": 162,
     "qid": 1085,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and act on MAPK10.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) TP53, (2) BCL2L1, (3) CRK, (4) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 15.21
+      },
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 7.99
+      }
+    ]
   },
   {
     "question_number": 163,
     "qid": 1086,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and act on BMX.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) TP53, (2) CBL, (3) CRKL, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 10.6
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 10.27
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 7.24
+      }
+    ]
   },
   {
     "question_number": 164,
     "qid": 1090,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are curated as interacting with CNTNAP1.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) GRB2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "GRB2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      }
+    ]
   },
   {
     "question_number": 165,
     "qid": 1099,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are curated as interacting with HTT.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) GAB2, (2) TP53, (3) CRK, (4) PIK3R1"
+    "llm_ranking": [
+      {
+        "entity_name": "GAB2",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 7.09
+      }
+    ]
   },
   {
     "question_number": 166,
     "qid": 1101,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are compiled as interacting with PTK2.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 167,
     "qid": 1103,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and act on LPXN.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CRK, (2) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 8.59
+      }
+    ]
   },
   {
     "question_number": 168,
     "qid": 1108,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are compiled as interacting with GOLPH3.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CRK, (2) MYC"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 169,
     "qid": 1115,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and act on BMX.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) CBL, (2) TP53, (3) CRKL, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 14.18
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 10.3
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 9.08
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 170,
     "qid": 1120,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are compiled as interacting with GOLPH3.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) MYC, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      }
+    ]
   },
   {
     "question_number": 171,
     "qid": 1130,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are compiled as interacting with GOLPH3.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) CRK, (2) MYC"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 9.86
+      }
+    ]
   },
   {
     "question_number": 172,
     "qid": 1134,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are compiled as interacting with SOCS6.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) SKP2, (2) STAT5A, (3) JAK2, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "SKP2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "STAT5A",
+        "llm-average": 10.99
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 10.72
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 173,
     "qid": 1144,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are compiled as interacting with TGFB1I1.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) MYC, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 174,
     "qid": 1148,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are the subunits of CIN85 complex (CIN85, CRK, BCAR1, CBL, PIK3R1, GRB2, SOS1).",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) PIK3R1, (2) GRB2, (3) CBL, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 17.0
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 9.44
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      }
+    ]
   },
   {
     "question_number": 175,
     "qid": 1156,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and act on FRS2.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRKL, (2) CBL, (3) CRK, (4) GRB2, (5) SOS1, (6) PIK3R1"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 14.48
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 11.39
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 9.37
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 8.87
+      }
+    ]
   },
   {
     "question_number": 176,
     "qid": 1157,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are curated as interacting with PTPN4.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) PIK3R1, (2) CRK, (3) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 13.75
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 177,
     "qid": 1158,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are curated as interacting with PRAG1.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) CRKL, (2) CRK, (3) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.75
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 178,
     "qid": 1161,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are compiled as interacting with RAC3.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) PIK3R1, (2) GRB2, (3) CRK, (4) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 16.55
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 7.99
+      }
+    ]
   },
   {
     "question_number": 179,
     "qid": 1164,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are compiled as interacting with DOCK7.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.64
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 180,
     "qid": 1166,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are compiled as interacting with TGFB1I1.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRKL, (2) MYC, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 14.14
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 11.73
+      }
+    ]
   },
   {
     "question_number": 181,
     "qid": 1177,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are compiled as interacting with SOCS6.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) JAK2, (2) STAT5A, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 19.25
+      },
+      {
+        "entity_name": "STAT5A",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 182,
     "qid": 1187,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are compiled as interacting with BCAR1.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.26
+      }
+    ]
   },
   {
     "question_number": 183,
     "qid": 1197,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are compiled as interacting with IRS4.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) PIK3R1, (2) MTOR, (3) GRB2, (4) CRK, (5) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 19.25
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 17.72
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 9.37
+      }
+    ]
   },
   {
     "question_number": 184,
     "qid": 1201,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and act on MAPK10.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) BCL2L1, (2) TP53, (3) CRK, (4) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 9.14
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 7.99
+      }
+    ]
   },
   {
     "question_number": 185,
     "qid": 1203,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are compiled as interacting with TGFB1I1.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) CRKL, (2) CRK, (3) MYC"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.96
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 186,
     "qid": 1205,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and act on SHC1.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) CRK, (2) JAK2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 8.74
+      }
+    ]
   },
   {
     "question_number": 187,
     "qid": 1206,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are the subunits of CRKL-PDGFRA-CRK-RAPGEF1 complex.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.64
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 188,
     "qid": 1226,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are compiled as interacting with IRS4.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) PIK3R1, (2) MTOR, (3) CRK, (4) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 189,
     "qid": 1232,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are compiled as interacting with FGFR3.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) PIK3R1, (2) TP53, (3) MDM2, (4) MYC, (5) CBL, (6) CRK, (7) GRB2, (8) JAK2"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "MDM2",
+        "llm-average": 11.97
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 9.85
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 6.1
+      }
+    ]
   },
   {
     "question_number": 190,
     "qid": 1241,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are compiled as interacting with BCAR1.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) JAK2, (2) PIK3R1, (3) GRB2, (4) RPS6KB1, (5) CBL, (6) CRK, (7) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 16.7
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 14.96
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 10.75
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 8.03
+      }
+    ]
   },
   {
     "question_number": 191,
     "qid": 1243,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and act on BMX.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) CBL, (2) TP53, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 14.18
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.74
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.21
+      }
+    ]
   },
   {
     "question_number": 192,
     "qid": 1253,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and act on BMX.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) CBL, (2) TP53, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 16.05
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 8.74
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.21
+      }
+    ]
   },
   {
     "question_number": 193,
     "qid": 1265,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are curated as interacting with CNTNAP1.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 194,
     "qid": 1270,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are curated as interacting with CNTNAP1.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 14.33
+      }
+    ]
   },
   {
     "question_number": 195,
     "qid": 1272,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are compiled as interacting with IRS4.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) PIK3R1, (2) MTOR, (3) CRK, (4) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 12.21
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 196,
     "qid": 1275,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are compiled as interacting with PEAK1.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 13.43
+      }
+    ]
   },
   {
     "question_number": 197,
     "qid": 1277,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and act on LPXN.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) CRK, (2) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 8.59
+      }
+    ]
   },
   {
     "question_number": 198,
     "qid": 1291,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are compiled as interacting with GOLPH3.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) CRK, (2) MYC"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 14.76
+      },
+      {
+        "entity_name": "MYC",
+        "llm-average": 14.33
+      }
+    ]
   },
   {
     "question_number": 199,
     "qid": 1299,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are curated as interacting with CNTNAP1.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) GRB2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "GRB2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      }
+    ]
   },
   {
     "question_number": 200,
     "qid": 1306,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are compiled as interacting with TGFB1I1.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) MYC, (2) CRK, (3) CRKL"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 8.29
+      }
+    ]
   },
   {
     "question_number": 201,
     "qid": 1315,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are curated as interacting with PTPN4.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) PIK3R1, (2) CRK, (3) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 13.75
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.97
+      }
+    ]
   },
   {
     "question_number": 202,
     "qid": 1323,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are curated as interacting with HTT.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) PIK3R1, (2) TP53, (3) GAB2, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 15.86
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "GAB2",
+        "llm-average": 10.76
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 203,
     "qid": 1326,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are curated as interacting with CNTNAP1.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 204,
     "qid": 1339,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are curated as interacting with PTPN4.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) PIK3R1, (2) GRB2, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 17.9
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 205,
     "qid": 1340,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are curated as interacting with HTT.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) PIK3R1, (2) TP53, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 206,
     "qid": 1344,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are compiled as interacting with PEAK1.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 207,
     "qid": 1359,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are the subunits of CIN85 complex (CIN85, CRK, BCAR1, CBL, PIK3R1, GRB2, SOS1).",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) SOS1, (2) CBL, (3) PIK3R1, (4) CRK, (5) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 12.36
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 11.02
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 10.14
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.62
+      }
+    ]
   },
   {
     "question_number": 208,
     "qid": 1367,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are compiled as interacting with PEAK1.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 12.26
+      }
+    ]
   },
   {
     "question_number": 209,
     "qid": 1368,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are curated as interacting with PRAG1.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 12.68
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.49
+      }
+    ]
   },
   {
     "question_number": 210,
     "qid": 1369,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are compiled as interacting with DOCK7.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.64
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 211,
     "qid": 1372,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and act on MAPK10.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) BCL2L1, (2) CRK, (3) CRKL, (4) TP53"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 7.99
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 6.22
+      }
+    ]
   },
   {
     "question_number": 212,
     "qid": 1377,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and act on FRS2.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) PIK3R1, (2) CRKL, (3) GAB2, (4) CBL, (5) CRK, (6) GRB2, (7) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 10.78
+      },
+      {
+        "entity_name": "GAB2",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 10.19
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 9.82
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 6.79
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 4.36
+      }
+    ]
   },
   {
     "question_number": 213,
     "qid": 1399,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are compiled as interacting with RAC3.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) GRB2, (2) PIK3R1, (3) CRK, (4) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "GRB2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 12.81
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 7.99
+      }
+    ]
   },
   {
     "question_number": 214,
     "qid": 1401,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are curated as interacting with HTT.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) PIK3R1, (2) TP53, (3) CRK, (4) GAB2"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 13.72
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "GAB2",
+        "llm-average": 7.99
+      }
+    ]
   },
   {
     "question_number": 215,
     "qid": 1404,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are compiled as interacting with IRS1.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.11
+      }
+    ]
   },
   {
     "question_number": 216,
     "qid": 1409,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with Blau syndrome, and are compiled as interacting with FGFR3.",
     "category": "genetic disease:autosomal genetic disease",
-    "llm_ranking": "(1) JAK2, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 14.33
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 217,
     "qid": 1421,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and act on SHC1.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) MTOR, (2) JAK2, (3) RPS6KB1, (4) GAB2, (5) CBL, (6) CRK, (7) GRB2, (8) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "MTOR",
+        "llm-average": 12.74
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.7
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 11.37
+      },
+      {
+        "entity_name": "GAB2",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 8.94
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 7.17
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 7.13
+      }
+    ]
   },
   {
     "question_number": 218,
     "qid": 1423,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and act on MAPK10.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) TP53, (2) CRK, (3) BCL2L1"
+    "llm_ranking": [
+      {
+        "entity_name": "TP53",
+        "llm-average": 13.98
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 8.74
+      }
+    ]
   },
   {
     "question_number": 219,
     "qid": 1430,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are curated as interacting with WASL.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 12.26
+      }
+    ]
   },
   {
     "question_number": 220,
     "qid": 1439,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are compiled as interacting with TGFB1I1.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) MYC, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "MYC",
+        "llm-average": 12.26
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 221,
     "qid": 1446,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with familial hyperlipidemia, and are compiled as interacting with BCAR1.",
     "category": "genetic disease:lipid metabolism disorder",
-    "llm_ranking": "(1) PIK3R1, (2) GRB2, (3) JAK2, (4) CBL, (5) CRK, (6) RPS6KB1"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 14.91
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 11.92
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 11.39
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 5.89
+      }
+    ]
   },
   {
     "question_number": 222,
     "qid": 1448,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are compiled as interacting with SOCS6.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) JAK2, (2) STAT5A, (3) SKP2, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "JAK2",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "STAT5A",
+        "llm-average": 15.83
+      },
+      {
+        "entity_name": "SKP2",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 6.94
+      }
+    ]
   },
   {
     "question_number": 223,
     "qid": 1449,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are compiled as interacting with BCAR1.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) CRKL, (2) JAK2, (3) GRB2, (4) CRK, (5) CBL, (6) PIK3R1, (7) RPS6KB1"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.64
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.61
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 11.73
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 11.0
+      },
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 8.03
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 5.0
+      }
+    ]
   },
   {
     "question_number": 224,
     "qid": 1451,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and act on SHC1.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) RPS6KB1, (2) MTOR, (3) JAK2, (4) GRB2, (5) GAB2, (6) CBL, (7) SOS1, (8) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 15.86
+      },
+      {
+        "entity_name": "MTOR",
+        "llm-average": 14.99
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 11.2
+      },
+      {
+        "entity_name": "GAB2",
+        "llm-average": 10.29
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 8.94
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 225,
     "qid": 1454,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and act on MAPK10.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) BCL2L1, (2) TP53, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "BCL2L1",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.21
+      }
+    ]
   },
   {
     "question_number": 226,
     "qid": 1469,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with chromosomal deletion syndrome, and are curated as interacting with HTT.",
     "category": "genetic disease:chromosomal deletion syndrome",
-    "llm_ranking": "(1) PIK3R1, (2) TP53, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "TP53",
+        "llm-average": 11.21
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.11
+      }
+    ]
   },
   {
     "question_number": 227,
     "qid": 1470,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and act on FGFR3.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) CBL, (2) MDM2, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 19.25
+      },
+      {
+        "entity_name": "MDM2",
+        "llm-average": 12.63
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      }
+    ]
   },
   {
     "question_number": 228,
     "qid": 1472,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are the subunits of CRKL-PDGFRA-CRK-RAPGEF1 complex.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CRKL, (2) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CRKL",
+        "llm-average": 13.64
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 10.61
+      }
+    ]
   },
   {
     "question_number": 229,
     "qid": 1485,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and act on FGFR3.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) CBL, (2) MDM2, (3) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "CBL",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "MDM2",
+        "llm-average": 14.7
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 230,
     "qid": 1489,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with bone disease, and are curated as interacting with WASL.",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) CRK, (2) GRB2"
+    "llm_ranking": [
+      {
+        "entity_name": "CRK",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 8.59
+      }
+    ]
   },
   {
     "question_number": 231,
     "qid": 1491,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and are compiled as interacting with SOCS6.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) SKP2, (2) JAK2, (3) STAT5A, (4) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "SKP2",
+        "llm-average": 13.81
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 11.77
+      },
+      {
+        "entity_name": "STAT5A",
+        "llm-average": 10.99
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 9.71
+      }
+    ]
   },
   {
     "question_number": 232,
     "qid": 1515,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with type 2 diabetes mellitus, and are compiled as interacting with BCAR1.",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) PIK3R1, (2) JAK2, (3) CBL, (4) GRB2, (5) RPS6KB1, (6) CRK"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 13.58
+      },
+      {
+        "entity_name": "JAK2",
+        "llm-average": 12.12
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 10.67
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 9.93
+      },
+      {
+        "entity_name": "RPS6KB1",
+        "llm-average": 7.58
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 5.59
+      }
+    ]
   },
   {
     "question_number": 233,
     "qid": 1520,
     "text": "List the proteins that are annotated in the pathway Bosutinib Inhibition of BCR-ABL, are associated with ovarian disease, and act on FRS2.",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) PIK3R1, (2) GRB2, (3) GAB2, (4) CRKL, (5) CRK, (6) CBL, (7) SOS1"
+    "llm_ranking": [
+      {
+        "entity_name": "PIK3R1",
+        "llm-average": 14.24
+      },
+      {
+        "entity_name": "GAB2",
+        "llm-average": 12.12
+      },
+      {
+        "entity_name": "GRB2",
+        "llm-average": 11.63
+      },
+      {
+        "entity_name": "CRKL",
+        "llm-average": 9.82
+      },
+      {
+        "entity_name": "CRK",
+        "llm-average": 8.36
+      },
+      {
+        "entity_name": "CBL",
+        "llm-average": 8.12
+      },
+      {
+        "entity_name": "SOS1",
+        "llm-average": 5.74
+      }
+    ]
   },
   {
     "question_number": 234,
     "qid": 287,
     "text": "List the proteins that are acted on by GIPR, which Chenodeoxycholic acid acts on.",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) GPHB5, (2) ADCYAP1R1, (3) CGA, (4) GNB1"
+    "llm_ranking": [
+      {
+        "entity_name": "GPHB5",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "ADCYAP1R1",
+        "llm-average": 12.61
+      },
+      {
+        "entity_name": "CGA",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "GNB1",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 235,
     "qid": 290,
     "text": "List the proteins that are acted on by Trabectedin, which Trametinib interacts with.",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) JUN, (2) CYP2C9, (3) NR1I2"
+    "llm_ranking": [
+      {
+        "entity_name": "CYP2C9",
+        "llm-average": 14.84
+      },
+      {
+        "entity_name": "JUN",
+        "llm-average": 13.86
+      },
+      {
+        "entity_name": "NR1I2",
+        "llm-average": 7.71
+      }
+    ]
   },
   {
     "question_number": 236,
     "qid": 292,
     "text": "List the proteins that are acted on by Zanamivir, which Trametinib interacts with.",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) NEU3, (2) NEU1, (3) NEU2"
+    "llm_ranking": [
+      {
+        "entity_name": "NEU3",
+        "llm-average": 13.93
+      },
+      {
+        "entity_name": "NEU2",
+        "llm-average": 9.27
+      },
+      {
+        "entity_name": "NEU1",
+        "llm-average": 9.26
+      }
+    ]
   },
   {
     "question_number": 237,
     "qid": 305,
     "text": "Which proteins are acted on by RARRES1, which is compiled as a target of Tazarotene?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) CTCF, (2) TMEM192"
+    "llm_ranking": [
+      {
+        "entity_name": "TMEM192",
+        "llm-average": 15.08
+      },
+      {
+        "entity_name": "CTCF",
+        "llm-average": 14.04
+      }
+    ]
   },
   {
     "question_number": 238,
     "qid": 319,
     "text": "List the biological processes that are associated with RARRES1, which is compiled as a target of Tazarotene.",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) negative regulation of endopeptidase activity, (2) negative regulation of cell population proliferation"
+    "llm_ranking": [
+      {
+        "entity_name": "negative regulation of cell population proliferation",
+        "llm-average": 11.53
+      },
+      {
+        "entity_name": "negative regulation of endopeptidase activity",
+        "llm-average": 10.94
+      }
+    ]
   },
   {
     "question_number": 239,
     "qid": 322,
     "text": "Which proteins are acted on by SLCO1B1, which Chenodeoxycholic acid acts on?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) SLCO1B3, (2) ALB"
+    "llm_ranking": [
+      {
+        "entity_name": "SLCO1B3",
+        "llm-average": 10.94
+      },
+      {
+        "entity_name": "ALB",
+        "llm-average": 3.83
+      }
+    ]
   },
   {
     "question_number": 240,
     "qid": 323,
     "text": "Which pathways are annotated with SLCO1B1, which Chenodeoxycholic acid acts on?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Defective SLCO1B1 causes hyperbilirubinemia, Rotor type (HBLRR), (2) Recycling of bile acids and salts, (3) Transport of organic anions, (4) Heme degradation, (5) Irinotecan Action Pathway, (6) Rosiglitazone Metabolism Pathway, (7) Irinotecan Metabolism Pathway, (8) Mycophenolic Acid Metabolism Pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Defective SLCO1B1 causes hyperbilirubinemia, Rotor type (HBLRR)",
+        "llm-average": 16.36
+      },
+      {
+        "entity_name": "Recycling of bile acids and salts",
+        "llm-average": 15.41
+      },
+      {
+        "entity_name": "Transport of organic anions",
+        "llm-average": 11.74
+      },
+      {
+        "entity_name": "Heme degradation",
+        "llm-average": 9.57
+      },
+      {
+        "entity_name": "Irinotecan Action Pathway",
+        "llm-average": 6.4
+      },
+      {
+        "entity_name": "Rosiglitazone Metabolism Pathway",
+        "llm-average": 4.33
+      },
+      {
+        "entity_name": "Irinotecan Metabolism Pathway",
+        "llm-average": 3.61
+      },
+      {
+        "entity_name": "Mycophenolic Acid Metabolism Pathway",
+        "llm-average": 3.11
+      }
+    ]
   },
   {
     "question_number": 241,
     "qid": 324,
     "text": "List the pathways that are annotated with IFNA6, which Chenodeoxycholic acid acts on.",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) TRAF6 mediated IRF7 activation, (2) Factors involved in megakaryocyte development and platelet production, (3) Interferon alpha/beta signaling, (4) Regulation of IFNA signaling"
+    "llm_ranking": [
+      {
+        "entity_name": "TRAF6 mediated IRF7 activation",
+        "llm-average": 10.93
+      },
+      {
+        "entity_name": "Interferon alpha/beta signaling",
+        "llm-average": 8.95
+      },
+      {
+        "entity_name": "Factors involved in megakaryocyte development and platelet production",
+        "llm-average": 7.83
+      },
+      {
+        "entity_name": "Regulation of IFNA signaling",
+        "llm-average": 7.33
+      }
+    ]
   },
   {
     "question_number": 242,
     "qid": 336,
     "text": "Which genes are curated as targets of Megestrol acetate, which Trametinib interacts with?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) interleukin 15, (2) ATP binding cassette subfamily B member 1, (3) sphingosine-1-phosphate receptor 4, (4) sphingosine-1-phosphate receptor 1, (5) interleukin 2 receptor subunit alpha, (6) kallikrein related peptidase 3, (7) progesterone receptor, (8) estrogen receptor 1"
+    "llm_ranking": [
+      {
+        "entity_name": "ATP binding cassette subfamily B member 1",
+        "llm-average": 14.2
+      },
+      {
+        "entity_name": "sphingosine-1-phosphate receptor 4",
+        "llm-average": 13.78
+      },
+      {
+        "entity_name": "interleukin 15",
+        "llm-average": 13.55
+      },
+      {
+        "entity_name": "sphingosine-1-phosphate receptor 1",
+        "llm-average": 11.86
+      },
+      {
+        "entity_name": "interleukin 2 receptor subunit alpha",
+        "llm-average": 8.63
+      },
+      {
+        "entity_name": "progesterone receptor",
+        "llm-average": 5.5
+      },
+      {
+        "entity_name": "kallikrein related peptidase 3",
+        "llm-average": 5.38
+      },
+      {
+        "entity_name": "estrogen receptor 1",
+        "llm-average": 4.34
+      }
+    ]
   },
   {
     "question_number": 243,
     "qid": 361,
     "text": "Which pathways are annotated with RXRG, which is compiled as a target of Chenodeoxycholic acid?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Signaling by Retinoic Acid, (2) Nuclear Receptor transcription pathway"
+    "llm_ranking": [
+      {
+        "entity_name": "Signaling by Retinoic Acid",
+        "llm-average": 15.15
+      },
+      {
+        "entity_name": "Nuclear Receptor transcription pathway",
+        "llm-average": 7.97
+      }
+    ]
   },
   {
     "question_number": 244,
     "qid": 7,
     "text": "Which genes are curated as targets of Cimetidine?",
     "category": "Abnormality of the immune system:Immunologic hypersensitivity",
-    "llm_ranking": "(1) solute carrier family 47 member 1, (2) solute carrier family 29 member 4, (3) leucine rich repeat containing G protein-coupled receptor 4, (4) leucine rich repeat containing G protein-coupled receptor 5, (5) Fc fragment of IgG receptor IIIa, (6) actin gamma 1 pseudogene 4, (7) nitric oxide synthase 1, (8) histamine receptor H2"
+    "llm_ranking": [
+      {
+        "entity_name": "solute carrier family 47 member 1",
+        "llm-average": 16.24
+      },
+      {
+        "entity_name": "solute carrier family 29 member 4",
+        "llm-average": 15.36
+      },
+      {
+        "entity_name": "leucine rich repeat containing G protein-coupled receptor 4",
+        "llm-average": 12.5
+      },
+      {
+        "entity_name": "leucine rich repeat containing G protein-coupled receptor 5",
+        "llm-average": 12.5
+      },
+      {
+        "entity_name": "Fc fragment of IgG receptor IIIa",
+        "llm-average": 12.11
+      },
+      {
+        "entity_name": "actin gamma 1 pseudogene 4",
+        "llm-average": 10.86
+      },
+      {
+        "entity_name": "nitric oxide synthase 1",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "histamine receptor H2",
+        "llm-average": 5.56
+      }
+    ]
   },
   {
     "question_number": 245,
     "qid": 11,
     "text": "Which diseases have GPT2 as a biomarker?",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) hepatic veno-occlusive disease, (2) alcohol dependence, (3) liver disease"
+    "llm_ranking": [
+      {
+        "entity_name": "hepatic veno-occlusive disease",
+        "llm-average": 13.18
+      },
+      {
+        "entity_name": "alcohol dependence",
+        "llm-average": 11.94
+      },
+      {
+        "entity_name": "liver disease",
+        "llm-average": 8.22
+      }
+    ]
   },
   {
     "question_number": 246,
     "qid": 12,
     "text": "Which phenotypes is Azathioprine indicated for?",
     "category": "Abnormality of the immune system:Autoimmunity",
-    "llm_ranking": "(1) Autoimmune hemolytic anemia, (2) Chronic active hepatitis, (3) Crohn's disease, (4) Systemic lupus erythematosus, (5) Ulcerative colitis, (6) Rheumatoid arthritis, (7) Inflammation of the large intestine"
+    "llm_ranking": [
+      {
+        "entity_name": "Autoimmune hemolytic anemia",
+        "llm-average": 17.11
+      },
+      {
+        "entity_name": "Chronic active hepatitis",
+        "llm-average": 16.77
+      },
+      {
+        "entity_name": "Crohn's disease",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "Systemic lupus erythematosus",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "Ulcerative colitis",
+        "llm-average": 11.44
+      },
+      {
+        "entity_name": "Rheumatoid arthritis",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Inflammation of the large intestine",
+        "llm-average": 5.9
+      }
+    ]
   },
   {
     "question_number": 247,
     "qid": 26,
     "text": "List the diseases of which GPT2 serve as a biomarker.",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) hepatic veno-occlusive disease, (2) alcohol dependence, (3) liver disease"
+    "llm_ranking": [
+      {
+        "entity_name": "hepatic veno-occlusive disease",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "alcohol dependence",
+        "llm-average": 10.73
+      },
+      {
+        "entity_name": "liver disease",
+        "llm-average": 9.14
+      }
+    ]
   },
   {
     "question_number": 248,
     "qid": 32,
     "text": "List the diseases of which C4A serve as a biomarker.",
     "category": "genetic disease:None",
-    "llm_ranking": "(1) glomerulonephritis, (2) genetic disease"
+    "llm_ranking": [
+      {
+        "entity_name": "glomerulonephritis",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "genetic disease",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 249,
     "qid": 39,
     "text": "Which phenotypes is Chlorhexidine indicated for?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Periodontitis, (2) Gingival bleeding, (3) Carious teeth, (4) Gingivitis"
+    "llm_ranking": [
+      {
+        "entity_name": "Periodontitis",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "Gingival bleeding",
+        "llm-average": 7.5
+      },
+      {
+        "entity_name": "Carious teeth",
+        "llm-average": 7.11
+      },
+      {
+        "entity_name": "Gingivitis",
+        "llm-average": 6.26
+      }
+    ]
   },
   {
     "question_number": 250,
     "qid": 43,
     "text": "What diseases is FSHB a biomarker of?",
     "category": "reproductive system disease:ovarian disease",
-    "llm_ranking": "(1) pituitary gland disease, (2) ovarian disease"
+    "llm_ranking": [
+      {
+        "entity_name": "pituitary gland disease",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "ovarian disease",
+        "llm-average": 7.86
+      }
+    ]
   },
   {
     "question_number": 251,
     "qid": 46,
     "text": "Which diseases have SHBG as a biomarker?",
     "category": "reproductive system disease:infertility",
-    "llm_ranking": "(1) infertility, (2) endocrine system disease, (3) pituitary gland disease"
+    "llm_ranking": [
+      {
+        "entity_name": "infertility",
+        "llm-average": 16.25
+      },
+      {
+        "entity_name": "endocrine system disease",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "pituitary gland disease",
+        "llm-average": 8.55
+      }
+    ]
   },
   {
     "question_number": 252,
     "qid": 49,
     "text": "What phenotypes is Decitabine indicated for?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Chronic myelomonocytic leukemia, (2) Acute megakaryocytic leukemia, (3) Refractory anemia, (4) Elevated hepatic transaminase"
+    "llm_ranking": [
+      {
+        "entity_name": "Chronic myelomonocytic leukemia",
+        "llm-average": 14.65
+      },
+      {
+        "entity_name": "Acute megakaryocytic leukemia",
+        "llm-average": 14.1
+      },
+      {
+        "entity_name": "Refractory anemia",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Elevated hepatic transaminase",
+        "llm-average": 5.01
+      }
+    ]
   },
   {
     "question_number": 253,
     "qid": 51,
     "text": "List the diseases of which GPT serve as a biomarker.",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) alcohol dependence, (2) hepatic veno-occlusive disease, (3) liver disease"
+    "llm_ranking": [
+      {
+        "entity_name": "alcohol dependence",
+        "llm-average": 13.22
+      },
+      {
+        "entity_name": "hepatic veno-occlusive disease",
+        "llm-average": 11.58
+      },
+      {
+        "entity_name": "liver disease",
+        "llm-average": 10.73
+      }
+    ]
   },
   {
     "question_number": 254,
     "qid": 54,
     "text": "List the phenotypes that Scopolamine are indicated for.",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Vomiting, (2) Nausea, (3) Iridocyclitis, (4) Mydriasis"
+    "llm_ranking": [
+      {
+        "entity_name": "Vomiting",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "Nausea",
+        "llm-average": 9.64
+      },
+      {
+        "entity_name": "Iridocyclitis",
+        "llm-average": 5.35
+      },
+      {
+        "entity_name": "Mydriasis",
+        "llm-average": 4.83
+      }
+    ]
   },
   {
     "question_number": 255,
     "qid": 55,
     "text": "What diseases is GOT1 a biomarker of?",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) hepatic veno-occlusive disease, (2) liver disease"
+    "llm_ranking": [
+      {
+        "entity_name": "hepatic veno-occlusive disease",
+        "llm-average": 11.78
+      },
+      {
+        "entity_name": "liver disease",
+        "llm-average": 5.55
+      }
+    ]
   },
   {
     "question_number": 256,
     "qid": 57,
     "text": "Which genes are curated as targets of Aminoglutethimide?",
     "category": "Neoplasm:None",
-    "llm_ranking": "(1) cytochrome P450 family 19 subfamily A member 1, (2) cytochrome P450 family 11 subfamily A member 1, (3) trefoil factor 3, (4) gamma-glutamyltransferase 1, (5) cytochrome P450 family 1 subfamily B member 1, (6) thyroglobulin, (7) gonadotropin releasing hormone 1"
+    "llm_ranking": [
+      {
+        "entity_name": "cytochrome P450 family 19 subfamily A member 1",
+        "llm-average": 15.72
+      },
+      {
+        "entity_name": "cytochrome P450 family 11 subfamily A member 1",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "trefoil factor 3",
+        "llm-average": 13.88
+      },
+      {
+        "entity_name": "gamma-glutamyltransferase 1",
+        "llm-average": 12.46
+      },
+      {
+        "entity_name": "cytochrome P450 family 1 subfamily B member 1",
+        "llm-average": 11.06
+      },
+      {
+        "entity_name": "thyroglobulin",
+        "llm-average": 7.13
+      },
+      {
+        "entity_name": "gonadotropin releasing hormone 1",
+        "llm-average": 6.78
+      }
+    ]
   },
   {
     "question_number": 257,
     "qid": 58,
     "text": "What diseases is SHBG a biomarker of?",
     "category": "reproductive system disease:infertility",
-    "llm_ranking": "(1) infertility, (2) endocrine system disease, (3) pituitary gland disease"
+    "llm_ranking": [
+      {
+        "entity_name": "infertility",
+        "llm-average": 13.74
+      },
+      {
+        "entity_name": "endocrine system disease",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "pituitary gland disease",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 258,
     "qid": 60,
     "text": "Which phenotypes is Terbutaline indicated for?",
     "category": "Abnormality of the immune system:Immunologic hypersensitivity",
-    "llm_ranking": "(1) Emphysema, (2) Asthma, (3) Bronchitis"
+    "llm_ranking": [
+      {
+        "entity_name": "Emphysema",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 7.34
+      },
+      {
+        "entity_name": "Bronchitis",
+        "llm-average": 7.14
+      }
+    ]
   },
   {
     "question_number": 259,
     "qid": 66,
     "text": "Which phenotypes is Salmeterol indicated for?",
     "category": "Abnormality of the immune system:Immunologic hypersensitivity",
-    "llm_ranking": "(1) Airway obstruction, (2) Respiratory distress, (3) Exercise-induced asthma, (4) Emphysema, (5) Chronic bronchitis, (6) Asthma, (7) Chronic pulmonary obstruction"
+    "llm_ranking": [
+      {
+        "entity_name": "Airway obstruction",
+        "llm-average": 9.08
+      },
+      {
+        "entity_name": "Respiratory distress",
+        "llm-average": 8.71
+      },
+      {
+        "entity_name": "Exercise-induced asthma",
+        "llm-average": 8.22
+      },
+      {
+        "entity_name": "Emphysema",
+        "llm-average": 8.19
+      },
+      {
+        "entity_name": "Chronic bronchitis",
+        "llm-average": 7.85
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 7.34
+      },
+      {
+        "entity_name": "Chronic pulmonary obstruction",
+        "llm-average": 7.33
+      }
+    ]
   },
   {
     "question_number": 260,
     "qid": 77,
     "text": "What phenotypes is Cladribine indicated for?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Neoplasm, (2) Leukemia, (3) Lymphoma, (4) Nausea, (5) Fever"
+    "llm_ranking": [
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 10.35
+      },
+      {
+        "entity_name": "Leukemia",
+        "llm-average": 10.01
+      },
+      {
+        "entity_name": "Lymphoma",
+        "llm-average": 6.97
+      },
+      {
+        "entity_name": "Nausea",
+        "llm-average": 0.53
+      },
+      {
+        "entity_name": "Fever",
+        "llm-average": 0.0
+      }
+    ]
   },
   {
     "question_number": 261,
     "qid": 82,
     "text": "Which phenotypes is Ascorbic acid indicated for?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Gingival bleeding, (2) Pneumonia, (3) Sinusitis, (4) Gingivitis, (5) Fever"
+    "llm_ranking": [
+      {
+        "entity_name": "Gingival bleeding",
+        "llm-average": 8.56
+      },
+      {
+        "entity_name": "Pneumonia",
+        "llm-average": 7.99
+      },
+      {
+        "entity_name": "Sinusitis",
+        "llm-average": 7.47
+      },
+      {
+        "entity_name": "Gingivitis",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Fever",
+        "llm-average": 2.67
+      }
+    ]
   },
   {
     "question_number": 262,
     "qid": 89,
     "text": "What phenotypes is Fosamprenavir indicated for?",
     "category": "Abnormality of the immune system:Immunodeficiency",
-    "llm_ranking": "(1) Reduced factor XI activity, (2) Immunodeficiency"
+    "llm_ranking": [
+      {
+        "entity_name": "Reduced factor XI activity",
+        "llm-average": 17.85
+      },
+      {
+        "entity_name": "Immunodeficiency",
+        "llm-average": 11.06
+      }
+    ]
   },
   {
     "question_number": 263,
     "qid": 95,
     "text": "What phenotypes is Ipratropium indicated for?",
     "category": "Abnormality of the immune system:Immunologic hypersensitivity",
-    "llm_ranking": "(1) Emphysema, (2) Nasal obstruction, (3) Chronic pulmonary obstruction, (4) Glaucoma, (5) Chronic bronchitis, (6) Asthma, (7) Seasonal allergy"
+    "llm_ranking": [
+      {
+        "entity_name": "Emphysema",
+        "llm-average": 9.31
+      },
+      {
+        "entity_name": "Nasal obstruction",
+        "llm-average": 8.91
+      },
+      {
+        "entity_name": "Glaucoma",
+        "llm-average": 8.35
+      },
+      {
+        "entity_name": "Chronic pulmonary obstruction",
+        "llm-average": 8.07
+      },
+      {
+        "entity_name": "Chronic bronchitis",
+        "llm-average": 7.34
+      },
+      {
+        "entity_name": "Asthma",
+        "llm-average": 6.45
+      },
+      {
+        "entity_name": "Seasonal allergy",
+        "llm-average": 6.41
+      }
+    ]
   },
   {
     "question_number": 264,
     "qid": 100,
     "text": "Which diseases have MPO as a biomarker?",
     "category": "immune system disease:autoimmune disease",
-    "llm_ranking": "(1) vasculitis, (2) autoimmune disease"
+    "llm_ranking": [
+      {
+        "entity_name": "vasculitis",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "autoimmune disease",
+        "llm-average": 7.86
+      }
+    ]
   },
   {
     "question_number": 265,
     "qid": 110,
     "text": "What phenotypes is Propantheline indicated for?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Hyperhidrosis, (2) Peptic ulcer, (3) Cholecystitis, (4) Diarrhea, (5) Gastritis, (6) Ulcerative colitis, (7) Pancreatitis"
+    "llm_ranking": [
+      {
+        "entity_name": "Hyperhidrosis",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "Peptic ulcer",
+        "llm-average": 12.01
+      },
+      {
+        "entity_name": "Cholecystitis",
+        "llm-average": 7.31
+      },
+      {
+        "entity_name": "Diarrhea",
+        "llm-average": 6.09
+      },
+      {
+        "entity_name": "Gastritis",
+        "llm-average": 6.08
+      },
+      {
+        "entity_name": "Ulcerative colitis",
+        "llm-average": 4.63
+      },
+      {
+        "entity_name": "Pancreatitis",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 266,
     "qid": 112,
     "text": "Which diseases have ALDOB as a biomarker?",
     "category": "genetic disease:carbohydrate metabolic disorder",
-    "llm_ranking": "(1) hereditary fructose intolerance syndrome, (2) disease of metabolism, (3) gastrointestinal system disease"
+    "llm_ranking": [
+      {
+        "entity_name": "hereditary fructose intolerance syndrome",
+        "llm-average": 18.92
+      },
+      {
+        "entity_name": "disease of metabolism",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "gastrointestinal system disease",
+        "llm-average": 4.83
+      }
+    ]
   },
   {
     "question_number": 267,
     "qid": 117,
     "text": "Which diseases have C4A as a biomarker?",
     "category": "genetic disease:None",
-    "llm_ranking": "(1) glomerulonephritis, (2) genetic disease"
+    "llm_ranking": [
+      {
+        "entity_name": "glomerulonephritis",
+        "llm-average": 14.45
+      },
+      {
+        "entity_name": "genetic disease",
+        "llm-average": 7.86
+      }
+    ]
   },
   {
     "question_number": 268,
     "qid": 118,
     "text": "What phenotypes is Calcipotriol indicated for?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Psoriasiform dermatitis, (2) Abnormality of the skin"
+    "llm_ranking": [
+      {
+        "entity_name": "Psoriasiform dermatitis",
+        "llm-average": 11.06
+      },
+      {
+        "entity_name": "Abnormality of the skin",
+        "llm-average": 4.3
+      }
+    ]
   },
   {
     "question_number": 269,
     "qid": 129,
     "text": "Which phenotypes is Monobenzone indicated for?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Vitiligo, (2) Hyperpigmentation of the skin, (3) Cafe-au-lait spot, (4) Cutaneous melanoma, (5) Nevus, (6) Hypopigmentation of the skin, (7) Inflammatory abnormality of the skin"
+    "llm_ranking": [
+      {
+        "entity_name": "Vitiligo",
+        "llm-average": 17.33
+      },
+      {
+        "entity_name": "Hyperpigmentation of the skin",
+        "llm-average": 8.92
+      },
+      {
+        "entity_name": "Cafe-au-lait spot",
+        "llm-average": 8.72
+      },
+      {
+        "entity_name": "Cutaneous melanoma",
+        "llm-average": 8.51
+      },
+      {
+        "entity_name": "Nevus",
+        "llm-average": 6.04
+      },
+      {
+        "entity_name": "Hypopigmentation of the skin",
+        "llm-average": 5.35
+      },
+      {
+        "entity_name": "Inflammatory abnormality of the skin",
+        "llm-average": 4.1
+      }
+    ]
   },
   {
     "question_number": 270,
     "qid": 132,
     "text": "List the phenotypes that Decitabine are indicated for.",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Chronic myelomonocytic leukemia, (2) Acute megakaryocytic leukemia, (3) Refractory anemia, (4) Elevated hepatic transaminase"
+    "llm_ranking": [
+      {
+        "entity_name": "Acute megakaryocytic leukemia",
+        "llm-average": 12.3
+      },
+      {
+        "entity_name": "Chronic myelomonocytic leukemia",
+        "llm-average": 12.14
+      },
+      {
+        "entity_name": "Refractory anemia",
+        "llm-average": 6.42
+      },
+      {
+        "entity_name": "Elevated hepatic transaminase",
+        "llm-average": 3.58
+      }
+    ]
   },
   {
     "question_number": 271,
     "qid": 134,
     "text": "List the phenotypes that Dihydrocodeine are indicated for.",
     "category": "Neoplasm:None",
-    "llm_ranking": "(1) Neoplasm, (2) Chronic pain, (3) Pain"
+    "llm_ranking": [
+      {
+        "entity_name": "Neoplasm",
+        "llm-average": 11.42
+      },
+      {
+        "entity_name": "Chronic pain",
+        "llm-average": 8.58
+      },
+      {
+        "entity_name": "Pain",
+        "llm-average": 5.55
+      }
+    ]
   },
   {
     "question_number": 272,
     "qid": 138,
     "text": "List the diseases of which C3 serve as a biomarker.",
     "category": "genetic disease:None",
-    "llm_ranking": "(1) glomerulonephritis, (2) genetic disease"
+    "llm_ranking": [
+      {
+        "entity_name": "glomerulonephritis",
+        "llm-average": 13.38
+      },
+      {
+        "entity_name": "genetic disease",
+        "llm-average": 6.42
+      }
+    ]
   },
   {
     "question_number": 273,
     "qid": 147,
     "text": "Which genes are curated as targets of Clotrimazole?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) transient receptor potential cation channel subfamily M member 8, (2) transient receptor potential cation channel subfamily M member 2, (3) transient receptor potential cation channel subfamily M member 4, (4) nuclear receptor subfamily 1 group I member 3, (5) potassium calcium-activated channel subfamily N member 4, (6) cytochrome P450 family 3 subfamily A member 4"
+    "llm_ranking": [
+      {
+        "entity_name": "transient receptor potential cation channel subfamily M member 8",
+        "llm-average": 16.42
+      },
+      {
+        "entity_name": "transient receptor potential cation channel subfamily M member 2",
+        "llm-average": 15.17
+      },
+      {
+        "entity_name": "transient receptor potential cation channel subfamily M member 4",
+        "llm-average": 13.92
+      },
+      {
+        "entity_name": "nuclear receptor subfamily 1 group I member 3",
+        "llm-average": 13.22
+      },
+      {
+        "entity_name": "potassium calcium-activated channel subfamily N member 4",
+        "llm-average": 9.65
+      },
+      {
+        "entity_name": "cytochrome P450 family 3 subfamily A member 4",
+        "llm-average": 6.98
+      }
+    ]
   },
   {
     "question_number": 274,
     "qid": 166,
     "text": "What drugs are indicated for Acne?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Moxifloxacin, (2) Doxycycline, (3) Clindamycin, (4) Azithromycin, (5) Erythromycin, (6) D-Levofloxacin, (7) Ofloxacin, (8) Levofloxacin"
+    "llm_ranking": [
+      {
+        "entity_name": "Moxifloxacin",
+        "llm-average": 9.46
+      },
+      {
+        "entity_name": "Doxycycline",
+        "llm-average": 8.64
+      },
+      {
+        "entity_name": "Clindamycin",
+        "llm-average": 8.01
+      },
+      {
+        "entity_name": "Azithromycin",
+        "llm-average": 7.91
+      },
+      {
+        "entity_name": "Erythromycin",
+        "llm-average": 7.75
+      },
+      {
+        "entity_name": "D-Levofloxacin",
+        "llm-average": 7.62
+      },
+      {
+        "entity_name": "Ofloxacin",
+        "llm-average": 7.39
+      },
+      {
+        "entity_name": "Levofloxacin",
+        "llm-average": 7.19
+      }
+    ]
   },
   {
     "question_number": 275,
     "qid": 170,
     "text": "What proteins are biomarkers of the disease hepatic veno-occlusive disease?",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) GOT2, (2) GOT1, (3) GPT2, (4) ALPL, (5) GPT"
+    "llm_ranking": [
+      {
+        "entity_name": "GOT2",
+        "llm-average": 12.27
+      },
+      {
+        "entity_name": "GOT1",
+        "llm-average": 10.06
+      },
+      {
+        "entity_name": "GPT2",
+        "llm-average": 9.56
+      },
+      {
+        "entity_name": "ALPL",
+        "llm-average": 8.67
+      },
+      {
+        "entity_name": "GPT",
+        "llm-average": 7.36
+      }
+    ]
   },
   {
     "question_number": 276,
     "qid": 172,
     "text": "What drugs are indicated for Crohn's disease?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Clodronic acid, (2) Cyanocobalamin, (3) Metronidazole, (4) Azathioprine, (5) Mesalazine, (6) Budesonide, (7) Sulfasalazine, (8) Prednisone"
+    "llm_ranking": [
+      {
+        "entity_name": "Clodronic acid",
+        "llm-average": 14.52
+      },
+      {
+        "entity_name": "Cyanocobalamin",
+        "llm-average": 13.31
+      },
+      {
+        "entity_name": "Metronidazole",
+        "llm-average": 13.29
+      },
+      {
+        "entity_name": "Azathioprine",
+        "llm-average": 12.6
+      },
+      {
+        "entity_name": "Mesalazine",
+        "llm-average": 11.49
+      },
+      {
+        "entity_name": "Budesonide",
+        "llm-average": 10.49
+      },
+      {
+        "entity_name": "Sulfasalazine",
+        "llm-average": 9.28
+      },
+      {
+        "entity_name": "Prednisone",
+        "llm-average": 9.15
+      }
+    ]
   },
   {
     "question_number": 277,
     "qid": 179,
     "text": "What drugs have Decreased body weight as a side effect?",
     "category": "Growth abnormality:Decreased body weight",
-    "llm_ranking": "(1) Ranolazine, (2) Ziprasidone, (3) Phenylephrine"
+    "llm_ranking": [
+      {
+        "entity_name": "Ranolazine",
+        "llm-average": 12.41
+      },
+      {
+        "entity_name": "Ziprasidone",
+        "llm-average": 8.67
+      },
+      {
+        "entity_name": "Phenylephrine",
+        "llm-average": 3.79
+      }
+    ]
   },
   {
     "question_number": 278,
     "qid": 188,
     "text": "What proteins are biomarkers of the disease alcohol dependence?",
     "category": "disease of mental health:substance dependence",
-    "llm_ranking": "(1) GPT2, (2) GPT"
+    "llm_ranking": [
+      {
+        "entity_name": "GPT2",
+        "llm-average": 8.94
+      },
+      {
+        "entity_name": "GPT",
+        "llm-average": 7.1
+      }
+    ]
   },
   {
     "question_number": 279,
     "qid": 197,
     "text": "What proteins are biomarkers of the disease immune system disease?",
     "category": "immune system disease:None",
-    "llm_ranking": "(1) PLA2G1B, (2) C1R, (3) C1S"
+    "llm_ranking": [
+      {
+        "entity_name": "PLA2G1B",
+        "llm-average": 16.86
+      },
+      {
+        "entity_name": "C1R",
+        "llm-average": 13.27
+      },
+      {
+        "entity_name": "C1S",
+        "llm-average": 12.34
+      }
+    ]
   },
   {
     "question_number": 280,
     "qid": 207,
     "text": "What drugs are indicated for Pallor?",
     "category": "Abnormality of the integument:Abnormality of skin morphology",
-    "llm_ranking": "(1) Dopamine, (2) Buspirone, (3) Epinephrine, (4) Dihydroergotamine"
+    "llm_ranking": [
+      {
+        "entity_name": "Dopamine",
+        "llm-average": 13.24
+      },
+      {
+        "entity_name": "Buspirone",
+        "llm-average": 12.27
+      },
+      {
+        "entity_name": "Epinephrine",
+        "llm-average": 11.48
+      },
+      {
+        "entity_name": "Dihydroergotamine",
+        "llm-average": 8.94
+      }
+    ]
   },
   {
     "question_number": 281,
     "qid": 217,
     "text": "What drugs are indicated for Acrocyanosis?",
     "category": "Abnormality of the integument:Abnormality of skin morphology",
-    "llm_ranking": "(1) Arginine, (2) D-arginine"
+    "llm_ranking": [
+      {
+        "entity_name": "Arginine",
+        "llm-average": 12.34
+      },
+      {
+        "entity_name": "D-arginine",
+        "llm-average": 11.88
+      }
+    ]
   },
   {
     "question_number": 282,
     "qid": 220,
     "text": "What drugs are indicated for Optic neuritis?",
     "category": "Abnormality of the immune system:Abnormal inflammatory response",
-    "llm_ranking": "(1) Methylprednisolone, (2) Prednisone, (3) Dexamethasone, (4) Prednisolone, (5) Hydrocortisone, (6) Betamethasone"
+    "llm_ranking": [
+      {
+        "entity_name": "Methylprednisolone",
+        "llm-average": 13.03
+      },
+      {
+        "entity_name": "Prednisone",
+        "llm-average": 9.7
+      },
+      {
+        "entity_name": "Dexamethasone",
+        "llm-average": 9.6
+      },
+      {
+        "entity_name": "Prednisolone",
+        "llm-average": 8.17
+      },
+      {
+        "entity_name": "Hydrocortisone",
+        "llm-average": 5.81
+      },
+      {
+        "entity_name": "Betamethasone",
+        "llm-average": 5.71
+      }
+    ]
   },
   {
     "question_number": 283,
     "qid": 233,
     "text": "What drugs are indicated for Scleroderma?",
     "category": "Abnormality of the integument:Abnormality of skin morphology",
-    "llm_ranking": "(1) Bosentan, (2) Epoprostenol, (3) Cimetidine, (4) Ranitidine, (5) Dexamethasone, (6) Betamethasone"
+    "llm_ranking": [
+      {
+        "entity_name": "Bosentan",
+        "llm-average": 17.52
+      },
+      {
+        "entity_name": "Epoprostenol",
+        "llm-average": 16.09
+      },
+      {
+        "entity_name": "Cimetidine",
+        "llm-average": 5.87
+      },
+      {
+        "entity_name": "Ranitidine",
+        "llm-average": 5.64
+      },
+      {
+        "entity_name": "Dexamethasone",
+        "llm-average": 5.29
+      },
+      {
+        "entity_name": "Betamethasone",
+        "llm-average": 4.33
+      }
+    ]
   },
   {
     "question_number": 284,
     "qid": 234,
     "text": "What drugs have EPH receptor A2 as a curated target?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) Dorsomorphin, (2) Regorafenib, (3) Dasatinib, (4) Vandetanib"
+    "llm_ranking": [
+      {
+        "entity_name": "Dorsomorphin",
+        "llm-average": 14.96
+      },
+      {
+        "entity_name": "Regorafenib",
+        "llm-average": 11.31
+      },
+      {
+        "entity_name": "Dasatinib",
+        "llm-average": 9.2
+      },
+      {
+        "entity_name": "Vandetanib",
+        "llm-average": 9.03
+      }
+    ]
   },
   {
     "question_number": 285,
     "qid": 394,
     "text": "Which biological processes are associated with IGLL5, which acts on C1R that is the biomarker of disease immune system disease?",
     "category": "immune system disease:None",
-    "llm_ranking": "(1) complement activation, classical pathway, (2) positive regulation of B cell activation, (3) B cell receptor signaling pathway, (4) phagocytosis, engulfment, (5) defense response to bacterium, (6) innate immune response, (7) phagocytosis, recognition"
+    "llm_ranking": [
+      {
+        "entity_name": "complement activation, classical pathway",
+        "llm-average": 13.37
+      },
+      {
+        "entity_name": "positive regulation of B cell activation",
+        "llm-average": 11.45
+      },
+      {
+        "entity_name": "B cell receptor signaling pathway",
+        "llm-average": 11.09
+      },
+      {
+        "entity_name": "phagocytosis, engulfment",
+        "llm-average": 9.04
+      },
+      {
+        "entity_name": "defense response to bacterium",
+        "llm-average": 7.72
+      },
+      {
+        "entity_name": "innate immune response",
+        "llm-average": 4.32
+      },
+      {
+        "entity_name": "phagocytosis, recognition",
+        "llm-average": 3.7
+      }
+    ]
   },
   {
     "question_number": 286,
     "qid": 418,
     "text": "Which genes are curated as targets of Cytidine, which acts on AHNAK that is curated as interacting with ARMH4?",
     "category": "Abnormality of the immune system:Abnormal cellular immune system morphology",
-    "llm_ranking": "(1) gastrin releasing peptide receptor, (2) neuromedin B receptor"
+    "llm_ranking": [
+      {
+        "entity_name": "gastrin releasing peptide receptor",
+        "llm-average": 6.44
+      },
+      {
+        "entity_name": "neuromedin B receptor",
+        "llm-average": 6.2
+      }
+    ]
   },
   {
     "question_number": 287,
     "qid": 422,
     "text": "Which biological processes are associated with CD52, which acts on ALPL that is the biomarker of disease liver disease?",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) respiratory burst, (2) positive regulation of cytosolic calcium ion concentration"
+    "llm_ranking": [
+      {
+        "entity_name": "respiratory burst",
+        "llm-average": 15.74
+      },
+      {
+        "entity_name": "positive regulation of cytosolic calcium ion concentration",
+        "llm-average": 10.5
+      }
+    ]
   },
   {
     "question_number": 288,
     "qid": 435,
     "text": "Which genes are curated as targets of Clofibrate, which acts on ALB that is the biomarker of disease liver disease?",
     "category": "gastrointestinal system disease:liver disease",
-    "llm_ranking": "(1) peroxisome proliferator activated receptor alpha, (2) stearoyl-CoA desaturase, (3) lipoprotein lipase, (4) solute carrier organic anion transporter family member 1B1, (5) solute carrier family 2 member 4, (6) fatty acid binding protein 1, (7) kinase insert domain receptor, (8) MET proto-oncogene, receptor tyrosine kinase"
+    "llm_ranking": [
+      {
+        "entity_name": "peroxisome proliferator activated receptor alpha",
+        "llm-average": 20.0
+      },
+      {
+        "entity_name": "stearoyl-CoA desaturase",
+        "llm-average": 14.82
+      },
+      {
+        "entity_name": "solute carrier organic anion transporter family member 1B1",
+        "llm-average": 10.63
+      },
+      {
+        "entity_name": "lipoprotein lipase",
+        "llm-average": 10.5
+      },
+      {
+        "entity_name": "solute carrier family 2 member 4",
+        "llm-average": 9.01
+      },
+      {
+        "entity_name": "fatty acid binding protein 1",
+        "llm-average": 8.12
+      },
+      {
+        "entity_name": "kinase insert domain receptor",
+        "llm-average": 7.79
+      },
+      {
+        "entity_name": "MET proto-oncogene, receptor tyrosine kinase",
+        "llm-average": 4.49
+      }
+    ]
   },
   {
     "question_number": 289,
     "qid": 448,
     "text": "Which biological processes are associated with SVEP1, which acts on C1S that is the biomarker of disease immune system disease?",
     "category": "immune system disease:None",
-    "llm_ranking": "(1) Tie signaling pathway, (2) lymph vessel morphogenesis, (3) lymph circulation, (4) epidermis development, (5) cell adhesion, (6) tight junction organization, (7) gene expression"
+    "llm_ranking": [
+      {
+        "entity_name": "Tie signaling pathway",
+        "llm-average": 14.52
+      },
+      {
+        "entity_name": "lymph vessel morphogenesis",
+        "llm-average": 13.27
+      },
+      {
+        "entity_name": "lymph circulation",
+        "llm-average": 8.78
+      },
+      {
+        "entity_name": "epidermis development",
+        "llm-average": 6.96
+      },
+      {
+        "entity_name": "cell adhesion",
+        "llm-average": 5.31
+      },
+      {
+        "entity_name": "tight junction organization",
+        "llm-average": 4.32
+      },
+      {
+        "entity_name": "gene expression",
+        "llm-average": 0.0
+      }
+    ]
   }
 ]

--- a/lib/batches/batch6_test.ts
+++ b/lib/batches/batch6_test.ts
@@ -6,13 +6,59 @@ export const batch6_test: Question[] = [
     "qid": -1,
     "text": "Which protein is a subunit of the BBS-chaperonin complex, which is associated with intraciliary transport and lateral meningocele syndrome?",
     "category": "musculoskeletal system disease:bone disease",
-    "llm_ranking": "(1) BBS10, (2) BBS7"
+    "llm_ranking": [
+  {
+    "entity_name": "Darifenacin",
+    "llm-average": 16.8
+  },
+  {
+    "entity_name": "Trospium",
+    "llm-average": 12.63
+  },
+  {
+    "entity_name": "Oxybutynin",
+    "llm-average": 7.84
+  }
+]
   },
   {
     "question_number": 2,
     "qid": -2,
     "text": "Which transcript translates into HOGA1, which is detected in pathology samples of endometrial cancer, and is located on chromosome 10?",
     "category": "immune system disease:gastrointestinal allergy",
-    "llm_ranking": "(1) NP_612422.2, (2) NP_001128142.1"
+    "llm_ranking": [
+      {
+        "entity_name": "free fatty acid receptor 2",
+        "llm-average": 17.33
+      },
+      {
+        "entity_name": "hydroxycarboxylic acid receptor 2",
+        "llm-average": 15.91
+      },
+      {
+        "entity_name": "5-hydroxytryptamine receptor 5A",
+        "llm-average": 14.13
+      },
+      {
+        "entity_name": "histone deacetylase 1",
+        "llm-average": 10.5
+      },
+      {
+        "entity_name": "histone deacetylase 2",
+        "llm-average": 10.03
+      },
+      {
+        "entity_name": "histone deacetylase 3",
+        "llm-average": 8.09
+      },
+      {
+        "entity_name": "adenosine deaminase RNA specific B2 (inactive)",
+        "llm-average": 8.02
+      },
+      {
+        "entity_name": "histone deacetylase 8",
+        "llm-average": 6.17
+      }
+    ]
   },
 ]


### PR DESCRIPTION
Refactor the `llm_ranking` field in multiple questions to use a 
structured object format instead of a string. This change improves 
data consistency and readability, allowing for easier parsing and 
manipulation of the ranking data. Each drug now includes its name 
and average ranking, enhancing clarity and maintainability.