### PR TITLE
fix: update llm-average values for various entities

### DIFF
--- a/lib/batches/batch1.ts
+++ b/lib/batches/batch1.ts
@@ -9,15 +9,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.8
+        "llm-average": 8.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       }
     ]
   },
@@ -29,19 +29,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.57
+        "llm-average": 6.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -53,27 +53,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.67
+        "llm-average": 5.8
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.9
+        "llm-average": 2.5
       }
     ]
   },
@@ -85,19 +85,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 15.43
+        "llm-average": 7.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 11.33
+        "llm-average": 5.7
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.07
+        "llm-average": 1.0
       }
     ]
   },
@@ -109,23 +109,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.66
+        "llm-average": 7.3
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.18
+        "llm-average": 5.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -137,27 +137,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.77
+        "llm-average": 5.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.77
+        "llm-average": 5.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.5
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.19
+        "llm-average": 3.1
       }
     ]
   },
@@ -169,19 +169,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.21
+        "llm-average": 4.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -193,19 +193,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.86
+        "llm-average": 4.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.71
+        "llm-average": 2.9
       }
     ]
   },
@@ -217,19 +217,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -241,11 +241,11 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -257,23 +257,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.84
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.4
+        "llm-average": 4.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.06
+        "llm-average": 4.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -285,19 +285,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.04
+        "llm-average": 1.0
       }
     ]
   },
@@ -309,27 +309,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.96
+        "llm-average": 4.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -341,15 +341,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       }
     ]
   },
@@ -361,11 +361,11 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -377,19 +377,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.04
+        "llm-average": 1.0
       }
     ]
   },
@@ -401,27 +401,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.59
+        "llm-average": 4.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -433,27 +433,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.89
+        "llm-average": 3.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -465,27 +465,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.65
+        "llm-average": 7.3
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.77
+        "llm-average": 5.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.66
+        "llm-average": 1.8
       }
     ]
   },
@@ -497,23 +497,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.21
+        "llm-average": 7.1
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.78
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -525,27 +525,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.03
+        "llm-average": 4.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.78
+        "llm-average": 3.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -557,19 +557,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.21
+        "llm-average": 4.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -581,15 +581,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -601,27 +601,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -633,27 +633,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 15.26
+        "llm-average": 7.6
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.57
+        "llm-average": 4.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -665,19 +665,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 15.66
+        "llm-average": 7.8
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.64
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -689,27 +689,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.41
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -721,15 +721,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       }
     ]
   },
@@ -741,27 +741,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.62
+        "llm-average": 4.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -773,19 +773,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.38
+        "llm-average": 6.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.06
+        "llm-average": 2.0
       }
     ]
   },
@@ -797,23 +797,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -825,19 +825,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.14
+        "llm-average": 0.6
       }
     ]
   },
@@ -849,15 +849,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -869,27 +869,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.26
+        "llm-average": 2.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -901,19 +901,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.11
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.94
+        "llm-average": 3.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       }
     ]
   },
@@ -925,19 +925,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.18
+        "llm-average": 5.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -949,27 +949,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.22
+        "llm-average": 3.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -981,27 +981,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -1013,19 +1013,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 15.43
+        "llm-average": 7.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 11.33
+        "llm-average": 5.7
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.12
+        "llm-average": 3.1
       }
     ]
   },
@@ -1037,19 +1037,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.04
+        "llm-average": 1.0
       }
     ]
   },
@@ -1061,27 +1061,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.51
+        "llm-average": 1.3
       }
     ]
   },
@@ -1093,15 +1093,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 9.11
+        "llm-average": 4.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.74
+        "llm-average": 4.4
       }
     ]
   },
@@ -1113,19 +1113,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.36
+        "llm-average": 5.7
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.81
+        "llm-average": 2.4
       }
     ]
   },
@@ -1137,19 +1137,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.81
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1161,23 +1161,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.59
+        "llm-average": 5.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.91
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.19
+        "llm-average": 3.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.15
+        "llm-average": 3.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -1189,15 +1189,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.74
+        "llm-average": 4.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.21
+        "llm-average": 4.1
       }
     ]
   },
@@ -1209,19 +1209,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.81
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1233,27 +1233,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.01
+        "llm-average": 2.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1265,15 +1265,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.45
+        "llm-average": 2.7
       }
     ]
   },
@@ -1285,19 +1285,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1309,19 +1309,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -1333,15 +1333,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.73
+        "llm-average": 8.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       }
     ]
   },
@@ -1353,15 +1353,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -1373,19 +1373,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.81
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1397,23 +1397,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.65
+        "llm-average": 7.3
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -1425,27 +1425,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.9
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1457,27 +1457,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.04
+        "llm-average": 6.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -1489,23 +1489,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.78
+        "llm-average": 6.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -1517,15 +1517,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.8
+        "llm-average": 8.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       }
     ]
   },
@@ -1537,19 +1537,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.44
+        "llm-average": 5.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1561,15 +1561,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       }
     ]
   },
@@ -1581,15 +1581,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.86
+        "llm-average": 4.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.81
+        "llm-average": 3.9
       }
     ]
   },
@@ -1601,15 +1601,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -1621,19 +1621,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.04
+        "llm-average": 1.0
       }
     ]
   },
@@ -1645,19 +1645,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1669,27 +1669,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.27
+        "llm-average": 6.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.29
+        "llm-average": 6.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 9.11
+        "llm-average": 4.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.19
+        "llm-average": 3.1
       }
     ]
   },
@@ -1701,19 +1701,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1725,27 +1725,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.78
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -1757,27 +1757,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.14
+        "llm-average": 1.6
       }
     ]
   },
@@ -1789,19 +1789,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.14
+        "llm-average": 0.6
       }
     ]
   },
@@ -1813,15 +1813,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.11
+        "llm-average": 7.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.62
+        "llm-average": 3.8
       }
     ]
   },
@@ -1833,23 +1833,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.53
+        "llm-average": 5.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.45
+        "llm-average": 2.7
       }
     ]
   },
@@ -1861,19 +1861,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.14
+        "llm-average": 0.6
       }
     ]
   },
@@ -1885,15 +1885,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.51
+        "llm-average": 5.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.45
+        "llm-average": 2.7
       }
     ]
   },
@@ -1905,27 +1905,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.9
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1937,19 +1937,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.46
+        "llm-average": 4.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.19
+        "llm-average": 3.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.56
+        "llm-average": 2.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -1961,27 +1961,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.03
+        "llm-average": 4.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -1993,19 +1993,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.03
+        "llm-average": 6.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2017,27 +2017,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.65
+        "llm-average": 4.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2049,27 +2049,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.67
+        "llm-average": 5.8
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.9
+        "llm-average": 2.5
       }
     ]
   },
@@ -2081,19 +2081,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.04
+        "llm-average": 2.0
       }
     ]
   },
@@ -2105,23 +2105,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.24
+        "llm-average": 6.6
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.71
+        "llm-average": 5.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.3
+        "llm-average": 3.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.47
+        "llm-average": 2.2
       }
     ]
   },
@@ -2133,23 +2133,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2161,19 +2161,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.61
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2185,15 +2185,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.11
+        "llm-average": 7.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2205,19 +2205,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.03
+        "llm-average": 6.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2229,15 +2229,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -2249,27 +2249,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2281,27 +2281,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 8.81
+        "llm-average": 4.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 5.05
+        "llm-average": 2.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -2313,19 +2313,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -2337,23 +2337,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.21
+        "llm-average": 7.1
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.78
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2365,19 +2365,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 6.64
+        "llm-average": 3.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.43
+        "llm-average": 2.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -2389,15 +2389,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
@@ -2413,19 +2413,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -2437,15 +2437,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       }
     ]
   },
@@ -2457,19 +2457,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.04
+        "llm-average": 2.0
       }
     ]
   },
@@ -2481,27 +2481,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.96
+        "llm-average": 4.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.27
+        "llm-average": 4.1
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 8.26
+        "llm-average": 4.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.0
+        "llm-average": 3.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -2513,27 +2513,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2545,19 +2545,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.83
+        "llm-average": 5.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.26
+        "llm-average": 2.6
       }
     ]
   },
@@ -2569,19 +2569,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.36
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.64
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -2593,27 +2593,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.4
+        "llm-average": 3.2
       }
     ]
   },
@@ -2625,19 +2625,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.14
+        "llm-average": 0.6
       }
     ]
   },
@@ -2649,19 +2649,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -2673,15 +2673,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 9.11
+        "llm-average": 4.6
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.74
+        "llm-average": 4.4
       }
     ]
   },
@@ -2693,23 +2693,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.97
+        "llm-average": 6.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.81
+        "llm-average": 4.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.91
+        "llm-average": 2.0
       }
     ]
   },
@@ -2721,19 +2721,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.04
+        "llm-average": 1.0
       }
     ]
   },
@@ -2745,23 +2745,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.62
+        "llm-average": 5.3
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 9.16
+        "llm-average": 4.6
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.76
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 5.55
+        "llm-average": 2.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -2773,23 +2773,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.53
+        "llm-average": 5.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -2801,27 +2801,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2833,27 +2833,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.34
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2865,27 +2865,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2897,23 +2897,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.21
+        "llm-average": 7.1
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.78
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -2925,19 +2925,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.04
+        "llm-average": 2.0
       }
     ]
   },
@@ -2949,19 +2949,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -2973,27 +2973,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.47
+        "llm-average": 4.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -3005,23 +3005,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -3033,23 +3033,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.76
+        "llm-average": 5.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -3061,27 +3061,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.26
+        "llm-average": 2.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -3093,19 +3093,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3117,27 +3117,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3149,19 +3149,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.04
+        "llm-average": 2.0
       }
     ]
   },
@@ -3173,27 +3173,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 16.31
+        "llm-average": 8.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.8
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3205,19 +3205,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -3229,19 +3229,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.86
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3253,15 +3253,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -3273,27 +3273,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3305,27 +3305,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3337,19 +3337,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.21
+        "llm-average": 4.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3361,27 +3361,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.84
+        "llm-average": 6.9
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.17
+        "llm-average": 4.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -3393,27 +3393,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 16.31
+        "llm-average": 8.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.04
+        "llm-average": 6.5
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3425,23 +3425,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.47
+        "llm-average": 6.7
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.78
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3453,15 +3453,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -3473,11 +3473,11 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.24
+        "llm-average": 3.6
       }
     ]
   },
@@ -3489,27 +3489,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.78
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -3521,27 +3521,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3553,27 +3553,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.78
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -3585,27 +3585,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 17.44
+        "llm-average": 8.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.3
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.46
+        "llm-average": 2.7
       }
     ]
   },
@@ -3617,15 +3617,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       }
     ]
   },
@@ -3637,23 +3637,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.51
+        "llm-average": 5.8
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 8.93
+        "llm-average": 4.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.08
+        "llm-average": 2.0
       }
     ]
   },
@@ -3665,19 +3665,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -3689,15 +3689,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -3709,19 +3709,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -3733,19 +3733,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.04
+        "llm-average": 1.0
       }
     ]
   },
@@ -3757,15 +3757,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
@@ -3781,19 +3781,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.41
+        "llm-average": 1.2
       }
     ]
   },
@@ -3805,19 +3805,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -3829,15 +3829,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3849,19 +3849,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -3873,19 +3873,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.83
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3897,19 +3897,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   },
@@ -3921,23 +3921,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -3949,23 +3949,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -3977,19 +3977,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 0.45
+        "llm-average": 0.2
       }
     ]
   },
@@ -4001,27 +4001,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4033,27 +4033,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 16.31
+        "llm-average": 8.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.79
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4065,27 +4065,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.65
+        "llm-average": 7.3
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -4097,15 +4097,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.11
+        "llm-average": 7.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.62
+        "llm-average": 3.8
       }
     ]
   },
@@ -4117,15 +4117,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
@@ -4141,27 +4141,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -4173,27 +4173,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4205,27 +4205,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.65
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 5.74
+        "llm-average": 2.9
       }
     ]
   },
@@ -4237,27 +4237,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.65
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 5.74
+        "llm-average": 2.9
       }
     ]
   },
@@ -4269,19 +4269,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.35
+        "llm-average": 0.7
       }
     ]
   },
@@ -4293,27 +4293,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.59
+        "llm-average": 4.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -4325,27 +4325,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.65
+        "llm-average": 4.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4357,15 +4357,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 11.51
+        "llm-average": 5.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -4377,19 +4377,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4401,15 +4401,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -4421,15 +4421,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.26
+        "llm-average": 5.1
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -4441,19 +4441,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.35
+        "llm-average": 0.7
       }
     ]
   },
@@ -4465,23 +4465,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trospium",
-        "llm-average": 11.36
+        "llm-average": 5.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.27
+        "llm-average": 5.1
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.39
+        "llm-average": 4.7
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.94
+        "llm-average": 3.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.05
+        "llm-average": 2.5
       }
     ]
   },
@@ -4493,15 +4493,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 9.11
+        "llm-average": 4.6
       }
     ]
   },
@@ -4513,27 +4513,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4545,27 +4545,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.72
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -4577,19 +4577,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   },
@@ -4601,23 +4601,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 17.36
+        "llm-average": 8.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 12.26
+        "llm-average": 6.1
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       }
     ]
   },
@@ -4629,19 +4629,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 0.69
+        "llm-average": 0.3
       }
     ]
   },
@@ -4653,15 +4653,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 11.51
+        "llm-average": 5.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -4673,23 +4673,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.33
+        "llm-average": 5.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.08
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -4701,19 +4701,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.83
+        "llm-average": 6.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.06
+        "llm-average": 2.0
       }
     ]
   },
@@ -4725,19 +4725,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.41
+        "llm-average": 1.2
       }
     ]
   },
@@ -4749,19 +4749,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.38
+        "llm-average": 6.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.06
+        "llm-average": 2.0
       }
     ]
   },
@@ -4773,15 +4773,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.11
+        "llm-average": 7.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4793,19 +4793,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 0.69
+        "llm-average": 0.3
       }
     ]
   },
@@ -4817,19 +4817,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.36
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.64
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -4841,19 +4841,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.41
+        "llm-average": 1.2
       }
     ]
   },
@@ -4865,19 +4865,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.72
+        "llm-average": 0.9
       }
     ]
   },
@@ -4889,19 +4889,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.41
+        "llm-average": 1.2
       }
     ]
   },
@@ -4913,19 +4913,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.83
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4937,27 +4937,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -4969,19 +4969,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.61
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -4993,15 +4993,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 17.18
+        "llm-average": 8.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       }
     ]
   },
@@ -5013,23 +5013,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.08
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5041,23 +5041,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.78
+        "llm-average": 6.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -5069,27 +5069,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.28
+        "llm-average": 5.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.83
+        "llm-average": 4.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -5101,19 +5101,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.81
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5125,27 +5125,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.6
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5157,27 +5157,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.35
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5189,15 +5189,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5209,19 +5209,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.73
+        "llm-average": 8.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.25
+        "llm-average": 1.1
       }
     ]
   },
@@ -5233,19 +5233,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.18
+        "llm-average": 5.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.81
+        "llm-average": 2.4
       }
     ]
   },
@@ -5257,19 +5257,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.13
+        "llm-average": 6.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   },
@@ -5281,19 +5281,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -5305,27 +5305,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5337,15 +5337,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
@@ -5361,19 +5361,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.36
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.64
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -5385,23 +5385,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.53
+        "llm-average": 5.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.45
+        "llm-average": 2.7
       }
     ]
   },
@@ -5413,27 +5413,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5445,23 +5445,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.84
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.16
+        "llm-average": 4.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.81
+        "llm-average": 4.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.78
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5473,19 +5473,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.38
+        "llm-average": 6.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.06
+        "llm-average": 2.0
       }
     ]
   },
@@ -5497,23 +5497,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.0
+        "llm-average": 4.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 6.19
+        "llm-average": 3.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.7
+        "llm-average": 1.9
       }
     ]
   },
@@ -5525,23 +5525,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.07
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -5553,19 +5553,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.06
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5577,15 +5577,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5597,19 +5597,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.04
+        "llm-average": 1.0
       }
     ]
   },
@@ -5621,15 +5621,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5641,23 +5641,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.37
+        "llm-average": 4.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5669,15 +5669,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.11
+        "llm-average": 7.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5689,19 +5689,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5713,19 +5713,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.45
+        "llm-average": 2.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.91
+        "llm-average": 2.0
       }
     ]
   },
@@ -5737,15 +5737,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       }
     ]
   },
@@ -5757,27 +5757,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5789,27 +5789,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.65
+        "llm-average": 4.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5821,27 +5821,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.59
+        "llm-average": 4.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5853,15 +5853,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.49
+        "llm-average": 3.2
       }
     ]
   },
@@ -5873,19 +5873,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.81
+        "llm-average": 4.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   },
@@ -5897,19 +5897,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 17.18
+        "llm-average": 8.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   },
@@ -5921,19 +5921,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   },
@@ -5945,23 +5945,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5973,11 +5973,11 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5989,23 +5989,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.78
+        "llm-average": 6.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -6017,27 +6017,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.4
+        "llm-average": 3.2
       }
     ]
   },
@@ -6049,27 +6049,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6081,23 +6081,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -6109,27 +6109,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.03
+        "llm-average": 4.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6141,19 +6141,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -6165,27 +6165,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 8.59
+        "llm-average": 4.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6197,27 +6197,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.72
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6229,23 +6229,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.52
+        "llm-average": 5.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.7
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6257,27 +6257,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.9
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6289,27 +6289,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6321,23 +6321,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.33
+        "llm-average": 5.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.08
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6349,15 +6349,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.51
+        "llm-average": 5.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.45
+        "llm-average": 2.7
       }
     ]
   },
@@ -6369,19 +6369,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   },
@@ -6393,23 +6393,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.75
+        "llm-average": 4.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.7
+        "llm-average": 1.9
       }
     ]
   },
@@ -6421,23 +6421,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 15.64
+        "llm-average": 7.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.76
+        "llm-average": 5.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -6449,27 +6449,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6481,19 +6481,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.04
+        "llm-average": 2.0
       }
     ]
   },
@@ -6505,27 +6505,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -6537,23 +6537,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.47
+        "llm-average": 6.7
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.78
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6565,15 +6565,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -6585,19 +6585,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.25
+        "llm-average": 1.1
       }
     ]
   },
@@ -6609,15 +6609,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
@@ -6633,19 +6633,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.57
+        "llm-average": 6.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6657,27 +6657,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.96
+        "llm-average": 7.5
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.34
+        "llm-average": 3.7
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6689,23 +6689,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.78
+        "llm-average": 2.9
       }
     ]
   },
@@ -6717,19 +6717,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.1
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6741,27 +6741,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 8.81
+        "llm-average": 4.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.65
+        "llm-average": 3.8
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 5.05
+        "llm-average": 2.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6773,19 +6773,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.18
+        "llm-average": 7.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.86
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6797,19 +6797,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -6821,27 +6821,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6853,27 +6853,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.6
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6885,19 +6885,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.64
+        "llm-average": 3.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.61
+        "llm-average": 1.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -6909,27 +6909,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 3.63
+        "llm-average": 1.8
       }
     ]
   },
@@ -6941,11 +6941,11 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -6957,27 +6957,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -6989,27 +6989,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -7021,19 +7021,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.03
+        "llm-average": 6.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7045,15 +7045,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -7065,27 +7065,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.22
+        "llm-average": 3.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7097,23 +7097,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.43
+        "llm-average": 3.7
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7125,23 +7125,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.27
+        "llm-average": 6.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.08
+        "llm-average": 3.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7153,15 +7153,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.11
+        "llm-average": 7.1
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.62
+        "llm-average": 3.8
       }
     ]
   },
@@ -7173,27 +7173,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 8.62
+        "llm-average": 4.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -7205,19 +7205,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.35
+        "llm-average": 0.7
       }
     ]
   },
@@ -7229,15 +7229,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
@@ -7253,19 +7253,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7277,27 +7277,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7309,19 +7309,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.04
+        "llm-average": 2.0
       }
     ]
   },
@@ -7333,19 +7333,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.18
+        "llm-average": 7.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 5.86
+        "llm-average": 2.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7357,27 +7357,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.03
+        "llm-average": 4.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7389,15 +7389,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 9.11
+        "llm-average": 4.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 8.74
+        "llm-average": 4.4
       }
     ]
   },
@@ -7409,19 +7409,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.53
+        "llm-average": 6.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -7433,19 +7433,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.74
+        "llm-average": 2.4
       }
     ]
   },
@@ -7457,27 +7457,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.89
+        "llm-average": 3.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7489,23 +7489,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.77
+        "llm-average": 6.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.18
+        "llm-average": 5.6
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7517,27 +7517,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.89
+        "llm-average": 3.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7549,23 +7549,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 8.81
+        "llm-average": 4.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 1.83
+        "llm-average": 0.9
       }
     ]
   },
@@ -7577,19 +7577,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 16.73
+        "llm-average": 8.4
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.25
+        "llm-average": 1.1
       }
     ]
   },
@@ -7601,15 +7601,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.11
+        "llm-average": 7.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7621,19 +7621,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 4.81
+        "llm-average": 2.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7645,19 +7645,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 0.69
+        "llm-average": 0.3
       }
     ]
   },
@@ -7669,19 +7669,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.21
+        "llm-average": 4.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7693,23 +7693,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.91
+        "llm-average": 6.5
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7721,15 +7721,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -7741,27 +7741,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.52
+        "llm-average": 4.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 5.74
+        "llm-average": 2.9
       }
     ]
   },
@@ -7773,15 +7773,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.74
+        "llm-average": 4.4
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.21
+        "llm-average": 4.1
       }
     ]
   },
@@ -7793,19 +7793,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 0.69
+        "llm-average": 0.3
       }
     ]
   },
@@ -7817,15 +7817,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -7837,15 +7837,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 17.18
+        "llm-average": 8.6
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -7857,27 +7857,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 16.09
+        "llm-average": 8.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.03
+        "llm-average": 3.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -7889,27 +7889,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.52
+        "llm-average": 4.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 5.74
+        "llm-average": 2.9
       }
     ]
   },
@@ -7921,15 +7921,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.21
+        "llm-average": 4.1
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.09
+        "llm-average": 3.5
       }
     ]
   },
@@ -7941,23 +7941,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 16.09
+        "llm-average": 8.0
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.53
+        "llm-average": 5.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.45
+        "llm-average": 2.7
       }
     ]
   },
@@ -7969,11 +7969,11 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -7985,23 +7985,23 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 13.3
+        "llm-average": 6.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 11.69
+        "llm-average": 5.8
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -8013,27 +8013,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -8045,27 +8045,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.6
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -8077,15 +8077,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.89
+        "llm-average": 4.9
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -8097,27 +8097,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 10.62
+        "llm-average": 5.3
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 8.26
+        "llm-average": 4.1
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 6.51
+        "llm-average": 3.3
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 6.0
+        "llm-average": 3.0
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -8129,15 +8129,15 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -8149,27 +8149,27 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Darifenacin",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 7.72
+        "llm-average": 3.9
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -8181,19 +8181,19 @@ export const batch1: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Darifenacin",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Trospium",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "Oxybutynin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 2.94
+        "llm-average": 1.5
       }
     ]
   }

--- a/lib/batches/batch2.ts
+++ b/lib/batches/batch2.ts
@@ -9,11 +9,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Isosorbide mononitrate",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Patent Blue",
-        "llm-average": 9.02
+        "llm-average": 4.5
       }
     ]
   },
@@ -25,11 +25,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cilastatin",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "Dexamethasone",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -41,15 +41,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Daprodustat",
-        "llm-average": 15.16
+        "llm-average": 7.6
       },
       {
         "entity_name": "Roxadustat",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "Vadadustat",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -61,15 +61,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Formoterol",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Mianserin",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Magnesium",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -81,19 +81,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lenalidomide",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "Decitabine",
-        "llm-average": 14.58
+        "llm-average": 7.3
       },
       {
         "entity_name": "Azacitidine",
-        "llm-average": 13.23
+        "llm-average": 6.6
       },
       {
         "entity_name": "Lomustine",
-        "llm-average": 9.92
+        "llm-average": 5.0
       }
     ]
   },
@@ -105,27 +105,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Erlotinib",
-        "llm-average": 13.23
+        "llm-average": 6.6
       },
       {
         "entity_name": "Tamoxifen",
-        "llm-average": 11.8
+        "llm-average": 5.9
       },
       {
         "entity_name": "Gemcitabine",
-        "llm-average": 10.83
+        "llm-average": 5.4
       },
       {
         "entity_name": "Irinotecan",
-        "llm-average": 10.07
+        "llm-average": 5.0
       },
       {
         "entity_name": "Paclitaxel",
-        "llm-average": 9.14
+        "llm-average": 4.6
       },
       {
         "entity_name": "Topotecan",
-        "llm-average": 9.08
+        "llm-average": 4.5
       }
     ]
   },
@@ -137,23 +137,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Eprosartan",
-        "llm-average": 5.89
+        "llm-average": 2.9
       },
       {
         "entity_name": "Telmisartan",
-        "llm-average": 5.52
+        "llm-average": 2.8
       },
       {
         "entity_name": "Valsartan",
-        "llm-average": 3.76
+        "llm-average": 1.9
       },
       {
         "entity_name": "Irbesartan",
-        "llm-average": 3.43
+        "llm-average": 1.7
       },
       {
         "entity_name": "Losartan",
-        "llm-average": 1.67
+        "llm-average": 0.8
       }
     ]
   },
@@ -165,11 +165,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Zolmitriptan",
-        "llm-average": 12.09
+        "llm-average": 6.0
       },
       {
         "entity_name": "Cisplatin",
-        "llm-average": 10.45
+        "llm-average": 5.2
       }
     ]
   },
@@ -181,11 +181,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Iron",
-        "llm-average": 6.45
+        "llm-average": 3.2
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 2.8
+        "llm-average": 1.4
       }
     ]
   },
@@ -197,19 +197,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Rosiglitazone",
-        "llm-average": 16.98
+        "llm-average": 8.5
       },
       {
         "entity_name": "Pentamidine",
-        "llm-average": 14.07
+        "llm-average": 7.0
       },
       {
         "entity_name": "Verapamil",
-        "llm-average": 12.83
+        "llm-average": 6.4
       },
       {
         "entity_name": "Quinine",
-        "llm-average": 8.04
+        "llm-average": 4.0
       }
     ]
   },
@@ -221,11 +221,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.2
+        "llm-average": 6.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 7.34
+        "llm-average": 3.7
       }
     ]
   },
@@ -237,11 +237,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Mefenamic acid",
-        "llm-average": 13.27
+        "llm-average": 6.6
       },
       {
         "entity_name": "Indomethacin",
-        "llm-average": 9.85
+        "llm-average": 4.9
       }
     ]
   },
@@ -253,19 +253,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Mifepristone",
-        "llm-average": 11.66
+        "llm-average": 5.8
       },
       {
         "entity_name": "Disopyramide",
-        "llm-average": 11.41
+        "llm-average": 5.7
       },
       {
         "entity_name": "(R)-warfarin",
-        "llm-average": 10.97
+        "llm-average": 5.5
       },
       {
         "entity_name": "Warfarin",
-        "llm-average": 7.37
+        "llm-average": 3.7
       }
     ]
   },
@@ -277,11 +277,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Codeine",
-        "llm-average": 6.91
+        "llm-average": 3.5
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 6.45
+        "llm-average": 3.2
       }
     ]
   },
@@ -293,11 +293,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Methotrexate",
-        "llm-average": 10.31
+        "llm-average": 5.2
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 9.85
+        "llm-average": 4.9
       }
     ]
   },
@@ -309,11 +309,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Methotrexate",
-        "llm-average": 12.82
+        "llm-average": 6.4
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -325,11 +325,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 15.6
+        "llm-average": 7.8
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 8.34
+        "llm-average": 4.2
       }
     ]
   },
@@ -341,15 +341,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dapagliflozin",
-        "llm-average": 12.28
+        "llm-average": 6.1
       },
       {
         "entity_name": "Canagliflozin",
-        "llm-average": 12.07
+        "llm-average": 6.0
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 11.68
+        "llm-average": 5.8
       }
     ]
   },
@@ -361,11 +361,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.08
+        "llm-average": 5.0
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 8.19
+        "llm-average": 4.1
       }
     ]
   },
@@ -377,11 +377,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Epitestosterone",
-        "llm-average": 10.08
+        "llm-average": 5.0
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 8.95
+        "llm-average": 4.5
       }
     ]
   },
@@ -393,11 +393,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 6.45
+        "llm-average": 3.2
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 5.78
+        "llm-average": 2.9
       }
     ]
   },
@@ -409,11 +409,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Codeine",
-        "llm-average": 6.91
+        "llm-average": 3.5
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 6.45
+        "llm-average": 3.2
       }
     ]
   },
@@ -425,19 +425,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Resveratrol",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 13.11
+        "llm-average": 6.6
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 9.77
+        "llm-average": 4.9
       },
       {
         "entity_name": "Cilostazol",
-        "llm-average": 7.95
+        "llm-average": 4.0
       }
     ]
   },
@@ -449,11 +449,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.82
+        "llm-average": 6.4
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -465,11 +465,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 8.48
+        "llm-average": 4.2
       },
       {
         "entity_name": "Iron",
-        "llm-average": 4.03
+        "llm-average": 2.0
       }
     ]
   },
@@ -481,23 +481,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 11.54
+        "llm-average": 5.8
       },
       {
         "entity_name": "Sulfasalazine",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "Rosiglitazone",
-        "llm-average": 8.26
+        "llm-average": 4.1
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 8.2
+        "llm-average": 4.1
       },
       {
         "entity_name": "Pioglitazone",
-        "llm-average": 7.63
+        "llm-average": 3.8
       }
     ]
   },
@@ -509,11 +509,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.2
+        "llm-average": 6.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 9.05
+        "llm-average": 4.5
       }
     ]
   },
@@ -525,15 +525,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Balsalazide",
-        "llm-average": 13.11
+        "llm-average": 6.6
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 8.26
+        "llm-average": 4.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 3.93
+        "llm-average": 2.0
       }
     ]
   },
@@ -545,19 +545,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Balsalazide",
-        "llm-average": 17.02
+        "llm-average": 8.5
       },
       {
         "entity_name": "Troglitazone",
-        "llm-average": 13.88
+        "llm-average": 6.9
       },
       {
         "entity_name": "Metformin",
-        "llm-average": 12.82
+        "llm-average": 6.4
       },
       {
         "entity_name": "Rosiglitazone",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -569,15 +569,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Netoglitazone",
-        "llm-average": 16.06
+        "llm-average": 8.0
       },
       {
         "entity_name": "Pioglitazone",
-        "llm-average": 12.82
+        "llm-average": 6.4
       },
       {
         "entity_name": "Iloprost",
-        "llm-average": 9.85
+        "llm-average": 4.9
       }
     ]
   },
@@ -589,15 +589,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Triethylene glycol",
-        "llm-average": 11.14
+        "llm-average": 5.6
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 9.79
+        "llm-average": 4.9
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 6.45
+        "llm-average": 3.2
       }
     ]
   },
@@ -609,19 +609,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Troglitazone",
-        "llm-average": 14.57
+        "llm-average": 7.3
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "Indomethacin",
-        "llm-average": 8.57
+        "llm-average": 4.3
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 5.21
+        "llm-average": 2.6
       }
     ]
   },
@@ -633,11 +633,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lacosamide",
-        "llm-average": 11.14
+        "llm-average": 5.6
       },
       {
         "entity_name": "Doxycycline",
-        "llm-average": 6.45
+        "llm-average": 3.2
       }
     ]
   },
@@ -649,11 +649,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tacrolimus",
-        "llm-average": 15.4
+        "llm-average": 7.7
       },
       {
         "entity_name": "Ritonavir",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -665,11 +665,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Epitestosterone",
-        "llm-average": 10.08
+        "llm-average": 5.0
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -681,11 +681,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Resveratrol",
-        "llm-average": 14.09
+        "llm-average": 7.0
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.83
+        "llm-average": 6.4
       }
     ]
   },
@@ -697,11 +697,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bortezomib",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -713,23 +713,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 16.36
+        "llm-average": 8.2
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -741,31 +741,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Istradefylline",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "Grapiprant",
-        "llm-average": 12.95
+        "llm-average": 6.5
       },
       {
         "entity_name": "Theophylline",
-        "llm-average": 7.76
+        "llm-average": 3.9
       },
       {
         "entity_name": "Pentoxifylline",
-        "llm-average": 7.55
+        "llm-average": 3.8
       },
       {
         "entity_name": "Caffeine",
-        "llm-average": 6.53
+        "llm-average": 3.3
       },
       {
         "entity_name": "Oxtriphylline",
-        "llm-average": 6.33
+        "llm-average": 3.2
       },
       {
         "entity_name": "Aminophylline",
-        "llm-average": 5.87
+        "llm-average": 2.9
       }
     ]
   },
@@ -777,11 +777,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vorinostat",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "Tacrolimus",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -793,15 +793,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 7.37
+        "llm-average": 3.7
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 7.0
+        "llm-average": 3.5
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 6.22
+        "llm-average": 3.1
       }
     ]
   },
@@ -813,19 +813,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Carmustine",
-        "llm-average": 13.54
+        "llm-average": 6.8
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 13.02
+        "llm-average": 6.5
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.12
+        "llm-average": 2.1
       }
     ]
   },
@@ -837,15 +837,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Estradiol",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.45
+        "llm-average": 2.2
       }
     ]
   },
@@ -857,11 +857,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dronabinol",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.77
+        "llm-average": 5.4
       }
     ]
   },
@@ -873,35 +873,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPN11",
-        "llm-average": 15.76
+        "llm-average": 7.9
       },
       {
         "entity_name": "IKBKG",
-        "llm-average": 15.43
+        "llm-average": 7.7
       },
       {
         "entity_name": "PTPN18",
-        "llm-average": 13.06
+        "llm-average": 6.5
       },
       {
         "entity_name": "PIK3CA",
-        "llm-average": 12.82
+        "llm-average": 6.4
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 10.99
+        "llm-average": 5.5
       },
       {
         "entity_name": "MAPK8",
-        "llm-average": 9.48
+        "llm-average": 4.7
       },
       {
         "entity_name": "IGF2",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -913,15 +913,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 10.01
+        "llm-average": 5.0
       }
     ]
   },
@@ -933,19 +933,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Phenobarbital",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "Dihydroergotamine",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Citalopram",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "Escitalopram",
-        "llm-average": 7.77
+        "llm-average": 3.9
       }
     ]
   },
@@ -957,23 +957,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Puromycin",
-        "llm-average": 15.24
+        "llm-average": 7.6
       },
       {
         "entity_name": "Gemcitabine",
-        "llm-average": 14.08
+        "llm-average": 7.0
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 11.86
+        "llm-average": 5.9
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 5.99
+        "llm-average": 3.0
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 1.98
+        "llm-average": 1.0
       },
       {
         "entity_name": "Acetaminophen",
@@ -989,11 +989,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dactinomycin",
-        "llm-average": 16.09
+        "llm-average": 8.0
       },
       {
         "entity_name": "Carbamazepine",
-        "llm-average": 8.15
+        "llm-average": 4.1
       }
     ]
   },
@@ -1005,27 +1005,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 16.83
+        "llm-average": 8.4
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 14.58
+        "llm-average": 7.3
       },
       {
         "entity_name": "AGPAT5",
-        "llm-average": 14.4
+        "llm-average": 7.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -1037,19 +1037,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Codeine",
-        "llm-average": 15.62
+        "llm-average": 7.8
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 8.15
+        "llm-average": 4.1
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -1061,11 +1061,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LEP",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "REL",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -1077,15 +1077,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lapatinib",
-        "llm-average": 14.18
+        "llm-average": 7.1
       },
       {
         "entity_name": "Erlotinib",
-        "llm-average": 7.0
+        "llm-average": 3.5
       },
       {
         "entity_name": "Selumetinib",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -1097,23 +1097,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HMOX1",
-        "llm-average": 15.76
+        "llm-average": 7.9
       },
       {
         "entity_name": "BATF3",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "MAPK14",
-        "llm-average": 12.05
+        "llm-average": 6.0
       },
       {
         "entity_name": "MAPK1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "CCND1",
-        "llm-average": 8.95
+        "llm-average": 4.5
       }
     ]
   },
@@ -1125,19 +1125,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FRK",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "CSNK2B",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "PSMD5",
-        "llm-average": 11.55
+        "llm-average": 5.8
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 9.29
+        "llm-average": 4.6
       }
     ]
   },
@@ -1149,19 +1149,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Mestranol",
-        "llm-average": 14.18
+        "llm-average": 7.1
       },
       {
         "entity_name": "Baclofen",
-        "llm-average": 12.32
+        "llm-average": 6.2
       },
       {
         "entity_name": "Digoxin",
-        "llm-average": 9.16
+        "llm-average": 4.6
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -1173,23 +1173,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bepridil",
-        "llm-average": 18.85
+        "llm-average": 9.4
       },
       {
         "entity_name": "Tacrolimus",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.3
+        "llm-average": 5.2
       },
       {
         "entity_name": "Chlorothiazide",
-        "llm-average": 5.95
+        "llm-average": 3.0
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 1.98
+        "llm-average": 1.0
       }
     ]
   },
@@ -1201,27 +1201,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ARL13B",
-        "llm-average": 13.54
+        "llm-average": 6.8
       },
       {
         "entity_name": "AXL",
-        "llm-average": 12.61
+        "llm-average": 6.3
       },
       {
         "entity_name": "SMAD9",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "TMCO2",
-        "llm-average": 11.46
+        "llm-average": 5.7
       },
       {
         "entity_name": "CLTC",
-        "llm-average": 5.72
+        "llm-average": 2.9
       },
       {
         "entity_name": "SLC2A4",
-        "llm-average": 5.5
+        "llm-average": 2.8
       }
     ]
   },
@@ -1233,11 +1233,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FOS",
-        "llm-average": 9.55
+        "llm-average": 4.8
       },
       {
         "entity_name": "JUN",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -1249,15 +1249,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Eltrombopag",
-        "llm-average": 17.71
+        "llm-average": 8.9
       },
       {
         "entity_name": "Ruxolitinib",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "Everolimus",
-        "llm-average": 8.15
+        "llm-average": 4.1
       }
     ]
   },
@@ -1269,15 +1269,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ITGB4",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "ITGA6",
-        "llm-average": 10.79
+        "llm-average": 5.4
       },
       {
         "entity_name": "FYN",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -1289,15 +1289,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diethylstilbestrol",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "Ethinylestradiol",
-        "llm-average": 7.39
+        "llm-average": 3.7
       }
     ]
   },
@@ -1309,11 +1309,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dronabinol",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -1325,31 +1325,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Doxazosin",
-        "llm-average": 16.8
+        "llm-average": 8.4
       },
       {
         "entity_name": "Tamsulosin",
-        "llm-average": 14.97
+        "llm-average": 7.5
       },
       {
         "entity_name": "Epinephrine",
-        "llm-average": 12.25
+        "llm-average": 6.1
       },
       {
         "entity_name": "Methotrimeprazine",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Periciazine",
-        "llm-average": 9.94
+        "llm-average": 5.0
       },
       {
         "entity_name": "Cyproterone acetate",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "Promazine",
-        "llm-average": 7.64
+        "llm-average": 3.8
       }
     ]
   },
@@ -1361,19 +1361,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Captopril",
-        "llm-average": 14.61
+        "llm-average": 7.3
       },
       {
         "entity_name": "Probenecid",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "Dinoprostone",
-        "llm-average": 8.99
+        "llm-average": 4.5
       },
       {
         "entity_name": "Progesterone",
-        "llm-average": 4.93
+        "llm-average": 2.5
       }
     ]
   },
@@ -1385,31 +1385,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sunitinib",
-        "llm-average": 14.63
+        "llm-average": 7.3
       },
       {
         "entity_name": "Pentamidine",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Bromocriptine",
-        "llm-average": 10.43
+        "llm-average": 5.2
       },
       {
         "entity_name": "Dapagliflozin",
-        "llm-average": 8.95
+        "llm-average": 4.5
       },
       {
         "entity_name": "Glimepiride",
-        "llm-average": 8.83
+        "llm-average": 4.4
       },
       {
         "entity_name": "Rosiglitazone",
-        "llm-average": 7.99
+        "llm-average": 4.0
       },
       {
         "entity_name": "Pioglitazone",
-        "llm-average": 7.09
+        "llm-average": 3.5
       }
     ]
   },
@@ -1421,23 +1421,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Roflumilast",
-        "llm-average": 14.68
+        "llm-average": 7.3
       },
       {
         "entity_name": "Theophylline",
-        "llm-average": 12.89
+        "llm-average": 6.4
       },
       {
         "entity_name": "Cilostazol",
-        "llm-average": 12.39
+        "llm-average": 6.2
       },
       {
         "entity_name": "Milrinone",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Amrinone",
-        "llm-average": 8.15
+        "llm-average": 4.1
       }
     ]
   },
@@ -1449,27 +1449,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sorafenib",
-        "llm-average": 17.66
+        "llm-average": 8.8
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 16.29
+        "llm-average": 8.1
       },
       {
         "entity_name": "Naringenin",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "Progesterone",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 8.95
+        "llm-average": 4.5
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 7.09
+        "llm-average": 3.5
       }
     ]
   },
@@ -1481,23 +1481,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lidocaine",
-        "llm-average": 8.4
+        "llm-average": 4.2
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 7.81
+        "llm-average": 3.9
       },
       {
         "entity_name": "Nebivolol",
-        "llm-average": 7.37
+        "llm-average": 3.7
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 5.95
+        "llm-average": 3.0
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 5.43
+        "llm-average": 2.7
       }
     ]
   },
@@ -1509,11 +1509,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dextroamphetamine",
-        "llm-average": 11.5
+        "llm-average": 5.7
       },
       {
         "entity_name": "Norepinephrine",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -1525,11 +1525,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Pramlintide",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "Ethanol",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -1541,11 +1541,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FGF1",
-        "llm-average": 13.65
+        "llm-average": 6.8
       },
       {
         "entity_name": "FGF2",
-        "llm-average": 13.45
+        "llm-average": 6.7
       }
     ]
   },
@@ -1557,11 +1557,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Inositol",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "Safinamide",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -1573,11 +1573,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tamoxifen",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -1589,19 +1589,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 17.36
+        "llm-average": 8.7
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 14.28
+        "llm-average": 7.1
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.39
+        "llm-average": 5.7
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 10.81
+        "llm-average": 5.4
       }
     ]
   },
@@ -1613,11 +1613,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Amiodarone",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -1629,27 +1629,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Genistein",
-        "llm-average": 17.84
+        "llm-average": 8.9
       },
       {
         "entity_name": "Trifluoperazine",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "Sunitinib",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "Guanine",
-        "llm-average": 10.89
+        "llm-average": 5.4
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 6.78
+        "llm-average": 3.4
       },
       {
         "entity_name": "Ethanol",
-        "llm-average": 3.3
+        "llm-average": 1.7
       }
     ]
   },
@@ -1661,11 +1661,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NFKB1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "PLCB1",
-        "llm-average": 15.07
+        "llm-average": 7.5
       }
     ]
   },
@@ -1677,19 +1677,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "(R)-warfarin",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "Warfarin",
-        "llm-average": 11.18
+        "llm-average": 5.6
       },
       {
         "entity_name": "Carbamazepine",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -1701,23 +1701,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 15.3
+        "llm-average": 7.7
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 14.15
+        "llm-average": 7.1
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -1729,27 +1729,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trazodone",
-        "llm-average": 13.61
+        "llm-average": 6.8
       },
       {
         "entity_name": "Pregabalin",
-        "llm-average": 12.95
+        "llm-average": 6.5
       },
       {
         "entity_name": "Zaleplon",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Paroxetine",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "Etodolac",
-        "llm-average": 6.29
+        "llm-average": 3.1
       },
       {
         "entity_name": "Naproxen",
-        "llm-average": 3.3
+        "llm-average": 1.7
       }
     ]
   },
@@ -1761,11 +1761,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Digoxin",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -1777,11 +1777,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Estradiol",
-        "llm-average": 7.85
+        "llm-average": 3.9
       },
       {
         "entity_name": "Progesterone",
-        "llm-average": 7.66
+        "llm-average": 3.8
       }
     ]
   },
@@ -1793,19 +1793,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 11.54
+        "llm-average": 5.8
       },
       {
         "entity_name": "Decitabine",
-        "llm-average": 8.99
+        "llm-average": 4.5
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 8.1
+        "llm-average": 4.1
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 3.74
+        "llm-average": 1.9
       }
     ]
   },
@@ -1817,19 +1817,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Calcitriol",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 2.82
+        "llm-average": 1.4
       }
     ]
   },
@@ -1841,23 +1841,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 14.68
+        "llm-average": 7.3
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 6.25
+        "llm-average": 3.1
       }
     ]
   },
@@ -1869,11 +1869,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sorafenib",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "Sunitinib",
-        "llm-average": 11.11
+        "llm-average": 5.6
       }
     ]
   },
@@ -1885,15 +1885,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 9.25
+        "llm-average": 4.6
       }
     ]
   },
@@ -1905,11 +1905,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -1921,15 +1921,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 17.18
+        "llm-average": 8.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -1941,11 +1941,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "MYC",
-        "llm-average": 14.7
+        "llm-average": 7.4
       }
     ]
   },
@@ -1957,23 +1957,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 12.87
+        "llm-average": 6.4
       },
       {
         "entity_name": "MYC",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.12
+        "llm-average": 5.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       }
     ]
   },
@@ -1985,11 +1985,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -2001,11 +2001,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GRB2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       }
     ]
   },
@@ -2017,11 +2017,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "MYC",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -2033,11 +2033,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GRB2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       }
     ]
   },
@@ -2049,11 +2049,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 9.86
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -2065,11 +2065,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -2081,19 +2081,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 14.16
+        "llm-average": 7.1
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 12.18
+        "llm-average": 6.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 11.73
+        "llm-average": 5.9
       }
     ]
   },
@@ -2105,23 +2105,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 15.56
+        "llm-average": 7.8
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 12.29
+        "llm-average": 6.1
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -2133,11 +2133,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       }
     ]
   },
@@ -2149,15 +2149,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KCNA3",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "OPRM1",
-        "llm-average": 13.29
+        "llm-average": 6.6
       },
       {
         "entity_name": "OPRD1",
-        "llm-average": 5.65
+        "llm-average": 2.8
       }
     ]
   },
@@ -2169,19 +2169,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HTRA3",
-        "llm-average": 14.42
+        "llm-average": 7.2
       },
       {
         "entity_name": "SLC22A6",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "SLC22A8",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "MPO",
-        "llm-average": 5.89
+        "llm-average": 2.9
       }
     ]
   },
@@ -2193,23 +2193,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Intracellular Signalling Through Adenosine Receptor A2b and Adenosine",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
-        "llm-average": 11.66
+        "llm-average": 5.8
       },
       {
         "entity_name": "Surfactant metabolism",
-        "llm-average": 8.27
+        "llm-average": 4.1
       },
       {
         "entity_name": "Adenosine P1 receptors",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "G alpha (s) signalling events",
-        "llm-average": 4.09
+        "llm-average": 2.0
       }
     ]
   },
@@ -2221,15 +2221,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "G alpha (q) signalling events",
-        "llm-average": 13.78
+        "llm-average": 6.9
       },
       {
         "entity_name": "G alpha (12/13) signalling events",
-        "llm-average": 9.12
+        "llm-average": 4.6
       },
       {
         "entity_name": "Adrenoceptors",
-        "llm-average": 7.4
+        "llm-average": 3.7
       }
     ]
   },
@@ -2241,15 +2241,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
-        "llm-average": 18.06
+        "llm-average": 9.0
       },
       {
         "entity_name": "G alpha (s) signalling events",
-        "llm-average": 15.54
+        "llm-average": 7.8
       },
       {
         "entity_name": "Prostanoid ligand receptors",
-        "llm-average": 7.33
+        "llm-average": 3.7
       }
     ]
   },
@@ -2261,11 +2261,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "one-carbon metabolic process",
-        "llm-average": 12.31
+        "llm-average": 6.2
       },
       {
         "entity_name": "bicarbonate transport",
-        "llm-average": 5.65
+        "llm-average": 2.8
       }
     ]
   },
@@ -2277,19 +2277,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "F2RL1",
-        "llm-average": 11.59
+        "llm-average": 5.8
       },
       {
         "entity_name": "F2RL2",
-        "llm-average": 9.01
+        "llm-average": 4.5
       },
       {
         "entity_name": "F2RL3",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "F2R",
-        "llm-average": 7.44
+        "llm-average": 3.7
       }
     ]
   },
@@ -2301,23 +2301,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MHC class II antigen presentation",
-        "llm-average": 19.35
+        "llm-average": 9.7
       },
       {
         "entity_name": "Neutrophil degranulation",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "Estrogen-dependent gene expression",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "Metabolism of Angiotensinogen to Angiotensins",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "Collagen degradation",
-        "llm-average": 6.8
+        "llm-average": 3.4
       }
     ]
   },
@@ -2329,15 +2329,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CARMIL2",
-        "llm-average": 12.75
+        "llm-average": 6.4
       },
       {
         "entity_name": "AR",
-        "llm-average": 12.31
+        "llm-average": 6.2
       },
       {
         "entity_name": "CARMIL1",
-        "llm-average": 9.0
+        "llm-average": 4.5
       }
     ]
   },
@@ -2349,23 +2349,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sphingolipid de novo biosynthesis",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "Glycerolipid Metabolism",
-        "llm-average": 11.2
+        "llm-average": 5.6
       },
       {
         "entity_name": "Glycerol Kinase Deficiency",
-        "llm-average": 4.15
+        "llm-average": 2.1
       },
       {
         "entity_name": "D-Glyceric Acidura",
-        "llm-average": 2.07
+        "llm-average": 1.0
       },
       {
         "entity_name": "Familial Lipoprotein Lipase Deficiency",
-        "llm-average": 1.55
+        "llm-average": 0.8
       }
     ]
   },
@@ -2377,23 +2377,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC6A2",
-        "llm-average": 8.25
+        "llm-average": 4.1
       },
       {
         "entity_name": "SLC6A3",
-        "llm-average": 7.27
+        "llm-average": 3.6
       },
       {
         "entity_name": "AFM",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "ETV6",
-        "llm-average": 5.16
+        "llm-average": 2.6
       },
       {
         "entity_name": "CHRM3",
-        "llm-average": 2.73
+        "llm-average": 1.4
       }
     ]
   },
@@ -2405,23 +2405,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Defective MTRR causes methylmalonic aciduria and homocystinuria type cblE",
-        "llm-average": 15.87
+        "llm-average": 7.9
       },
       {
         "entity_name": "Defective MTR causes methylmalonic aciduria and homocystinuria type cblG",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Cobalamin (Cbl, vitamin B12) transport and metabolism",
-        "llm-average": 10.63
+        "llm-average": 5.3
       },
       {
         "entity_name": "Methylation",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Sulfur amino acid metabolism",
-        "llm-average": 5.76
+        "llm-average": 2.9
       }
     ]
   },
@@ -2433,11 +2433,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "sepiapterin reductase",
-        "llm-average": 13.9
+        "llm-average": 6.9
       },
       {
         "entity_name": "tachykinin receptor 1",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -2449,11 +2449,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Serotonin receptors",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -2465,35 +2465,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2L14",
-        "llm-average": 11.06
+        "llm-average": 5.5
       },
       {
         "entity_name": "BCL2A1",
-        "llm-average": 9.89
+        "llm-average": 4.9
       },
       {
         "entity_name": "MCL1",
-        "llm-average": 9.36
+        "llm-average": 4.7
       },
       {
         "entity_name": "BOK",
-        "llm-average": 9.3
+        "llm-average": 4.7
       },
       {
         "entity_name": "BCL2L1",
-        "llm-average": 8.13
+        "llm-average": 4.1
       },
       {
         "entity_name": "POLA1",
-        "llm-average": 6.55
+        "llm-average": 3.3
       },
       {
         "entity_name": "RRM1",
-        "llm-average": 5.31
+        "llm-average": 2.7
       },
       {
         "entity_name": "DCK",
-        "llm-average": 4.41
+        "llm-average": 2.2
       }
     ]
   },
@@ -2505,31 +2505,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Primary Hyperoxaluria II, PH2",
-        "llm-average": 18.63
+        "llm-average": 9.3
       },
       {
         "entity_name": "Pyruvate Dehydrogenase Complex Deficiency",
-        "llm-average": 15.98
+        "llm-average": 8.0
       },
       {
         "entity_name": "Glyoxylate metabolism and glycine degradation",
-        "llm-average": 12.56
+        "llm-average": 6.3
       },
       {
         "entity_name": "Leigh Syndrome",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Pyruvate Decarboxylase E1 Component Deficiency (PDHE1 Deficiency)",
-        "llm-average": 9.32
+        "llm-average": 4.7
       },
       {
         "entity_name": "Pyruvate Kinase Deficiency",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Pyruvate Metabolism",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -2541,15 +2541,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "G alpha (q) signalling events",
-        "llm-average": 14.89
+        "llm-average": 7.4
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Class C/3 (Metabotropic glutamate/pheromone receptors)",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -2561,11 +2561,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC6A2",
-        "llm-average": 11.08
+        "llm-average": 5.5
       },
       {
         "entity_name": "SLC6A3",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -2577,31 +2577,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RYR2",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "ADRB1",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "ADRB3",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "ADRB2",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "FKBP1B",
-        "llm-average": 8.21
+        "llm-average": 4.1
       },
       {
         "entity_name": "AKAP10",
-        "llm-average": 7.3
+        "llm-average": 3.6
       },
       {
         "entity_name": "REN",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -2613,27 +2613,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GATA1",
-        "llm-average": 18.32
+        "llm-average": 9.2
       },
       {
         "entity_name": "PDE3A",
-        "llm-average": 17.08
+        "llm-average": 8.5
       },
       {
         "entity_name": "TLN1",
-        "llm-average": 11.84
+        "llm-average": 5.9
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 11.47
+        "llm-average": 5.7
       },
       {
         "entity_name": "THPO",
-        "llm-average": 10.41
+        "llm-average": 5.2
       },
       {
         "entity_name": "MPL",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -2645,11 +2645,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Class C/3 (Metabotropic glutamate/pheromone receptors)",
-        "llm-average": 6.84
+        "llm-average": 3.4
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 4.78
+        "llm-average": 2.4
       }
     ]
   },
@@ -2661,31 +2661,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OPRD1",
-        "llm-average": 15.22
+        "llm-average": 7.6
       },
       {
         "entity_name": "OPRM1",
-        "llm-average": 12.65
+        "llm-average": 6.3
       },
       {
         "entity_name": "CHRNA3",
-        "llm-average": 8.87
+        "llm-average": 4.4
       },
       {
         "entity_name": "CYP3A4",
-        "llm-average": 7.4
+        "llm-average": 3.7
       },
       {
         "entity_name": "CHRNB4",
-        "llm-average": 6.54
+        "llm-average": 3.3
       },
       {
         "entity_name": "CYP3A5",
-        "llm-average": 5.79
+        "llm-average": 2.9
       },
       {
         "entity_name": "KCNH2",
-        "llm-average": 5.65
+        "llm-average": 2.8
       }
     ]
   },
@@ -2697,27 +2697,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ALK receptor tyrosine kinase",
-        "llm-average": 18.45
+        "llm-average": 9.2
       },
       {
         "entity_name": "EMAP like 4",
-        "llm-average": 14.95
+        "llm-average": 7.5
       },
       {
         "entity_name": "ROS proto-oncogene 1, receptor tyrosine kinase",
-        "llm-average": 14.05
+        "llm-average": 7.0
       },
       {
         "entity_name": "tumor protein p53",
-        "llm-average": 7.59
+        "llm-average": 3.8
       },
       {
         "entity_name": "nucleophosmin 1",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "RB transcriptional corepressor 1",
-        "llm-average": 3.31
+        "llm-average": 1.7
       }
     ]
   },
@@ -2729,27 +2729,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OPRK1",
-        "llm-average": 13.42
+        "llm-average": 6.7
       },
       {
         "entity_name": "OPRD1",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "OPRM1",
-        "llm-average": 10.33
+        "llm-average": 5.2
       },
       {
         "entity_name": "HTR3A",
-        "llm-average": 6.29
+        "llm-average": 3.1
       },
       {
         "entity_name": "SLC6A4",
-        "llm-average": 5.89
+        "llm-average": 2.9
       },
       {
         "entity_name": "SLC6A2",
-        "llm-average": 5.13
+        "llm-average": 2.6
       }
     ]
   },
@@ -2761,31 +2761,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "L13a-mediated translational silencing of Ceruloplasmin expression",
-        "llm-average": 17.8
+        "llm-average": 8.9
       },
       {
         "entity_name": "Deadenylation of mRNA",
-        "llm-average": 12.77
+        "llm-average": 6.4
       },
       {
         "entity_name": "AUF1 (hnRNP D0) binds and destabilizes mRNA",
-        "llm-average": 12.57
+        "llm-average": 6.3
       },
       {
         "entity_name": "Nonsense Mediated Decay (NMD) independent of the Exon Junction Complex (EJC)",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Nonsense Mediated Decay (NMD) enhanced by the Exon Junction Complex (EJC)",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "Regulation of expression of SLITs and ROBOs",
-        "llm-average": 9.76
+        "llm-average": 4.9
       },
       {
         "entity_name": "Translation initiation complex formation",
-        "llm-average": 9.26
+        "llm-average": 4.6
       }
     ]
   },
@@ -2797,11 +2797,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "G protein-coupled receptor signaling pathway",
-        "llm-average": 8.18
+        "llm-average": 4.1
       },
       {
         "entity_name": "cell projection organization",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -2813,11 +2813,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "Class C/3 (Metabotropic glutamate/pheromone receptors)",
-        "llm-average": 4.21
+        "llm-average": 2.1
       }
     ]
   },
@@ -2829,31 +2829,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "positive regulation of acrosome reaction",
-        "llm-average": 19.35
+        "llm-average": 9.7
       },
       {
         "entity_name": "positive regulation of fertilization",
-        "llm-average": 15.54
+        "llm-average": 7.8
       },
       {
         "entity_name": "binding of sperm to zona pellucida",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "cell migration",
-        "llm-average": 8.34
+        "llm-average": 4.2
       },
       {
         "entity_name": "regulation of protein processing",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "protein maturation",
-        "llm-average": 6.35
+        "llm-average": 3.2
       },
       {
         "entity_name": "proteolysis",
-        "llm-average": 5.69
+        "llm-average": 2.8
       }
     ]
   },
@@ -2865,35 +2865,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Metabolism of Angiotensinogen to Angiotensins",
-        "llm-average": 13.65
+        "llm-average": 6.8
       },
       {
         "entity_name": "Heroin Metabolism Pathway",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "Mycophenolic Acid Metabolism Pathway",
-        "llm-average": 6.72
+        "llm-average": 3.4
       },
       {
         "entity_name": "Irinotecan Action Pathway",
-        "llm-average": 5.89
+        "llm-average": 2.9
       },
       {
         "entity_name": "Irinotecan Metabolism Pathway",
-        "llm-average": 5.69
+        "llm-average": 2.8
       },
       {
         "entity_name": "Capecitabine Metabolism Pathway",
-        "llm-average": 4.85
+        "llm-average": 2.4
       },
       {
         "entity_name": "Capecitabine Action Pathway",
-        "llm-average": 4.72
+        "llm-average": 2.4
       },
       {
         "entity_name": "Phase I - Functionalization of compounds",
-        "llm-average": 4.52
+        "llm-average": 2.3
       }
     ]
   },
@@ -2905,19 +2905,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HTR3B",
-        "llm-average": 9.92
+        "llm-average": 5.0
       },
       {
         "entity_name": "HTR3A",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "HTR3C",
-        "llm-average": 8.38
+        "llm-average": 4.2
       },
       {
         "entity_name": "HTR3D",
-        "llm-average": 5.38
+        "llm-average": 2.7
       }
     ]
   },
@@ -2929,23 +2929,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AFM",
-        "llm-average": 11.46
+        "llm-average": 5.7
       },
       {
         "entity_name": "SLC6A3",
-        "llm-average": 10.32
+        "llm-average": 5.2
       },
       {
         "entity_name": "CHRM3",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "SLC6A2",
-        "llm-average": 8.31
+        "llm-average": 4.2
       },
       {
         "entity_name": "ETV6",
-        "llm-average": 7.44
+        "llm-average": 3.7
       }
     ]
   },
@@ -2957,15 +2957,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Biogenic amines are oxidatively deaminated to aldehydes by MAOA and MAOB",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "Citalopram Metabolism Pathway",
-        "llm-average": 4.14
+        "llm-average": 2.1
       },
       {
         "entity_name": "Citalopram Action Pathway",
-        "llm-average": 1.55
+        "llm-average": 0.8
       }
     ]
   },
@@ -2977,23 +2977,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PDE3A",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "GATA1",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "P2RY12",
-        "llm-average": 10.68
+        "llm-average": 5.3
       },
       {
         "entity_name": "PDGFB",
-        "llm-average": 8.34
+        "llm-average": 4.2
       },
       {
         "entity_name": "TGFB1",
-        "llm-average": 4.46
+        "llm-average": 2.2
       }
     ]
   },
@@ -3005,19 +3005,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LACTB",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "SELP",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "YARS2",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "LACTBL1",
-        "llm-average": 5.89
+        "llm-average": 2.9
       }
     ]
   },
@@ -3029,11 +3029,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Peptide ligand-binding receptors",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -3045,31 +3045,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "COPI-independent Golgi-to-ER retrograde traffic",
-        "llm-average": 14.56
+        "llm-average": 7.3
       },
       {
         "entity_name": "Retrograde transport at the Trans-Golgi-Network",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "Pre-NOTCH Processing in Golgi",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "Neutrophil degranulation",
-        "llm-average": 10.67
+        "llm-average": 5.3
       },
       {
         "entity_name": "RAB geranylgeranylation",
-        "llm-average": 6.74
+        "llm-average": 3.4
       },
       {
         "entity_name": "RAB GEFs exchange GTP for GDP on RABs",
-        "llm-average": 5.65
+        "llm-average": 2.8
       },
       {
         "entity_name": "TBC/RABGAPs",
-        "llm-average": 4.87
+        "llm-average": 2.4
       }
     ]
   },
@@ -3081,11 +3081,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IL10",
-        "llm-average": 15.54
+        "llm-average": 7.8
       },
       {
         "entity_name": "XRCC2",
-        "llm-average": 14.04
+        "llm-average": 7.0
       }
     ]
   },
@@ -3097,23 +3097,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CHRM1",
-        "llm-average": 6.74
+        "llm-average": 3.4
       },
       {
         "entity_name": "CHRM5",
-        "llm-average": 6.22
+        "llm-average": 3.1
       },
       {
         "entity_name": "CHRM3",
-        "llm-average": 5.69
+        "llm-average": 2.8
       },
       {
         "entity_name": "CHRM4",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "CHRNA2",
-        "llm-average": 5.16
+        "llm-average": 2.6
       }
     ]
   },
@@ -3125,15 +3125,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Reversible hydration of carbon dioxide",
-        "llm-average": 12.31
+        "llm-average": 6.2
       },
       {
         "entity_name": "Erythrocytes take up carbon dioxide and release oxygen",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Erythrocytes take up oxygen and release carbon dioxide",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -3145,11 +3145,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 14.17
+        "llm-average": 7.1
       },
       {
         "entity_name": "Peptide ligand-binding receptors",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -3161,11 +3161,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Formation of the cornified envelope",
-        "llm-average": 12.1
+        "llm-average": 6.1
       },
       {
         "entity_name": "Regulation of Insulin-like Growth Factor (IGF) transport and uptake by Insulin-like Growth Factor Binding Proteins (IGFBPs)",
-        "llm-average": 10.67
+        "llm-average": 5.3
       }
     ]
   },
@@ -3177,11 +3177,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Activation of Matrix Metalloproteinases",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Cobalamin (Cbl, vitamin B12) transport and metabolism",
-        "llm-average": 10.28
+        "llm-average": 5.1
       }
     ]
   },
@@ -3193,11 +3193,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Peptide ligand-binding receptors",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -3209,11 +3209,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OPRM1",
-        "llm-average": 6.3
+        "llm-average": 3.2
       },
       {
         "entity_name": "OPRD1",
-        "llm-average": 5.65
+        "llm-average": 2.8
       }
     ]
   },
@@ -3225,15 +3225,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "protein peptidyl-prolyl isomerization",
-        "llm-average": 18.45
+        "llm-average": 9.2
       },
       {
         "entity_name": "protein folding",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "RNA splicing",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -3245,11 +3245,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC5A2",
-        "llm-average": 5.89
+        "llm-average": 2.9
       },
       {
         "entity_name": "SLC5A1",
-        "llm-average": 5.57
+        "llm-average": 2.8
       }
     ]
   },
@@ -3261,11 +3261,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Chemokine receptors bind chemokines",
-        "llm-average": 14.17
+        "llm-average": 7.1
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -3277,27 +3277,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PPIG",
-        "llm-average": 12.9
+        "llm-average": 6.5
       },
       {
         "entity_name": "CYP2C9",
-        "llm-average": 11.28
+        "llm-average": 5.6
       },
       {
         "entity_name": "CYP2C8",
-        "llm-average": 6.73
+        "llm-average": 3.4
       },
       {
         "entity_name": "CYP2C19",
-        "llm-average": 6.29
+        "llm-average": 3.1
       },
       {
         "entity_name": "CYP1A2",
-        "llm-average": 5.43
+        "llm-average": 2.7
       },
       {
         "entity_name": "CYP3A4",
-        "llm-average": 4.78
+        "llm-average": 2.4
       }
     ]
   },
@@ -3309,35 +3309,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FOXO-mediated transcription of oxidative stress, metabolic and neuronal genes",
-        "llm-average": 18.06
+        "llm-average": 9.0
       },
       {
         "entity_name": "Detoxification of Reactive Oxygen Species",
-        "llm-average": 11.4
+        "llm-average": 5.7
       },
       {
         "entity_name": "Neutrophil degranulation",
-        "llm-average": 9.57
+        "llm-average": 4.8
       },
       {
         "entity_name": "Degradation of Superoxides",
-        "llm-average": 7.05
+        "llm-average": 3.5
       },
       {
         "entity_name": "Disulfiram Action Pathway",
-        "llm-average": 6.46
+        "llm-average": 3.2
       },
       {
         "entity_name": "Peroxisomal protein import",
-        "llm-average": 5.77
+        "llm-average": 2.9
       },
       {
         "entity_name": "Tryptophan Metabolism",
-        "llm-average": 5.26
+        "llm-average": 2.6
       },
       {
         "entity_name": "Ethanol Degradation",
-        "llm-average": 3.69
+        "llm-average": 1.8
       }
     ]
   },
@@ -3349,15 +3349,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CARMIL1",
-        "llm-average": 10.16
+        "llm-average": 5.1
       },
       {
         "entity_name": "CARMIL2",
-        "llm-average": 8.99
+        "llm-average": 4.5
       },
       {
         "entity_name": "AR",
-        "llm-average": 8.18
+        "llm-average": 4.1
       }
     ]
   },
@@ -3369,11 +3369,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cytochrome P450 - arranged by substrate type",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "Doxorubicin Metabolism Pathway",
-        "llm-average": 4.78
+        "llm-average": 2.4
       }
     ]
   },
@@ -3385,19 +3385,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATF4 activates genes in response to endoplasmic reticulum  stress",
-        "llm-average": 13.51
+        "llm-average": 6.8
       },
       {
         "entity_name": "Chemokine receptors bind chemokines",
-        "llm-average": 12.44
+        "llm-average": 6.2
       },
       {
         "entity_name": "Interleukin-10 signaling",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Interleukin-4 and Interleukin-13 signaling",
-        "llm-average": 9.77
+        "llm-average": 4.9
       }
     ]
   },
@@ -3409,15 +3409,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Acetaminophen Metabolism Pathway",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "Glucuronidation",
-        "llm-average": 11.59
+        "llm-average": 5.8
       },
       {
         "entity_name": "Phenytoin (Antiarrhythmic) Action Pathway",
-        "llm-average": 5.89
+        "llm-average": 2.9
       }
     ]
   },
@@ -3429,15 +3429,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HEXB",
-        "llm-average": 12.53
+        "llm-average": 6.3
       },
       {
         "entity_name": "CHRNA2",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "BCHE",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -3449,11 +3449,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ACE",
-        "llm-average": 10.24
+        "llm-average": 5.1
       },
       {
         "entity_name": "REN",
-        "llm-average": 9.26
+        "llm-average": 4.6
       }
     ]
   },
@@ -3465,19 +3465,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Regulation of PTEN gene transcription",
-        "llm-average": 14.97
+        "llm-average": 7.5
       },
       {
         "entity_name": "Interferon alpha/beta signaling",
-        "llm-average": 13.9
+        "llm-average": 6.9
       },
       {
         "entity_name": "NGF-stimulated transcription",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "GnRH Signaling Pathway",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -3489,11 +3489,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Peptide ligand-binding receptors",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -3505,19 +3505,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP2D6",
-        "llm-average": 7.97
+        "llm-average": 4.0
       },
       {
         "entity_name": "CYP3A4",
-        "llm-average": 7.46
+        "llm-average": 3.7
       },
       {
         "entity_name": "CYP2B6",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "CYP1A2",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -3529,15 +3529,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC15A1",
-        "llm-average": 10.75
+        "llm-average": 5.4
       },
       {
         "entity_name": "SLC15A2",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "CAT",
-        "llm-average": 8.31
+        "llm-average": 4.2
       }
     ]
   },
@@ -3549,35 +3549,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OPRD1",
-        "llm-average": 9.6
+        "llm-average": 4.8
       },
       {
         "entity_name": "VEZF1",
-        "llm-average": 8.85
+        "llm-average": 4.4
       },
       {
         "entity_name": "OPRM1",
-        "llm-average": 8.77
+        "llm-average": 4.4
       },
       {
         "entity_name": "OPRK1",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "SPATA2L",
-        "llm-average": 7.89
+        "llm-average": 3.9
       },
       {
         "entity_name": "CYP2C19",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "NNT",
-        "llm-average": 5.16
+        "llm-average": 2.6
       },
       {
         "entity_name": "CYP2D6",
-        "llm-average": 4.48
+        "llm-average": 2.2
       }
     ]
   },
@@ -3589,31 +3589,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "negative regulation of high voltage-gated calcium channel activity",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "metaphase plate congression",
-        "llm-average": 9.45
+        "llm-average": 4.7
       },
       {
         "entity_name": "cell surface receptor signaling pathway",
-        "llm-average": 9.13
+        "llm-average": 4.6
       },
       {
         "entity_name": "chromosome organization",
-        "llm-average": 7.98
+        "llm-average": 4.0
       },
       {
         "entity_name": "signal transduction",
-        "llm-average": 4.15
+        "llm-average": 2.1
       },
       {
         "entity_name": "mitotic cell cycle",
-        "llm-average": 3.45
+        "llm-average": 1.7
       },
       {
         "entity_name": "immune response",
-        "llm-average": 2.28
+        "llm-average": 1.1
       }
     ]
   },
@@ -3625,19 +3625,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADRB3",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "REN",
-        "llm-average": 8.09
+        "llm-average": 4.0
       },
       {
         "entity_name": "ADRB2",
-        "llm-average": 5.65
+        "llm-average": 2.8
       },
       {
         "entity_name": "ADRB1",
-        "llm-average": 5.13
+        "llm-average": 2.6
       }
     ]
   },
@@ -3649,11 +3649,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "histamine receptor H1",
-        "llm-average": 17.33
+        "llm-average": 8.7
       },
       {
         "entity_name": "interferon lambda receptor 1",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -3665,27 +3665,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CD3g molecule",
-        "llm-average": 13.94
+        "llm-average": 7.0
       },
       {
         "entity_name": "CD3e molecule",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "CD40 ligand",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "Fc fragment of IgG receptor IIIa",
-        "llm-average": 11.38
+        "llm-average": 5.7
       },
       {
         "entity_name": "CD3d molecule",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "CD247 molecule",
-        "llm-average": 8.76
+        "llm-average": 4.4
       }
     ]
   },
@@ -3697,31 +3697,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KCNJ1",
-        "llm-average": 13.88
+        "llm-average": 6.9
       },
       {
         "entity_name": "ADRA2A",
-        "llm-average": 10.52
+        "llm-average": 5.3
       },
       {
         "entity_name": "ADRA2C",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "ADRA1D",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "ADRA1A",
-        "llm-average": 6.25
+        "llm-average": 3.1
       },
       {
         "entity_name": "ADRA1B",
-        "llm-average": 5.33
+        "llm-average": 2.7
       },
       {
         "entity_name": "ADRB1",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -3733,11 +3733,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Myelofibrosis",
-        "llm-average": 11.06
+        "llm-average": 5.5
       },
       {
         "entity_name": "Splenomegaly",
-        "llm-average": 7.14
+        "llm-average": 3.6
       }
     ]
   },
@@ -3749,19 +3749,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "carbonic anhydrase 12",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "carbonic anhydrase 4",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "carbonic anhydrase 1",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "carbonic anhydrase 2",
-        "llm-average": 5.19
+        "llm-average": 2.6
       }
     ]
   },
@@ -3773,35 +3773,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AKT serine/threonine kinase 1",
-        "llm-average": 15.53
+        "llm-average": 7.8
       },
       {
         "entity_name": "AKT serine/threonine kinase 2",
-        "llm-average": 13.03
+        "llm-average": 6.5
       },
       {
         "entity_name": "AKT serine/threonine kinase 3",
-        "llm-average": 12.14
+        "llm-average": 6.1
       },
       {
         "entity_name": "phosphatase and tensin homolog",
-        "llm-average": 9.3
+        "llm-average": 4.6
       },
       {
         "entity_name": "phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunit alpha",
-        "llm-average": 6.61
+        "llm-average": 3.3
       },
       {
         "entity_name": "KRAS proto-oncogene, GTPase",
-        "llm-average": 5.72
+        "llm-average": 2.9
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 2",
-        "llm-average": 3.75
+        "llm-average": 1.9
       },
       {
         "entity_name": "protein kinase cGMP-dependent 1",
-        "llm-average": 2.86
+        "llm-average": 1.4
       }
     ]
   },
@@ -3813,31 +3813,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "fms related receptor tyrosine kinase 3",
-        "llm-average": 13.02
+        "llm-average": 6.5
       },
       {
         "entity_name": "platelet derived growth factor receptor beta",
-        "llm-average": 10.56
+        "llm-average": 5.3
       },
       {
         "entity_name": "platelet derived growth factor receptor alpha",
-        "llm-average": 9.99
+        "llm-average": 5.0
       },
       {
         "entity_name": "KIT proto-oncogene, receptor tyrosine kinase",
-        "llm-average": 8.92
+        "llm-average": 4.5
       },
       {
         "entity_name": "colony stimulating factor 1 receptor",
-        "llm-average": 8.39
+        "llm-average": 4.2
       },
       {
         "entity_name": "MPL proto-oncogene, thrombopoietin receptor",
-        "llm-average": 6.06
+        "llm-average": 3.0
       },
       {
         "entity_name": "aurora kinase B",
-        "llm-average": 4.11
+        "llm-average": 2.1
       }
     ]
   },
@@ -3849,27 +3849,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ALK receptor tyrosine kinase",
-        "llm-average": 17.33
+        "llm-average": 8.7
       },
       {
         "entity_name": "ROS proto-oncogene 1, receptor tyrosine kinase",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "EMAP like 4",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "tumor protein p53",
-        "llm-average": 4.83
+        "llm-average": 2.4
       },
       {
         "entity_name": "RB transcriptional corepressor 1",
-        "llm-average": 4.48
+        "llm-average": 2.2
       },
       {
         "entity_name": "nucleophosmin 1",
-        "llm-average": 4.3
+        "llm-average": 2.1
       }
     ]
   },
@@ -3881,19 +3881,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "toll like receptor 7",
-        "llm-average": 14.61
+        "llm-average": 7.3
       },
       {
         "entity_name": "opioid receptor delta 1",
-        "llm-average": 5.7
+        "llm-average": 2.9
       },
       {
         "entity_name": "opioid receptor kappa 1",
-        "llm-average": 5.7
+        "llm-average": 2.9
       },
       {
         "entity_name": "opioid receptor mu 1",
-        "llm-average": 5.55
+        "llm-average": 2.8
       }
     ]
   },
@@ -3905,15 +3905,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "potassium voltage-gated channel subfamily H member 2",
-        "llm-average": 14.1
+        "llm-average": 7.0
       },
       {
         "entity_name": "calcium voltage-gated channel auxiliary subunit alpha2delta 2",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "adrenoceptor beta 1",
-        "llm-average": 10.01
+        "llm-average": 5.0
       }
     ]
   },
@@ -3925,19 +3925,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "potassium voltage-gated channel subfamily H member 2",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "potassium voltage-gated channel subfamily H member 1",
-        "llm-average": 14.65
+        "llm-average": 7.3
       },
       {
         "entity_name": "oxytocin receptor",
-        "llm-average": 13.18
+        "llm-average": 6.6
       },
       {
         "entity_name": "histamine receptor H1",
-        "llm-average": 6.62
+        "llm-average": 3.3
       }
     ]
   },
@@ -3949,19 +3949,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Endocarditis",
-        "llm-average": 11.42
+        "llm-average": 5.7
       },
       {
         "entity_name": "Recurrent pneumonia",
-        "llm-average": 9.79
+        "llm-average": 4.9
       },
       {
         "entity_name": "Meningitis",
-        "llm-average": 7.86
+        "llm-average": 3.9
       },
       {
         "entity_name": "Sepsis",
-        "llm-average": 6.8
+        "llm-average": 3.4
       }
     ]
   },
@@ -3973,19 +3973,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "lipoprotein lipase",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "adrenoceptor beta 1",
-        "llm-average": 12.51
+        "llm-average": 6.3
       },
       {
         "entity_name": "adrenoceptor beta 3",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "adrenoceptor beta 2",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -3997,19 +3997,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "opioid related nociceptin receptor 1",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "opioid receptor mu 1",
-        "llm-average": 11.22
+        "llm-average": 5.6
       },
       {
         "entity_name": "opioid receptor delta 1",
-        "llm-average": 9.64
+        "llm-average": 4.8
       },
       {
         "entity_name": "opioid receptor kappa 1",
-        "llm-average": 8.55
+        "llm-average": 4.3
       }
     ]
   },
@@ -4021,19 +4021,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CA4",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "CA12",
-        "llm-average": 10.72
+        "llm-average": 5.4
       },
       {
         "entity_name": "CA2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       },
       {
         "entity_name": "CA9",
-        "llm-average": 8.22
+        "llm-average": 4.1
       }
     ]
   },
@@ -4045,15 +4045,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC6A9",
-        "llm-average": 13.02
+        "llm-average": 6.5
       },
       {
         "entity_name": "PGR",
-        "llm-average": 8.06
+        "llm-average": 4.0
       },
       {
         "entity_name": "AR",
-        "llm-average": 7.5
+        "llm-average": 3.7
       }
     ]
   },
@@ -4065,23 +4065,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "phosphatase and tensin homolog",
-        "llm-average": 12.1
+        "llm-average": 6.1
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 4",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 3",
-        "llm-average": 10.7
+        "llm-average": 5.4
       },
       {
         "entity_name": "epidermal growth factor receptor",
-        "llm-average": 9.14
+        "llm-average": 4.6
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 2",
-        "llm-average": 8.94
+        "llm-average": 4.5
       }
     ]
   },
@@ -4093,27 +4093,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Seborrheic dermatitis",
-        "llm-average": 12.65
+        "llm-average": 6.3
       },
       {
         "entity_name": "Facial erythema",
-        "llm-average": 11.94
+        "llm-average": 6.0
       },
       {
         "entity_name": "Corneal ulceration",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "Conjunctivitis",
-        "llm-average": 8.42
+        "llm-average": 4.2
       },
       {
         "entity_name": "Abnormality of the skin",
-        "llm-average": 6.77
+        "llm-average": 3.4
       },
       {
         "entity_name": "Pneumonia",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -4125,31 +4125,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Migraine",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "Glaucoma",
-        "llm-average": 9.14
+        "llm-average": 4.6
       },
       {
         "entity_name": "Myocardial infarction",
-        "llm-average": 8.19
+        "llm-average": 4.1
       },
       {
         "entity_name": "Open angle glaucoma",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Angina pectoris",
-        "llm-average": 7.33
+        "llm-average": 3.7
       },
       {
         "entity_name": "Atrial fibrillation",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 4.65
+        "llm-average": 2.3
       }
     ]
   },
@@ -4161,31 +4161,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "potassium calcium-activated channel subfamily N member 1",
-        "llm-average": 16.41
+        "llm-average": 8.2
       },
       {
         "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha4",
-        "llm-average": 11.97
+        "llm-average": 6.0
       },
       {
         "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha5",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha6",
-        "llm-average": 11.06
+        "llm-average": 5.5
       },
       {
         "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha2",
-        "llm-average": 10.55
+        "llm-average": 5.3
       },
       {
         "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha1",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "gamma-aminobutyric acid type A receptor subunit alpha3",
-        "llm-average": 10.36
+        "llm-average": 5.2
       }
     ]
   },
@@ -4197,35 +4197,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GRIN3A",
-        "llm-average": 13.55
+        "llm-average": 6.8
       },
       {
         "entity_name": "GRIN3B",
-        "llm-average": 13.19
+        "llm-average": 6.6
       },
       {
         "entity_name": "GRIN2C",
-        "llm-average": 13.02
+        "llm-average": 6.5
       },
       {
         "entity_name": "MMP9",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "GRIN2D",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "OPRD1",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "OPRM1",
-        "llm-average": 8.78
+        "llm-average": 4.4
       },
       {
         "entity_name": "OPRK1",
-        "llm-average": 7.86
+        "llm-average": 3.9
       }
     ]
   },
@@ -4237,11 +4237,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "endothelin receptor type A",
-        "llm-average": 8.05
+        "llm-average": 4.0
       },
       {
         "entity_name": "endothelin receptor type B",
-        "llm-average": 7.14
+        "llm-average": 3.6
       }
     ]
   },
@@ -4253,11 +4253,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "endothelin receptor type A",
-        "llm-average": 9.99
+        "llm-average": 5.0
       },
       {
         "entity_name": "endothelin receptor type B",
-        "llm-average": 9.3
+        "llm-average": 4.6
       }
     ]
   },
@@ -4269,31 +4269,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Elevated hepatic transaminase",
-        "llm-average": 14.43
+        "llm-average": 7.2
       },
       {
         "entity_name": "Renal artery stenosis",
-        "llm-average": 14.08
+        "llm-average": 7.0
       },
       {
         "entity_name": "Congestive heart failure",
-        "llm-average": 12.87
+        "llm-average": 6.4
       },
       {
         "entity_name": "Renovascular hypertension",
-        "llm-average": 10.15
+        "llm-average": 5.1
       },
       {
         "entity_name": "Nephropathy",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 3.75
+        "llm-average": 1.9
       }
     ]
   },
@@ -4305,35 +4305,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Third degree atrioventricular block",
-        "llm-average": 8.87
+        "llm-average": 4.4
       },
       {
         "entity_name": "Nasal obstruction",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 8.18
+        "llm-average": 4.1
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 7.27
+        "llm-average": 3.6
       },
       {
         "entity_name": "Seasonal allergy",
-        "llm-average": 6.99
+        "llm-average": 3.5
       },
       {
         "entity_name": "Narcolepsy",
-        "llm-average": 5.68
+        "llm-average": 2.8
       },
       {
         "entity_name": "Headache",
-        "llm-average": 3.92
+        "llm-average": 2.0
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 3.55
+        "llm-average": 1.8
       }
     ]
   },
@@ -4345,23 +4345,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KRAS proto-oncogene, GTPase",
-        "llm-average": 16.41
+        "llm-average": 8.2
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 4",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 3",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 2",
-        "llm-average": 9.84
+        "llm-average": 4.9
       },
       {
         "entity_name": "epidermal growth factor receptor",
-        "llm-average": 9.14
+        "llm-average": 4.6
       }
     ]
   },
@@ -4373,15 +4373,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "5-hydroxytryptamine receptor 2B",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "5-hydroxytryptamine receptor 2A",
-        "llm-average": 13.24
+        "llm-average": 6.6
       },
       {
         "entity_name": "5-hydroxytryptamine receptor 2C",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -4393,23 +4393,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HRH1",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "CHRM4",
-        "llm-average": 11.08
+        "llm-average": 5.5
       },
       {
         "entity_name": "CHRM5",
-        "llm-average": 11.06
+        "llm-average": 5.5
       },
       {
         "entity_name": "CHRM3",
-        "llm-average": 7.86
+        "llm-average": 3.9
       },
       {
         "entity_name": "CHRM1",
-        "llm-average": 4.83
+        "llm-average": 2.4
       }
     ]
   },
@@ -4421,23 +4421,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "checkpoint kinase 1",
-        "llm-average": 19.99
+        "llm-average": 10.0
       },
       {
         "entity_name": "MYC proto-oncogene, bHLH transcription factor",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "checkpoint kinase 2",
-        "llm-average": 11.74
+        "llm-average": 5.9
       },
       {
         "entity_name": "ribosomal protein S6 kinase A1",
-        "llm-average": 9.99
+        "llm-average": 5.0
       },
       {
         "entity_name": "CDP-diacylglycerol synthase 1",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -4449,15 +4449,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Seizure",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "Neoplasm",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "Coronary artery atherosclerosis",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -4469,11 +4469,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TNF receptor superfamily member 4",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "tumor necrosis factor",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -4485,35 +4485,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "C-C motif chemokine receptor 6",
-        "llm-average": 14.96
+        "llm-average": 7.5
       },
       {
         "entity_name": "solute carrier family 12 member 3",
-        "llm-average": 11.22
+        "llm-average": 5.6
       },
       {
         "entity_name": "solute carrier family 12 member 1",
-        "llm-average": 10.68
+        "llm-average": 5.3
       },
       {
         "entity_name": "carbonic anhydrase 12",
-        "llm-average": 10.16
+        "llm-average": 5.1
       },
       {
         "entity_name": "carbonic anhydrase 14",
-        "llm-average": 9.61
+        "llm-average": 4.8
       },
       {
         "entity_name": "carbonic anhydrase 4",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "carbonic anhydrase 7",
-        "llm-average": 6.05
+        "llm-average": 3.0
       },
       {
         "entity_name": "carbonic anhydrase 1",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -4525,19 +4525,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "carbonic anhydrase 12",
-        "llm-average": 12.3
+        "llm-average": 6.2
       },
       {
         "entity_name": "carbonic anhydrase 4",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "carbonic anhydrase 2",
-        "llm-average": 8.06
+        "llm-average": 4.0
       },
       {
         "entity_name": "carbonic anhydrase 1",
-        "llm-average": 7.5
+        "llm-average": 3.7
       }
     ]
   },
@@ -4549,27 +4549,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "plasminogen activator, tissue type",
-        "llm-average": 13.02
+        "llm-average": 6.5
       },
       {
         "entity_name": "serpin family E member 1",
-        "llm-average": 12.82
+        "llm-average": 6.4
       },
       {
         "entity_name": "plasminogen",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "plasminogen activator, urokinase receptor",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "serpin family B member 2",
-        "llm-average": 6.78
+        "llm-average": 3.4
       },
       {
         "entity_name": "plasminogen activator, urokinase",
-        "llm-average": 6.26
+        "llm-average": 3.1
       }
     ]
   },
@@ -4581,19 +4581,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "lysophosphatidic acid receptor 2",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "lysophosphatidic acid receptor 3",
-        "llm-average": 15.0
+        "llm-average": 7.5
       },
       {
         "entity_name": "G protein-coupled receptor 35",
-        "llm-average": 14.97
+        "llm-average": 7.5
       },
       {
         "entity_name": "lysophosphatidic acid receptor 1",
-        "llm-average": 12.14
+        "llm-average": 6.1
       }
     ]
   },
@@ -4605,35 +4605,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Toxemia of pregnancy",
-        "llm-average": 13.54
+        "llm-average": 6.8
       },
       {
         "entity_name": "Nephrotic syndrome",
-        "llm-average": 11.4
+        "llm-average": 5.7
       },
       {
         "entity_name": "Cirrhosis",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "Edema",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "Hypervolemia",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "Congestive heart failure",
-        "llm-average": 6.61
+        "llm-average": 3.3
       },
       {
         "entity_name": "Abnormality of the cardiovascular system",
-        "llm-average": 4.63
+        "llm-average": 2.3
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 3.75
+        "llm-average": 1.9
       }
     ]
   },
@@ -4645,19 +4645,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Type II diabetes mellitus",
-        "llm-average": 10.93
+        "llm-average": 5.5
       },
       {
         "entity_name": "Obesity",
-        "llm-average": 9.27
+        "llm-average": 4.6
       },
       {
         "entity_name": "Hyperglycemia",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Diabetes mellitus",
-        "llm-average": 5.56
+        "llm-average": 2.8
       }
     ]
   },
@@ -4669,31 +4669,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Chronic pulmonary obstruction",
-        "llm-average": 9.95
+        "llm-average": 5.0
       },
       {
         "entity_name": "Stroke",
-        "llm-average": 9.84
+        "llm-average": 4.9
       },
       {
         "entity_name": "Myocardial infarction",
-        "llm-average": 9.14
+        "llm-average": 4.6
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 8.35
+        "llm-average": 4.2
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 8.34
+        "llm-average": 4.2
       },
       {
         "entity_name": "ST segment elevation",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Ischemic stroke",
-        "llm-average": 7.51
+        "llm-average": 3.8
       }
     ]
   },
@@ -4705,27 +4705,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Right ventricular failure",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Bronchitis",
-        "llm-average": 11.94
+        "llm-average": 6.0
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "Anemia",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "Edema",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Headache",
-        "llm-average": 3.39
+        "llm-average": 1.7
       }
     ]
   },
@@ -4737,27 +4737,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Pulmonary venous occlusion",
-        "llm-average": 13.74
+        "llm-average": 6.9
       },
       {
         "entity_name": "Scleroderma",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 9.14
+        "llm-average": 4.6
       },
       {
         "entity_name": "Immunodeficiency",
-        "llm-average": 9.06
+        "llm-average": 4.5
       },
       {
         "entity_name": "Abnormal heart morphology",
-        "llm-average": 3.02
+        "llm-average": 1.5
       },
       {
         "entity_name": "Abnormal lung morphology",
-        "llm-average": 2.83
+        "llm-average": 1.4
       }
     ]
   },
@@ -4769,35 +4769,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Narcolepsy",
-        "llm-average": 13.19
+        "llm-average": 6.6
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 12.85
+        "llm-average": 6.4
       },
       {
         "entity_name": "Nasal obstruction",
-        "llm-average": 11.08
+        "llm-average": 5.5
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "Third degree atrioventricular block",
-        "llm-average": 9.95
+        "llm-average": 5.0
       },
       {
         "entity_name": "Seasonal allergy",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "Headache",
-        "llm-average": 4.63
+        "llm-average": 2.3
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 1.06
+        "llm-average": 0.5
       }
     ]
   },
@@ -4809,11 +4809,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "plasminogen",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "fibrinogen alpha chain",
-        "llm-average": 8.58
+        "llm-average": 4.3
       }
     ]
   },
@@ -4825,23 +4825,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TSG101",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "VPS36",
-        "llm-average": 12.29
+        "llm-average": 6.1
       },
       {
         "entity_name": "UEVLD",
-        "llm-average": 11.74
+        "llm-average": 5.9
       },
       {
         "entity_name": "F10",
-        "llm-average": 6.78
+        "llm-average": 3.4
       },
       {
         "entity_name": "F3",
-        "llm-average": 3.03
+        "llm-average": 1.5
       }
     ]
   },
@@ -4853,23 +4853,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KRAS proto-oncogene, GTPase",
-        "llm-average": 16.41
+        "llm-average": 8.2
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 4",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 3",
-        "llm-average": 12.86
+        "llm-average": 6.4
       },
       {
         "entity_name": "erb-b2 receptor tyrosine kinase 2",
-        "llm-average": 12.51
+        "llm-average": 6.3
       },
       {
         "entity_name": "epidermal growth factor receptor",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -4881,19 +4881,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "prostaglandin E receptor 4",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "prostaglandin I2 receptor",
-        "llm-average": 11.42
+        "llm-average": 5.7
       },
       {
         "entity_name": "prostaglandin E receptor 3",
-        "llm-average": 8.92
+        "llm-average": 4.5
       },
       {
         "entity_name": "prostaglandin E receptor 2",
-        "llm-average": 7.5
+        "llm-average": 3.7
       }
     ]
   },
@@ -4905,35 +4905,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Toxemia of pregnancy",
-        "llm-average": 16.41
+        "llm-average": 8.2
       },
       {
         "entity_name": "Nephrotic syndrome",
-        "llm-average": 13.91
+        "llm-average": 7.0
       },
       {
         "entity_name": "Cirrhosis",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "Edema",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "Hypervolemia",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "Congestive heart failure",
-        "llm-average": 9.48
+        "llm-average": 4.7
       },
       {
         "entity_name": "Abnormality of the cardiovascular system",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 4.83
+        "llm-average": 2.4
       }
     ]
   },
@@ -4945,35 +4945,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Congestive heart failure",
-        "llm-average": 11.94
+        "llm-average": 6.0
       },
       {
         "entity_name": "Angina pectoris",
-        "llm-average": 5.69
+        "llm-average": 2.8
       },
       {
         "entity_name": "Myocardial infarction",
-        "llm-average": 5.68
+        "llm-average": 2.8
       },
       {
         "entity_name": "Diabetes mellitus",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 3.94
+        "llm-average": 2.0
       },
       {
         "entity_name": "Hyperlipidemia",
-        "llm-average": 3.92
+        "llm-average": 2.0
       },
       {
         "entity_name": "Abnormality of the cardiovascular system",
-        "llm-average": 3.75
+        "llm-average": 1.9
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 2.83
+        "llm-average": 1.4
       }
     ]
   },
@@ -4985,15 +4985,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MPL",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "THPO",
-        "llm-average": 9.32
+        "llm-average": 4.7
       },
       {
         "entity_name": "SLCO1B1",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -5005,15 +5005,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Coronary artery atherosclerosis",
-        "llm-average": 8.19
+        "llm-average": 4.1
       },
       {
         "entity_name": "Myocardial infarction",
-        "llm-average": 7.5
+        "llm-average": 3.7
       },
       {
         "entity_name": "Angina pectoris",
-        "llm-average": 7.34
+        "llm-average": 3.7
       }
     ]
   },
@@ -5025,35 +5025,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAX dimerization protein MGA",
-        "llm-average": 16.76
+        "llm-average": 8.4
       },
       {
         "entity_name": "alpha glucosidase",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "maltase-glucoamylase",
-        "llm-average": 14.47
+        "llm-average": 7.2
       },
       {
         "entity_name": "sucrase-isomaltase",
-        "llm-average": 12.5
+        "llm-average": 6.2
       },
       {
         "entity_name": "amylase alpha 2A",
-        "llm-average": 11.41
+        "llm-average": 5.7
       },
       {
         "entity_name": "dopamine receptor D2",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "solute carrier family 2 member 4",
-        "llm-average": 7.69
+        "llm-average": 3.8
       },
       {
         "entity_name": "lipoprotein lipase",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -5065,35 +5065,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hypotension",
-        "llm-average": 13.74
+        "llm-average": 6.9
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 13.56
+        "llm-average": 6.8
       },
       {
         "entity_name": "Narcolepsy",
-        "llm-average": 12.83
+        "llm-average": 6.4
       },
       {
         "entity_name": "Third degree atrioventricular block",
-        "llm-average": 9.95
+        "llm-average": 5.0
       },
       {
         "entity_name": "Nasal obstruction",
-        "llm-average": 7.85
+        "llm-average": 3.9
       },
       {
         "entity_name": "Seasonal allergy",
-        "llm-average": 7.11
+        "llm-average": 3.6
       },
       {
         "entity_name": "Headache",
-        "llm-average": 3.55
+        "llm-average": 1.8
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 1.97
+        "llm-average": 1.0
       }
     ]
   },
@@ -5105,11 +5105,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "immune system disease",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "kidney disease",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -5121,11 +5121,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "collagen type IV alpha 5 chain",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "prostaglandin F receptor",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -5137,15 +5137,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Encephalopathy",
-        "llm-average": 13.9
+        "llm-average": 6.9
       },
       {
         "entity_name": "Retinopathy",
-        "llm-average": 10.15
+        "llm-average": 5.1
       },
       {
         "entity_name": "Hypertension",
-        "llm-average": 3.75
+        "llm-average": 1.9
       }
     ]
   },
@@ -5157,31 +5157,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Gastroparesis",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "Nausea",
-        "llm-average": 11.77
+        "llm-average": 5.9
       },
       {
         "entity_name": "Orthostatic hypotension",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Vomiting",
-        "llm-average": 11.22
+        "llm-average": 5.6
       },
       {
         "entity_name": "Migraine",
-        "llm-average": 6.76
+        "llm-average": 3.4
       },
       {
         "entity_name": "Gastritis",
-        "llm-average": 6.05
+        "llm-average": 3.0
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 3.19
+        "llm-average": 1.6
       }
     ]
   },
@@ -5193,15 +5193,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "cholinergic receptor muscarinic 3",
-        "llm-average": 5.36
+        "llm-average": 2.7
       },
       {
         "entity_name": "cholinergic receptor muscarinic 2",
-        "llm-average": 5.35
+        "llm-average": 2.7
       }
     ]
   },
@@ -5213,31 +5213,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "fms related receptor tyrosine kinase 3",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "platelet derived growth factor receptor beta",
-        "llm-average": 13.23
+        "llm-average": 6.6
       },
       {
         "entity_name": "platelet derived growth factor receptor alpha",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "KIT proto-oncogene, receptor tyrosine kinase",
-        "llm-average": 11.05
+        "llm-average": 5.5
       },
       {
         "entity_name": "colony stimulating factor 1 receptor",
-        "llm-average": 10.89
+        "llm-average": 5.4
       },
       {
         "entity_name": "aurora kinase B",
-        "llm-average": 9.11
+        "llm-average": 4.6
       },
       {
         "entity_name": "MPL proto-oncogene, thrombopoietin receptor",
-        "llm-average": 8.22
+        "llm-average": 4.1
       }
     ]
   },
@@ -5249,27 +5249,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Suramin",
-        "llm-average": 16.69
+        "llm-average": 8.3
       },
       {
         "entity_name": "Methotrexate",
-        "llm-average": 13.31
+        "llm-average": 6.7
       },
       {
         "entity_name": "Docetaxel",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Capromab pendetide",
-        "llm-average": 12.15
+        "llm-average": 6.1
       },
       {
         "entity_name": "Clavulanic acid",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "Stanolone",
-        "llm-average": 9.07
+        "llm-average": 4.5
       }
     ]
   },
@@ -5281,27 +5281,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vancomycin",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "Erythromycin",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "Phenoxymethylpenicillin",
-        "llm-average": 8.62
+        "llm-average": 4.3
       },
       {
         "entity_name": "Benzylpenicillin",
-        "llm-average": 7.56
+        "llm-average": 3.8
       },
       {
         "entity_name": "Cephalexin",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Amoxicillin",
-        "llm-average": 5.35
+        "llm-average": 2.7
       }
     ]
   },
@@ -5313,23 +5313,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Atrazine",
-        "llm-average": 12.99
+        "llm-average": 6.5
       },
       {
         "entity_name": "Cisplatin",
-        "llm-average": 9.3
+        "llm-average": 4.6
       },
       {
         "entity_name": "Phencyclidine",
-        "llm-average": 8.85
+        "llm-average": 4.4
       },
       {
         "entity_name": "Cocaine",
-        "llm-average": 8.46
+        "llm-average": 4.2
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 7.56
+        "llm-average": 3.8
       }
     ]
   },
@@ -5341,19 +5341,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Nerispirdine",
-        "llm-average": 15.36
+        "llm-average": 7.7
       },
       {
         "entity_name": "Ezogabine",
-        "llm-average": 13.72
+        "llm-average": 6.9
       },
       {
         "entity_name": "Bepridil",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "Dalfampridine",
-        "llm-average": 8.74
+        "llm-average": 4.4
       }
     ]
   },
@@ -5365,11 +5365,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Boceprevir",
-        "llm-average": 9.34
+        "llm-average": 4.7
       },
       {
         "entity_name": "Telaprevir",
-        "llm-average": 9.2
+        "llm-average": 4.6
       }
     ]
   },
@@ -5381,27 +5381,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sorafenib",
-        "llm-average": 17.08
+        "llm-average": 8.5
       },
       {
         "entity_name": "Doxorubicin",
-        "llm-average": 8.58
+        "llm-average": 4.3
       },
       {
         "entity_name": "Epirubicin",
-        "llm-average": 7.69
+        "llm-average": 3.8
       },
       {
         "entity_name": "Etoposide",
-        "llm-average": 6.79
+        "llm-average": 3.4
       },
       {
         "entity_name": "Mitoxantrone",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Gadobenic acid",
-        "llm-average": 2.44
+        "llm-average": 1.2
       }
     ]
   },
@@ -5413,19 +5413,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Esmolol",
-        "llm-average": 17.52
+        "llm-average": 8.8
       },
       {
         "entity_name": "Pindolol",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Oxprenolol",
-        "llm-average": 11.48
+        "llm-average": 5.7
       },
       {
         "entity_name": "Salbutamol",
-        "llm-average": 4.06
+        "llm-average": 2.0
       }
     ]
   },
@@ -5437,11 +5437,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Rifampicin",
-        "llm-average": 15.55
+        "llm-average": 7.8
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 9.18
+        "llm-average": 4.6
       }
     ]
   },
@@ -5453,11 +5453,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Omalizumab",
-        "llm-average": 17.52
+        "llm-average": 8.8
       },
       {
         "entity_name": "Benzylpenicilloyl polylysine",
-        "llm-average": 7.54
+        "llm-average": 3.8
       }
     ]
   },
@@ -5469,27 +5469,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Regorafenib",
-        "llm-average": 12.27
+        "llm-average": 6.1
       },
       {
         "entity_name": "Imatinib",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Nilotinib",
-        "llm-average": 11.91
+        "llm-average": 6.0
       },
       {
         "entity_name": "Dasatinib",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "Sorafenib",
-        "llm-average": 9.66
+        "llm-average": 4.8
       },
       {
         "entity_name": "Erlotinib",
-        "llm-average": 7.72
+        "llm-average": 3.9
       }
     ]
   },
@@ -5501,35 +5501,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Infigratinib",
-        "llm-average": 17.46
+        "llm-average": 8.7
       },
       {
         "entity_name": "Erdafitinib",
-        "llm-average": 16.84
+        "llm-average": 8.4
       },
       {
         "entity_name": "Orantinib",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "Brivanib",
-        "llm-average": 12.88
+        "llm-average": 6.4
       },
       {
         "entity_name": "Nintedanib",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Brivanib alaninate",
-        "llm-average": 11.46
+        "llm-average": 5.7
       },
       {
         "entity_name": "Palifermin",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "Dovitinib",
-        "llm-average": 9.18
+        "llm-average": 4.6
       }
     ]
   },
@@ -5541,11 +5541,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Ethoxzolamide",
-        "llm-average": 16.54
+        "llm-average": 8.3
       },
       {
         "entity_name": "Sunitinib",
-        "llm-average": 11.03
+        "llm-average": 5.5
       }
     ]
   },
@@ -5557,27 +5557,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Amiloride",
-        "llm-average": 18.9
+        "llm-average": 9.5
       },
       {
         "entity_name": "Prednisone",
-        "llm-average": 7.27
+        "llm-average": 3.6
       },
       {
         "entity_name": "D-Allopyranose",
-        "llm-average": 3.87
+        "llm-average": 1.9
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 3.56
+        "llm-average": 1.8
       },
       {
         "entity_name": "Beta-D-Glucose",
-        "llm-average": 2.75
+        "llm-average": 1.4
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 1.52
+        "llm-average": 0.8
       }
     ]
   },
@@ -5589,31 +5589,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Caffeine",
-        "llm-average": 17.52
+        "llm-average": 8.8
       },
       {
         "entity_name": "Doxapram",
-        "llm-average": 16.42
+        "llm-average": 8.2
       },
       {
         "entity_name": "Modafinil",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Hydroxocobalamin",
-        "llm-average": 4.91
+        "llm-average": 2.5
       },
       {
         "entity_name": "Desflurane",
-        "llm-average": 4.33
+        "llm-average": 2.2
       },
       {
         "entity_name": "Fentanyl",
-        "llm-average": 3.46
+        "llm-average": 1.7
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 1.98
+        "llm-average": 1.0
       }
     ]
   },
@@ -5625,31 +5625,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "alpha-Ketoisocaproic acid",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "Cocarboxylase",
-        "llm-average": 11.03
+        "llm-average": 5.5
       },
       {
         "entity_name": "NADH",
-        "llm-average": 10.74
+        "llm-average": 5.4
       },
       {
         "entity_name": "Coenzyme A",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "Isocaproic acid",
-        "llm-average": 10.62
+        "llm-average": 5.3
       },
       {
         "entity_name": "Pyruvic acid",
-        "llm-average": 8.28
+        "llm-average": 4.1
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 6.37
+        "llm-average": 3.2
       }
     ]
   },
@@ -5661,15 +5661,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Aminophylline",
-        "llm-average": 10.68
+        "llm-average": 5.3
       },
       {
         "entity_name": "Amantadine",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "Ribavirin",
-        "llm-average": 8.94
+        "llm-average": 4.5
       }
     ]
   },
@@ -5681,11 +5681,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dasatinib",
-        "llm-average": 17.52
+        "llm-average": 8.8
       },
       {
         "entity_name": "Erythropoietin",
-        "llm-average": 10.49
+        "llm-average": 5.2
       }
     ]
   },
@@ -5697,23 +5697,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 10.25
+        "llm-average": 5.1
       },
       {
         "entity_name": "ATP",
-        "llm-average": 7.48
+        "llm-average": 3.7
       },
       {
         "entity_name": "Adenosine phosphate",
-        "llm-average": 6.6
+        "llm-average": 3.3
       },
       {
         "entity_name": "Pyrophosphoric acid",
-        "llm-average": 4.62
+        "llm-average": 2.3
       }
     ]
   },
@@ -5725,15 +5725,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SCY-635",
-        "llm-average": 15.7
+        "llm-average": 7.8
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 13.31
+        "llm-average": 6.7
       },
       {
         "entity_name": "Proline",
-        "llm-average": 3.43
+        "llm-average": 1.7
       }
     ]
   },
@@ -5745,19 +5745,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sodium tetradecyl sulfate",
-        "llm-average": 18.9
+        "llm-average": 9.5
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 6.57
+        "llm-average": 3.3
       },
       {
         "entity_name": "Beta-D-Glucose",
-        "llm-average": 2.9
+        "llm-average": 1.5
       },
       {
         "entity_name": "D-Allopyranose",
-        "llm-average": 2.48
+        "llm-average": 1.2
       }
     ]
   },
@@ -5769,35 +5769,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Paclitaxel",
-        "llm-average": 15.04
+        "llm-average": 7.5
       },
       {
         "entity_name": "Mitomycin",
-        "llm-average": 13.88
+        "llm-average": 6.9
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "1,4-Dithiothreitol",
-        "llm-average": 7.95
+        "llm-average": 4.0
       },
       {
         "entity_name": "Butyric Acid",
-        "llm-average": 7.54
+        "llm-average": 3.8
       },
       {
         "entity_name": "Dithioerythritol",
-        "llm-average": 6.79
+        "llm-average": 3.4
       },
       {
         "entity_name": "D-1,4-dithiothreitol",
-        "llm-average": 4.85
+        "llm-average": 2.4
       },
       {
         "entity_name": "Beta-D-Fructopyranose",
-        "llm-average": 4.83
+        "llm-average": 2.4
       }
     ]
   },
@@ -5809,11 +5809,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diazoxide",
-        "llm-average": 16.54
+        "llm-average": 8.3
       },
       {
         "entity_name": "Thiamylal",
-        "llm-average": 9.18
+        "llm-average": 4.6
       }
     ]
   },
@@ -5825,11 +5825,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dexamethasone",
-        "llm-average": 8.67
+        "llm-average": 4.3
       },
       {
         "entity_name": "Betamethasone",
-        "llm-average": 7.32
+        "llm-average": 3.7
       }
     ]
   },
@@ -5841,11 +5841,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Pyridoxine",
-        "llm-average": 13.25
+        "llm-average": 6.6
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 12.15
+        "llm-average": 6.1
       }
     ]
   },
@@ -5857,23 +5857,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tolvaptan",
-        "llm-average": 18.9
+        "llm-average": 9.5
       },
       {
         "entity_name": "Conivaptan",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "D-Allopyranose",
-        "llm-average": 1.12
+        "llm-average": 0.6
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 0.79
+        "llm-average": 0.4
       },
       {
         "entity_name": "Beta-D-Glucose",
-        "llm-average": 0.59
+        "llm-average": 0.3
       },
       {
         "entity_name": "Balsalazide",
@@ -5889,31 +5889,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dexpropranolol",
-        "llm-average": 11.67
+        "llm-average": 5.8
       },
       {
         "entity_name": "Pindolol",
-        "llm-average": 11.61
+        "llm-average": 5.8
       },
       {
         "entity_name": "Oxprenolol",
-        "llm-average": 11.51
+        "llm-average": 5.8
       },
       {
         "entity_name": "Propranolol",
-        "llm-average": 11.48
+        "llm-average": 5.7
       },
       {
         "entity_name": "Metoprolol",
-        "llm-average": 10.96
+        "llm-average": 5.5
       },
       {
         "entity_name": "Acebutolol",
-        "llm-average": 9.74
+        "llm-average": 4.9
       },
       {
         "entity_name": "Nitroglycerin",
-        "llm-average": 8.94
+        "llm-average": 4.5
       }
     ]
   },
@@ -5925,31 +5925,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trandolapril",
-        "llm-average": 14.24
+        "llm-average": 7.1
       },
       {
         "entity_name": "Cilazapril",
-        "llm-average": 11.28
+        "llm-average": 5.6
       },
       {
         "entity_name": "Fosinopril",
-        "llm-average": 10.19
+        "llm-average": 5.1
       },
       {
         "entity_name": "Enalapril",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "Ramipril",
-        "llm-average": 7.3
+        "llm-average": 3.6
       },
       {
         "entity_name": "Quinapril",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Lisinopril",
-        "llm-average": 5.35
+        "llm-average": 2.7
       }
     ]
   },
@@ -5961,35 +5961,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bivalirudin",
-        "llm-average": 15.46
+        "llm-average": 7.7
       },
       {
         "entity_name": "Ximelagatran",
-        "llm-average": 15.44
+        "llm-average": 7.7
       },
       {
         "entity_name": "Argatroban",
-        "llm-average": 15.21
+        "llm-average": 7.6
       },
       {
         "entity_name": "Lepirudin",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "Menadione",
-        "llm-average": 9.33
+        "llm-average": 4.7
       },
       {
         "entity_name": "Tamoxifen",
-        "llm-average": 9.23
+        "llm-average": 4.6
       },
       {
         "entity_name": "Heparin",
-        "llm-average": 7.36
+        "llm-average": 3.7
       },
       {
         "entity_name": "Enoxaparin",
-        "llm-average": 7.35
+        "llm-average": 3.7
       }
     ]
   },
@@ -6001,23 +6001,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Resveratrol",
-        "llm-average": 14.71
+        "llm-average": 7.4
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 8.87
+        "llm-average": 4.4
       },
       {
         "entity_name": "ATP",
-        "llm-average": 5.8
+        "llm-average": 2.9
       },
       {
         "entity_name": "Pyrophosphoric acid",
-        "llm-average": 4.72
+        "llm-average": 2.4
       },
       {
         "entity_name": "Adenosine phosphate",
-        "llm-average": 4.62
+        "llm-average": 2.3
       }
     ]
   },
@@ -6029,23 +6029,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Crisaborole",
-        "llm-average": 13.26
+        "llm-average": 6.6
       },
       {
         "entity_name": "Bepridil",
-        "llm-average": 12.26
+        "llm-average": 6.1
       },
       {
         "entity_name": "Vinpocetine",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Dipyridamole",
-        "llm-average": 11.71
+        "llm-average": 5.9
       },
       {
         "entity_name": "Pentoxifylline",
-        "llm-average": 7.35
+        "llm-average": 3.7
       }
     ]
   },
@@ -6057,19 +6057,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Denileukin diftitox",
-        "llm-average": 17.92
+        "llm-average": 9.0
       },
       {
         "entity_name": "Daclizumab",
-        "llm-average": 13.07
+        "llm-average": 6.5
       },
       {
         "entity_name": "Basiliximab",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Aldesleukin",
-        "llm-average": 9.18
+        "llm-average": 4.6
       }
     ]
   },
@@ -6081,11 +6081,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "C4A",
-        "llm-average": 11.9
+        "llm-average": 6.0
       },
       {
         "entity_name": "C3",
-        "llm-average": 8.67
+        "llm-average": 4.3
       }
     ]
   },
@@ -6097,11 +6097,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Quercetin",
-        "llm-average": 12.32
+        "llm-average": 6.2
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 11.03
+        "llm-average": 5.5
       }
     ]
   },
@@ -6113,35 +6113,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 15.63
+        "llm-average": 7.8
       },
       {
         "entity_name": "Vincristine",
-        "llm-average": 12.24
+        "llm-average": 6.1
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 11.35
+        "llm-average": 5.7
       },
       {
         "entity_name": "Adenosine phosphate",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "ATP",
-        "llm-average": 5.35
+        "llm-average": 2.7
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 5.12
+        "llm-average": 2.6
       },
       {
         "entity_name": "Pyrophosphoric acid",
-        "llm-average": 3.83
+        "llm-average": 1.9
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 3.73
+        "llm-average": 1.9
       }
     ]
   },
@@ -6153,11 +6153,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tranexamic acid",
-        "llm-average": 14.17
+        "llm-average": 7.1
       },
       {
         "entity_name": "Phylloquinone",
-        "llm-average": 9.18
+        "llm-average": 4.6
       }
     ]
   },
@@ -6169,35 +6169,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lacosamide",
-        "llm-average": 14.65
+        "llm-average": 7.3
       },
       {
         "entity_name": "Fingolimod",
-        "llm-average": 13.72
+        "llm-average": 6.9
       },
       {
         "entity_name": "Regadenoson",
-        "llm-average": 12.99
+        "llm-average": 6.5
       },
       {
         "entity_name": "Gadobenic acid",
-        "llm-average": 12.2
+        "llm-average": 6.1
       },
       {
         "entity_name": "Aripiprazole",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Digoxin",
-        "llm-average": 11.0
+        "llm-average": 5.5
       },
       {
         "entity_name": "Naratriptan",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "Trazodone",
-        "llm-average": 9.99
+        "llm-average": 5.0
       }
     ]
   },
@@ -6209,23 +6209,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Imagabalin",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "Atagabalin",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "Pregabalin",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "Gabapentin enacarbil",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Gabapentin",
-        "llm-average": 9.18
+        "llm-average": 4.6
       }
     ]
   },
@@ -6237,15 +6237,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cobicistat",
-        "llm-average": 15.11
+        "llm-average": 7.6
       },
       {
         "entity_name": "Melatonin",
-        "llm-average": 13.31
+        "llm-average": 6.7
       },
       {
         "entity_name": "Chlorzoxazone",
-        "llm-average": 11.76
+        "llm-average": 5.9
       }
     ]
   },
@@ -6257,35 +6257,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 14.6
+        "llm-average": 7.3
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "(2S)-8-[(tert-butoxycarbonyl)amino]-2-(1H-indol-3-yl)octanoic acid",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "(2S)-2-(1H-indol-3-yl)pentanoic acid",
-        "llm-average": 11.71
+        "llm-average": 5.9
       },
       {
         "entity_name": "1-naphthaleneacetic acid",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "(2S)-2-(1H-indol-3-yl)hexanoic acid",
-        "llm-average": 10.55
+        "llm-average": 5.3
       },
       {
         "entity_name": "Indoleacetic acid",
-        "llm-average": 8.74
+        "llm-average": 4.4
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 4.62
+        "llm-average": 2.3
       }
     ]
   },
@@ -6297,15 +6297,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "Pyrophosphoric acid",
-        "llm-average": 9.52
+        "llm-average": 4.8
       },
       {
         "entity_name": "Adenosine phosphate",
-        "llm-average": 5.71
+        "llm-average": 2.9
       }
     ]
   },
@@ -6317,23 +6317,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Veliparib",
-        "llm-average": 14.96
+        "llm-average": 7.5
       },
       {
         "entity_name": "Niraparib",
-        "llm-average": 11.64
+        "llm-average": 5.8
       },
       {
         "entity_name": "Talazoparib",
-        "llm-average": 11.54
+        "llm-average": 5.8
       },
       {
         "entity_name": "Olaparib",
-        "llm-average": 11.38
+        "llm-average": 5.7
       },
       {
         "entity_name": "Rucaparib",
-        "llm-average": 8.67
+        "llm-average": 4.3
       }
     ]
   },
@@ -6345,31 +6345,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diaphragmatic paralysis",
-        "llm-average": 12.28
+        "llm-average": 6.1
       },
       {
         "entity_name": "Decreased pulmonary function",
-        "llm-average": 11.85
+        "llm-average": 5.9
       },
       {
         "entity_name": "Hypocalcemia",
-        "llm-average": 9.57
+        "llm-average": 4.8
       },
       {
         "entity_name": "Hyperhidrosis",
-        "llm-average": 6.93
+        "llm-average": 3.5
       },
       {
         "entity_name": "Erythema",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "Hypothermia",
-        "llm-average": 5.28
+        "llm-average": 2.6
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 5.05
+        "llm-average": 2.5
       }
     ]
   },
@@ -6381,35 +6381,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "growth differentiation factor 15",
-        "llm-average": 16.17
+        "llm-average": 8.1
       },
       {
         "entity_name": "interleukin 2",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "vitamin D receptor",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "plasminogen activator, urokinase",
-        "llm-average": 9.5
+        "llm-average": 4.8
       },
       {
         "entity_name": "thyroglobulin",
-        "llm-average": 8.38
+        "llm-average": 4.2
       },
       {
         "entity_name": "MYC proto-oncogene, bHLH transcription factor",
-        "llm-average": 8.15
+        "llm-average": 4.1
       },
       {
         "entity_name": "phosphate regulating endopeptidase homolog X-linked",
-        "llm-average": 5.58
+        "llm-average": 2.8
       },
       {
         "entity_name": "basic transcription factor 3 pseudogene 11",
-        "llm-average": 1.12
+        "llm-average": 0.6
       }
     ]
   },
@@ -6421,19 +6421,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "solute carrier family 29 member 4",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "cytochrome P450 family 3 subfamily A member 7",
-        "llm-average": 9.64
+        "llm-average": 4.8
       },
       {
         "entity_name": "potassium voltage-gated channel subfamily B member 2",
-        "llm-average": 7.92
+        "llm-average": 4.0
       },
       {
         "entity_name": "interleukin 2",
-        "llm-average": 7.59
+        "llm-average": 3.8
       }
     ]
   },
@@ -6445,19 +6445,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "guanylate cyclase 1 soluble subunit alpha 2",
-        "llm-average": 10.17
+        "llm-average": 5.1
       },
       {
         "entity_name": "natriuretic peptide receptor 1",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "dopamine receptor D1",
-        "llm-average": 7.39
+        "llm-average": 3.7
       },
       {
         "entity_name": "guanylate cyclase 1 soluble subunit beta 2 (pseudogene)",
-        "llm-average": 6.83
+        "llm-average": 3.4
       }
     ]
   },
@@ -6469,27 +6469,27 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hepatic necrosis",
-        "llm-average": 11.29
+        "llm-average": 5.6
       },
       {
         "entity_name": "Venous thrombosis",
-        "llm-average": 10.83
+        "llm-average": 5.4
       },
       {
         "entity_name": "Hypervolemia",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Decreased pulmonary function",
-        "llm-average": 8.15
+        "llm-average": 4.1
       },
       {
         "entity_name": "Hypoventilation",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "Fever",
-        "llm-average": 1.72
+        "llm-average": 0.9
       }
     ]
   },
@@ -6501,35 +6501,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "growth differentiation factor 15",
-        "llm-average": 16.7
+        "llm-average": 8.3
       },
       {
         "entity_name": "phosphate regulating endopeptidase homolog X-linked",
-        "llm-average": 11.39
+        "llm-average": 5.7
       },
       {
         "entity_name": "MYC proto-oncogene, bHLH transcription factor",
-        "llm-average": 9.77
+        "llm-average": 4.9
       },
       {
         "entity_name": "interleukin 2",
-        "llm-average": 9.7
+        "llm-average": 4.9
       },
       {
         "entity_name": "vitamin D receptor",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "plasminogen activator, urokinase",
-        "llm-average": 6.86
+        "llm-average": 3.4
       },
       {
         "entity_name": "thyroglobulin",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "basic transcription factor 3 pseudogene 11",
-        "llm-average": 3.89
+        "llm-average": 1.9
       }
     ]
   },
@@ -6541,19 +6541,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 2 subfamily D member 6",
-        "llm-average": 15.84
+        "llm-average": 7.9
       },
       {
         "entity_name": "opioid receptor delta 1",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "opioid receptor mu 1",
-        "llm-average": 8.38
+        "llm-average": 4.2
       },
       {
         "entity_name": "opioid receptor kappa 1",
-        "llm-average": 7.43
+        "llm-average": 3.7
       }
     ]
   },
@@ -6565,19 +6565,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 2 subfamily D member 6",
-        "llm-average": 12.38
+        "llm-average": 6.2
       },
       {
         "entity_name": "opioid receptor delta 1",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "opioid receptor mu 1",
-        "llm-average": 8.38
+        "llm-average": 4.2
       },
       {
         "entity_name": "opioid receptor kappa 1",
-        "llm-average": 7.43
+        "llm-average": 3.7
       }
     ]
   },
@@ -6589,23 +6589,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "free fatty acid receptor 2",
-        "llm-average": 8.32
+        "llm-average": 4.2
       },
       {
         "entity_name": "5-hydroxytryptamine receptor 2C",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "5-hydroxytryptamine receptor 2A",
-        "llm-average": 6.44
+        "llm-average": 3.2
       },
       {
         "entity_name": "5-hydroxytryptamine receptor 2B",
-        "llm-average": 6.4
+        "llm-average": 3.2
       },
       {
         "entity_name": "adenosine deaminase RNA specific B2 (inactive)",
-        "llm-average": 4.46
+        "llm-average": 2.2
       }
     ]
   },
@@ -6617,15 +6617,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cannabinoid receptor 2",
-        "llm-average": 10.63
+        "llm-average": 5.3
       },
       {
         "entity_name": "cytochrome P450 family 2 subfamily C member 9",
-        "llm-average": 10.5
+        "llm-average": 5.2
       },
       {
         "entity_name": "cannabinoid receptor 1",
-        "llm-average": 9.37
+        "llm-average": 4.7
       }
     ]
   },
@@ -6637,15 +6637,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "formyl peptide receptor 1",
-        "llm-average": 6.9
+        "llm-average": 3.4
       },
       {
         "entity_name": "formyl peptide receptor 3",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "formyl peptide receptor 2",
-        "llm-average": 6.44
+        "llm-average": 3.2
       }
     ]
   },
@@ -6657,19 +6657,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "peroxisome proliferator activated receptor gamma",
-        "llm-average": 14.85
+        "llm-average": 7.4
       },
       {
         "entity_name": "arachidonate 5-lipoxygenase",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 1",
-        "llm-average": 6.44
+        "llm-average": 3.2
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 2",
-        "llm-average": 5.61
+        "llm-average": 2.8
       }
     ]
   },
@@ -6681,15 +6681,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 2 subfamily C member 9",
-        "llm-average": 9.5
+        "llm-average": 4.8
       },
       {
         "entity_name": "cannabinoid receptor 2",
-        "llm-average": 9.5
+        "llm-average": 4.8
       },
       {
         "entity_name": "cannabinoid receptor 1",
-        "llm-average": 8.38
+        "llm-average": 4.2
       }
     ]
   },
@@ -6701,15 +6701,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
-        "llm-average": 13.07
+        "llm-average": 6.5
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
-        "llm-average": 11.29
+        "llm-average": 5.6
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
-        "llm-average": 6.6
+        "llm-average": 3.3
       }
     ]
   },
@@ -6721,31 +6721,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diaphragmatic paralysis",
-        "llm-average": 15.45
+        "llm-average": 7.7
       },
       {
         "entity_name": "Hypocalcemia",
-        "llm-average": 13.56
+        "llm-average": 6.8
       },
       {
         "entity_name": "Decreased pulmonary function",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "Hyperhidrosis",
-        "llm-average": 9.7
+        "llm-average": 4.9
       },
       {
         "entity_name": "Hypothermia",
-        "llm-average": 9.54
+        "llm-average": 4.8
       },
       {
         "entity_name": "Erythema",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 5.54
+        "llm-average": 2.8
       }
     ]
   },
@@ -6757,15 +6757,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
-        "llm-average": 14.26
+        "llm-average": 7.1
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
-        "llm-average": 11.29
+        "llm-average": 5.6
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
-        "llm-average": 7.79
+        "llm-average": 3.9
       }
     ]
   },
@@ -6777,11 +6777,11 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "adrenoceptor beta 1",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "adrenoceptor beta 2",
-        "llm-average": 4.32
+        "llm-average": 2.2
       }
     ]
   },
@@ -6793,15 +6793,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "formyl peptide receptor 1",
-        "llm-average": 6.9
+        "llm-average": 3.4
       },
       {
         "entity_name": "formyl peptide receptor 3",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "formyl peptide receptor 2",
-        "llm-average": 6.44
+        "llm-average": 3.2
       }
     ]
   },
@@ -6813,23 +6813,23 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "translocator protein",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "gamma-glutamyltransferase 1",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "aldehyde dehydrogenase 3 family member A1",
-        "llm-average": 8.78
+        "llm-average": 4.4
       },
       {
         "entity_name": "aldehyde dehydrogenase 2 family member",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "glial fibrillary acidic protein",
-        "llm-average": 6.44
+        "llm-average": 3.2
       }
     ]
   },
@@ -6841,31 +6841,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diaphragmatic paralysis",
-        "llm-average": 14.46
+        "llm-average": 7.2
       },
       {
         "entity_name": "Hypocalcemia",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "Decreased pulmonary function",
-        "llm-average": 11.62
+        "llm-average": 5.8
       },
       {
         "entity_name": "Hyperhidrosis",
-        "llm-average": 9.31
+        "llm-average": 4.7
       },
       {
         "entity_name": "Erythema",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "Hypothermia",
-        "llm-average": 5.78
+        "llm-average": 2.9
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 4.52
+        "llm-average": 2.3
       }
     ]
   },
@@ -6877,19 +6877,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 2 subfamily D member 6",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "opioid receptor kappa 1",
-        "llm-average": 10.89
+        "llm-average": 5.4
       },
       {
         "entity_name": "opioid receptor delta 1",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "opioid receptor mu 1",
-        "llm-average": 8.38
+        "llm-average": 4.2
       }
     ]
   },
@@ -6901,31 +6901,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2 associated X, apoptosis regulator",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "sigma non-opioid intracellular receptor 1",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "tachykinin precursor 1",
-        "llm-average": 9.64
+        "llm-average": 4.8
       },
       {
         "entity_name": "glucagon",
-        "llm-average": 9.31
+        "llm-average": 4.7
       },
       {
         "entity_name": "opioid receptor mu 1",
-        "llm-average": 8.75
+        "llm-average": 4.4
       },
       {
         "entity_name": "opioid receptor kappa 1",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "opioid receptor delta 1",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -6937,31 +6937,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diaphragmatic paralysis",
-        "llm-average": 12.67
+        "llm-average": 6.3
       },
       {
         "entity_name": "Decreased pulmonary function",
-        "llm-average": 11.85
+        "llm-average": 5.9
       },
       {
         "entity_name": "Hypocalcemia",
-        "llm-average": 7.26
+        "llm-average": 3.6
       },
       {
         "entity_name": "Hypothermia",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Hyperhidrosis",
-        "llm-average": 6.93
+        "llm-average": 3.5
       },
       {
         "entity_name": "Erythema",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 4.52
+        "llm-average": 2.3
       }
     ]
   },
@@ -6973,15 +6973,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 2 subfamily C member 9",
-        "llm-average": 9.9
+        "llm-average": 5.0
       },
       {
         "entity_name": "cannabinoid receptor 1",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "cannabinoid receptor 2",
-        "llm-average": 6.6
+        "llm-average": 3.3
       }
     ]
   },
@@ -6993,31 +6993,31 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hypocalcemia",
-        "llm-average": 16.3
+        "llm-average": 8.2
       },
       {
         "entity_name": "Diaphragmatic paralysis",
-        "llm-average": 13.47
+        "llm-average": 6.7
       },
       {
         "entity_name": "Decreased pulmonary function",
-        "llm-average": 11.32
+        "llm-average": 5.7
       },
       {
         "entity_name": "Hypothermia",
-        "llm-average": 8.05
+        "llm-average": 4.0
       },
       {
         "entity_name": "Hyperhidrosis",
-        "llm-average": 7.72
+        "llm-average": 3.9
       },
       {
         "entity_name": "Erythema",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "Hypotension",
-        "llm-average": 3.73
+        "llm-average": 1.9
       }
     ]
   },
@@ -7029,35 +7029,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "anti-Mullerian hormone",
-        "llm-average": 11.29
+        "llm-average": 5.6
       },
       {
         "entity_name": "cytochrome P450 family 2 subfamily C member 19",
-        "llm-average": 10.33
+        "llm-average": 5.2
       },
       {
         "entity_name": "aquaporin 8",
-        "llm-average": 9.5
+        "llm-average": 4.8
       },
       {
         "entity_name": "prolactin",
-        "llm-average": 8.15
+        "llm-average": 4.1
       },
       {
         "entity_name": "cyclin A2",
-        "llm-average": 7.92
+        "llm-average": 4.0
       },
       {
         "entity_name": "estrogen receptor 1",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "gamma-glutamyltransferase 1",
-        "llm-average": 5.12
+        "llm-average": 2.6
       },
       {
         "entity_name": "actin beta",
-        "llm-average": 3.47
+        "llm-average": 1.7
       }
     ]
   },
@@ -7069,35 +7069,35 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "growth differentiation factor 15",
-        "llm-average": 14.92
+        "llm-average": 7.5
       },
       {
         "entity_name": "vitamin D receptor",
-        "llm-average": 9.41
+        "llm-average": 4.7
       },
       {
         "entity_name": "MYC proto-oncogene, bHLH transcription factor",
-        "llm-average": 9.37
+        "llm-average": 4.7
       },
       {
         "entity_name": "interleukin 2",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "plasminogen activator, urokinase",
-        "llm-average": 8.32
+        "llm-average": 4.2
       },
       {
         "entity_name": "phosphate regulating endopeptidase homolog X-linked",
-        "llm-average": 7.46
+        "llm-average": 3.7
       },
       {
         "entity_name": "thyroglobulin",
-        "llm-average": 2.34
+        "llm-average": 1.2
       },
       {
         "entity_name": "basic transcription factor 3 pseudogene 11",
-        "llm-average": 1.22
+        "llm-average": 0.6
       }
     ]
   },
@@ -7109,15 +7109,15 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RAR related orphan receptor A",
-        "llm-average": 15.74
+        "llm-average": 7.9
       },
       {
         "entity_name": "coagulation factor X",
-        "llm-average": 9.37
+        "llm-average": 4.7
       },
       {
         "entity_name": "mitogen-activated protein kinase 10",
-        "llm-average": 8.91
+        "llm-average": 4.5
       }
     ]
   },
@@ -7129,19 +7129,19 @@ export const batch2: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "peroxisome proliferator activated receptor gamma",
-        "llm-average": 18.51
+        "llm-average": 9.3
       },
       {
         "entity_name": "arachidonate 5-lipoxygenase",
-        "llm-average": 14.26
+        "llm-average": 7.1
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 1",
-        "llm-average": 10.5
+        "llm-average": 5.2
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 2",
-        "llm-average": 8.09
+        "llm-average": 4.0
       }
     ]
   }

--- a/lib/batches/batch3.ts
+++ b/lib/batches/batch3.ts
@@ -9,19 +9,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Zinc",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "NADH",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 7.45
+        "llm-average": 3.7
       }
     ]
   },
@@ -33,23 +33,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Elacytarabine",
-        "llm-average": 13.2
+        "llm-average": 6.6
       },
       {
         "entity_name": "Cytarabine",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Cytidine",
-        "llm-average": 8.1
+        "llm-average": 4.1
       }
     ]
   },
@@ -61,19 +61,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "ESR1",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "IL4R",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "OSBPL5",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -85,19 +85,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Glycerophosphoinositol",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "Inositol phosphate",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Glycerol",
-        "llm-average": 5.1
+        "llm-average": 2.5
       },
       {
         "entity_name": "Water",
-        "llm-average": 1.18
+        "llm-average": 0.6
       }
     ]
   },
@@ -109,19 +109,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RTP3",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "RTP4",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "GNG13",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "GNGT1",
-        "llm-average": 7.97
+        "llm-average": 4.0
       }
     ]
   },
@@ -133,19 +133,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "EIF4E",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "NFYA",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "RDH12",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "EIF4E2",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -157,15 +157,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "METTL27",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "FBLN1",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "HMCN1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       }
     ]
   },
@@ -177,23 +177,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sinefungin",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "Ademetionine",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "N-Carboxymethionine",
-        "llm-average": 9.41
+        "llm-average": 4.7
       },
       {
         "entity_name": "Isopropyl alcohol",
-        "llm-average": 4.58
+        "llm-average": 2.3
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 3.01
+        "llm-average": 1.5
       }
     ]
   },
@@ -205,11 +205,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NPRL2",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "DAO",
-        "llm-average": 15.69
+        "llm-average": 7.8
       }
     ]
   },
@@ -221,11 +221,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Atrazine",
-        "llm-average": 18.82
+        "llm-average": 9.4
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 14.12
+        "llm-average": 7.1
       }
     ]
   },
@@ -237,35 +237,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "N-Dimethyl-Lysine",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "S-adenosyl-L-homocysteine",
-        "llm-average": 10.85
+        "llm-average": 5.4
       },
       {
         "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
-        "llm-average": 10.07
+        "llm-average": 5.0
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Nicotine",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 2.75
+        "llm-average": 1.4
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 2.09
+        "llm-average": 1.0
       }
     ]
   },
@@ -277,11 +277,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bardet-Biedl syndrome 5 protein",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Bardet-Biedl syndrome 5",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -293,19 +293,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Quercetin",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Kojic acid",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -317,19 +317,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NME7",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "PPP1CA",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "HADHA",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "ABI2",
-        "llm-average": 9.02
+        "llm-average": 4.5
       }
     ]
   },
@@ -341,15 +341,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SHARPIN",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "TNIP1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "CD81",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -361,35 +361,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Zoledronic acid",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "N-Dimethyl-Lysine",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "S-adenosyl-L-homocysteine",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Nicotine",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
-        "llm-average": 5.75
+        "llm-average": 2.9
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 3.92
+        "llm-average": 2.0
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 2.88
+        "llm-average": 1.4
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 0.39
+        "llm-average": 0.2
       }
     ]
   },
@@ -401,19 +401,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
-        "llm-average": 14.77
+        "llm-average": 7.4
       },
       {
         "entity_name": "alpha-N-Acetyl-D-galactosamine",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "N-acetyl-alpha-D-glucosamine",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Cyanocobalamin",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -425,15 +425,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Uridine-5'-diphosphate-mannose",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Galactose-uridine-5'-diphosphate",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "Uridine diphosphate glucose",
-        "llm-average": 8.24
+        "llm-average": 4.1
       }
     ]
   },
@@ -445,35 +445,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRIM28",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "ZNF638",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "SERAC1",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "UNC80",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "CYRIB",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "TSPAN3",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "CACHD1",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "C5orf63",
-        "llm-average": 5.49
+        "llm-average": 2.7
       }
     ]
   },
@@ -485,19 +485,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TGM5",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "PI3",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "TGM1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "CSTA",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -509,11 +509,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Inhibitor of Apoptosis domain",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Baculoviral IAP repeat-containing protein 6",
-        "llm-average": 9.02
+        "llm-average": 4.5
       }
     ]
   },
@@ -525,23 +525,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADRB2",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "TIMMDC1",
-        "llm-average": 14.25
+        "llm-average": 7.1
       },
       {
         "entity_name": "SSMEM1",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "TMEM237",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "HERPUD2",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -553,19 +553,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ARL8B",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "DEF8",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "PAFAH1B1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "TRAFD1",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -577,31 +577,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FAF1",
-        "llm-average": 19.48
+        "llm-average": 9.7
       },
       {
         "entity_name": "SPTY2D1",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "RNF11",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "NUP210L",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "NUP210",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "HEATR5B",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "H2BC1",
-        "llm-average": 8.1
+        "llm-average": 4.1
       }
     ]
   },
@@ -613,23 +613,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IFT88",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "PPP2R1A",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "PPP2CB",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "KRBA1",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "ZNRD2",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -641,27 +641,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vitamin E",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Mercuric iodide",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "Azacitidine",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "Bortezomib",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.58
+        "llm-average": 2.3
       }
     ]
   },
@@ -673,19 +673,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KMT5A",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "SUV39H1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "SRPK1",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "SRPK2",
-        "llm-average": 10.59
+        "llm-average": 5.3
       }
     ]
   },
@@ -697,23 +697,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PQBP1",
-        "llm-average": 17.91
+        "llm-average": 9.0
       },
       {
         "entity_name": "RALA",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "DDX5",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "PPIF",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "DCN",
-        "llm-average": 8.1
+        "llm-average": 4.1
       }
     ]
   },
@@ -725,15 +725,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ACTB",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "VAMP8",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "ADD2",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -745,11 +745,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tubocurarine",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 9.8
+        "llm-average": 4.9
       }
     ]
   },
@@ -761,15 +761,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP17A1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "RAB3IL1",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "HSPA8",
-        "llm-average": 10.33
+        "llm-average": 5.2
       }
     ]
   },
@@ -781,11 +781,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 5.88
+        "llm-average": 2.9
       }
     ]
   },
@@ -797,27 +797,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 16.34
+        "llm-average": 8.2
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Vitamin E",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 3.14
+        "llm-average": 1.6
       }
     ]
   },
@@ -829,11 +829,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Zc3h12a-like Ribonuclease NYN domain",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "Endoribonuclease Regnase 1/ ZC3H12 C-terminal domain",
-        "llm-average": 15.69
+        "llm-average": 7.8
       }
     ]
   },
@@ -845,11 +845,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Zinc",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -861,23 +861,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ZAP70",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "PRKX",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "PRKACA",
-        "llm-average": 9.54
+        "llm-average": 4.8
       },
       {
         "entity_name": "CSTF3",
-        "llm-average": 7.32
+        "llm-average": 3.7
       }
     ]
   },
@@ -889,11 +889,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 13.2
+        "llm-average": 6.6
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -905,27 +905,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Nicotine",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Cholic Acid",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "ATP",
-        "llm-average": 5.88
+        "llm-average": 2.9
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 5.1
+        "llm-average": 2.5
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 3.79
+        "llm-average": 1.9
       }
     ]
   },
@@ -937,15 +937,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MIDEAS",
-        "llm-average": 18.82
+        "llm-average": 9.4
       },
       {
         "entity_name": "HDAC1",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "SOX2",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -957,19 +957,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "alpha-N-Acetyl-D-galactosamine",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "N-acetyl-alpha-D-glucosamine",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Iodine",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -981,31 +981,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MIB2",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "MIB1",
-        "llm-average": 15.82
+        "llm-average": 7.9
       },
       {
         "entity_name": "DYRK1B",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "POU4F3",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "LDLRAP1",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "ODF3L2",
-        "llm-average": 10.85
+        "llm-average": 5.4
       },
       {
         "entity_name": "SLC7A9",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -1017,11 +1017,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "REXO2",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "PCNA",
-        "llm-average": 14.12
+        "llm-average": 7.1
       }
     ]
   },
@@ -1033,19 +1033,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Pyrophosphoric acid",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "Adenosine phosphate",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Tetraethylammonium",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -1057,19 +1057,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LEP",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "HACE1",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "CFL2",
-        "llm-average": 13.2
+        "llm-average": 6.6
       },
       {
         "entity_name": "DSTN",
-        "llm-average": 11.76
+        "llm-average": 5.9
       }
     ]
   },
@@ -1081,31 +1081,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Uridine-Diphosphate-N-Acetylglucosamine",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "Uridine-Diphosphate-N-Acetylgalactosamine",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "Galactose-uridine-5'-diphosphate",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Uridine diphosphate glucose",
-        "llm-average": 7.19
+        "llm-average": 3.6
       },
       {
         "entity_name": "Uridine-5'-diphosphate-mannose",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Uridine-5'-Diphosphate",
-        "llm-average": 5.88
+        "llm-average": 2.9
       },
       {
         "entity_name": "Uridine monophosphate",
-        "llm-average": 4.18
+        "llm-average": 2.1
       }
     ]
   },
@@ -1117,11 +1117,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL10",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "HLA-C",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -1133,27 +1133,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ESR1",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "VAPA",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "TOMM20",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "CANX",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "TOMM22",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "COX14",
-        "llm-average": 7.84
+        "llm-average": 3.9
       }
     ]
   },
@@ -1165,11 +1165,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bortezomib",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -1181,35 +1181,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SIAH1",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "SAMHD1",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "AGO2",
-        "llm-average": 14.25
+        "llm-average": 7.1
       },
       {
         "entity_name": "HNRNPA2B1",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "PRKRA",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "DHX9",
-        "llm-average": 9.41
+        "llm-average": 4.7
       },
       {
         "entity_name": "STAU1",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "MMGT1",
-        "llm-average": 6.54
+        "llm-average": 3.3
       }
     ]
   },
@@ -1221,11 +1221,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OAR motif",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "Homeodomain",
-        "llm-average": 11.63
+        "llm-average": 5.8
       }
     ]
   },
@@ -1237,15 +1237,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Magnesium",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Adenosine triphosphate",
-        "llm-average": 3.4
+        "llm-average": 1.7
       },
       {
         "entity_name": "ADP",
-        "llm-average": 2.88
+        "llm-average": 1.4
       }
     ]
   },
@@ -1257,11 +1257,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Ruxolitinib",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 11.76
+        "llm-average": 5.9
       }
     ]
   },
@@ -1273,15 +1273,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IL17B",
-        "llm-average": 14.77
+        "llm-average": 7.4
       },
       {
         "entity_name": "FSTL1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "IL17C",
-        "llm-average": 12.42
+        "llm-average": 6.2
       }
     ]
   },
@@ -1293,11 +1293,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cadherin cytoplasmic region",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Cadherin domain",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -1309,15 +1309,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAPT",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "RAB12",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "RAB10",
-        "llm-average": 14.9
+        "llm-average": 7.5
       }
     ]
   },
@@ -1329,15 +1329,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -1349,27 +1349,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LONRF2",
-        "llm-average": 18.43
+        "llm-average": 9.2
       },
       {
         "entity_name": "FBXL19",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "CAMKMT",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "PLOD2",
-        "llm-average": 9.54
+        "llm-average": 4.8
       },
       {
         "entity_name": "PLOD3",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "PLOD1",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -1381,11 +1381,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Calcium",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "Magnesium",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -1397,23 +1397,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "Amobarbital",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "Tetrodotoxin",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "D-Leucine",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Leucine",
-        "llm-average": 5.88
+        "llm-average": 2.9
       }
     ]
   },
@@ -1425,31 +1425,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CD44",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "TRAF2",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "FADD",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "MAD2L2",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "IFT27",
-        "llm-average": 7.97
+        "llm-average": 4.0
       },
       {
         "entity_name": "TMEM17",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "TTC30B",
-        "llm-average": 6.54
+        "llm-average": 3.3
       }
     ]
   },
@@ -1461,35 +1461,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADAM17",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "PSEN2",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "PSEN1",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "RBPJL",
-        "llm-average": 10.07
+        "llm-average": 5.0
       },
       {
         "entity_name": "ADAM10",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "MAML1",
-        "llm-average": 9.41
+        "llm-average": 4.7
       },
       {
         "entity_name": "RBPJ",
-        "llm-average": 9.15
+        "llm-average": 4.6
       },
       {
         "entity_name": "ICAM1",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -1501,19 +1501,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Estramustine",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 5.36
+        "llm-average": 2.7
       }
     ]
   },
@@ -1525,27 +1525,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RAC1",
-        "llm-average": 19.61
+        "llm-average": 9.8
       },
       {
         "entity_name": "PRKCB",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "SH2D3C",
-        "llm-average": 13.99
+        "llm-average": 7.0
       },
       {
         "entity_name": "POT1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "SMAD9",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "H4C1",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -1557,31 +1557,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IFNA21",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "EAF1",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "ZNF76",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "ENKD1",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "HSF2BP",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "FAM90A1",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "SCNM1",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -1593,11 +1593,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BMP3",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "BMP2",
-        "llm-average": 9.67
+        "llm-average": 4.8
       }
     ]
   },
@@ -1609,27 +1609,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SFPQ",
-        "llm-average": 15.42
+        "llm-average": 7.7
       },
       {
         "entity_name": "IPO13",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "HMGA2",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "FUS",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "DES",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "LMCD1",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -1641,11 +1641,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DERL3",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "BCL2L1",
-        "llm-average": 12.42
+        "llm-average": 6.2
       }
     ]
   },
@@ -1657,31 +1657,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "O-Desmethylverapamil (D-702)",
-        "llm-average": 14.77
+        "llm-average": 7.4
       },
       {
         "entity_name": "Flunarizine",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "Paramethadione",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "Cinnarizine",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Verapamil",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Zonisamide",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -1693,11 +1693,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tretinoin",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Ethanol",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -1709,19 +1709,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Calcitriol",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Epitestosterone",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 1.7
+        "llm-average": 0.8
       }
     ]
   },
@@ -1733,27 +1733,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Calcitriol",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 6.93
+        "llm-average": 3.5
       },
       {
         "entity_name": "Epitestosterone",
-        "llm-average": 6.67
+        "llm-average": 3.3
       }
     ]
   },
@@ -1765,11 +1765,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FBXL19",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "LONRF2",
-        "llm-average": 13.2
+        "llm-average": 6.6
       }
     ]
   },
@@ -1781,23 +1781,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ITGB4",
-        "llm-average": 14.77
+        "llm-average": 7.4
       },
       {
         "entity_name": "ITGA6",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "LAMA1",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "LAMB1",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "LAMC2",
-        "llm-average": 10.98
+        "llm-average": 5.5
       }
     ]
   },
@@ -1809,15 +1809,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ZFYVE27",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "HSCB",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "ATL3",
-        "llm-average": 13.59
+        "llm-average": 6.8
       }
     ]
   },
@@ -1829,11 +1829,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "C1q domain",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Collagen triple helix repeat (20 copies)",
-        "llm-average": 9.67
+        "llm-average": 4.8
       }
     ]
   },
@@ -1845,11 +1845,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DVL3",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "SDCBP2",
-        "llm-average": 10.98
+        "llm-average": 5.5
       }
     ]
   },
@@ -1861,23 +1861,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Epitestosterone",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "Calcitriol",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Vitamin E",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -1889,11 +1889,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Intermediate filament protein",
-        "llm-average": 10.85
+        "llm-average": 5.4
       },
       {
         "entity_name": "Keratin type II head",
-        "llm-average": 9.67
+        "llm-average": 4.8
       }
     ]
   },
@@ -1905,11 +1905,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RNF114",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "TRIM41",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -1921,35 +1921,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ESR1",
-        "llm-average": 15.42
+        "llm-average": 7.7
       },
       {
         "entity_name": "SLC30A6",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "AURKC",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "YEATS4",
-        "llm-average": 13.99
+        "llm-average": 7.0
       },
       {
         "entity_name": "PIP4K2A",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "FAM177A1",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "CDK17",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "SPC25",
-        "llm-average": 6.27
+        "llm-average": 3.1
       }
     ]
   },
@@ -1961,31 +1961,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "1D-myo-inositol 1,3,4-trisphosphate",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "1D-myo-inositol 1,4,5-trisphosphate",
-        "llm-average": 13.2
+        "llm-average": 6.6
       },
       {
         "entity_name": "Triethylene glycol",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "2-(2-{2-[2-(2-{2-[2-(2-Ethoxy-Ethoxy)-Ethoxy]-Ethoxy}-Ethoxy)-Ethoxy]-Ethoxy}-Ethoxy)-Ethanol, Polyethyleneglycol Peg400",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Inositol 2,4,5-trisphosphate",
-        "llm-average": 6.01
+        "llm-average": 3.0
       },
       {
         "entity_name": "Inositol-(1,3,4,5,6)-Pentakisphosphate",
-        "llm-average": 5.88
+        "llm-average": 2.9
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 3.4
+        "llm-average": 1.7
       }
     ]
   },
@@ -1997,23 +1997,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N-Dimethyl-Lysine",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Formic acid",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 4.05
+        "llm-average": 2.0
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 3.4
+        "llm-average": 1.7
       }
     ]
   },
@@ -2025,23 +2025,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MEF2A",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "MET",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "EGFR",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "INSR",
-        "llm-average": 8.37
+        "llm-average": 4.2
       }
     ]
   },
@@ -2053,15 +2053,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Inositol 1,3,4,5-Tetrakisphosphate",
-        "llm-average": 18.82
+        "llm-average": 9.4
       },
       {
         "entity_name": "Amiodarone",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 6.54
+        "llm-average": 3.3
       }
     ]
   },
@@ -2073,11 +2073,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -2089,27 +2089,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Zoledronic acid",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "S-adenosyl-L-homocysteine",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "N-Dimethyl-Lysine",
-        "llm-average": 9.41
+        "llm-average": 4.7
       },
       {
         "entity_name": "Nicotine",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
-        "llm-average": 4.97
+        "llm-average": 2.5
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 1.7
+        "llm-average": 0.8
       },
       {
         "entity_name": "Acetic acid",
@@ -2125,23 +2125,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CHRNG",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "NPTX1",
-        "llm-average": 15.56
+        "llm-average": 7.8
       },
       {
         "entity_name": "NREP",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "TNNI1",
-        "llm-average": 10.07
+        "llm-average": 5.0
       },
       {
         "entity_name": "TNNC2",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -2153,31 +2153,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Motexafin gadolinium",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Amiodarone",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Coenzyme A",
-        "llm-average": 8.1
+        "llm-average": 4.1
       },
       {
         "entity_name": "Mercuric iodide",
-        "llm-average": 6.01
+        "llm-average": 3.0
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.18
+        "llm-average": 2.1
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 1.96
+        "llm-average": 1.0
       }
     ]
   },
@@ -2189,35 +2189,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CCM2",
-        "llm-average": 16.6
+        "llm-average": 8.3
       },
       {
         "entity_name": "DNAAF2",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "MEMO1",
-        "llm-average": 15.95
+        "llm-average": 8.0
       },
       {
         "entity_name": "PPP5C",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "KLHDC2",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "FKBP6",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "CPSF3",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "DEFA1",
-        "llm-average": 8.1
+        "llm-average": 4.1
       }
     ]
   },
@@ -2229,15 +2229,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FXYD6",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "TMEM147",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "GPR152",
-        "llm-average": 11.24
+        "llm-average": 5.6
       }
     ]
   },
@@ -2249,11 +2249,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Melanoma associated antigen family N terminal",
-        "llm-average": 10.07
+        "llm-average": 5.0
       },
       {
         "entity_name": "MAGE family",
-        "llm-average": 5.49
+        "llm-average": 2.7
       }
     ]
   },
@@ -2265,19 +2265,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Chondroitin 4-sulfate",
-        "llm-average": 18.43
+        "llm-average": 9.2
       },
       {
         "entity_name": "Phosphoadenosine phosphosulfate",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Chondroitin",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Adenosine 3',5'-diphosphate",
-        "llm-average": 9.67
+        "llm-average": 4.8
       }
     ]
   },
@@ -2289,15 +2289,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Menadione",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "Vincristine",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -2309,23 +2309,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 18.3
+        "llm-average": 9.2
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Amiodarone",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -2337,15 +2337,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Atrazine",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 13.07
+        "llm-average": 6.5
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -2357,15 +2357,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Gemcitabine",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Beta-D-Glucose",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "D-Allopyranose",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -2377,35 +2377,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Balsalazide",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "sn-glycerol 3-phosphate",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "Citric acid",
-        "llm-average": 4.58
+        "llm-average": 2.3
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 2.22
+        "llm-average": 1.1
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 1.83
+        "llm-average": 0.9
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 1.31
+        "llm-average": 0.7
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 0.39
+        "llm-average": 0.2
       }
     ]
   },
@@ -2417,23 +2417,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vincristine",
-        "llm-average": 15.56
+        "llm-average": 7.8
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Mercuric iodide",
-        "llm-average": 5.49
+        "llm-average": 2.7
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 5.36
+        "llm-average": 2.7
       }
     ]
   },
@@ -2445,15 +2445,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Pyrophosphoric acid",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "ATP",
-        "llm-average": 4.58
+        "llm-average": 2.3
       },
       {
         "entity_name": "Adenosine phosphate",
-        "llm-average": 3.79
+        "llm-average": 1.9
       }
     ]
   },
@@ -2465,11 +2465,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KIN",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "HSPA5",
-        "llm-average": 12.42
+        "llm-average": 6.2
       }
     ]
   },
@@ -2481,11 +2481,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Azacitidine",
-        "llm-average": 13.2
+        "llm-average": 6.6
       },
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -2497,11 +2497,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "D-Tryptophan",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Tryptophan",
-        "llm-average": 6.14
+        "llm-average": 3.1
       }
     ]
   },
@@ -2513,11 +2513,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "7 transmembrane receptor (Secretin family)",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Hormone receptor domain",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -2529,15 +2529,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "7 transmembrane sweet-taste receptor of 3 GCPR",
-        "llm-average": 18.82
+        "llm-average": 9.4
       },
       {
         "entity_name": "Nine Cysteines Domain of family 3 GPCR",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Receptor family ligand binding region",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -2549,19 +2549,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DLX2",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "HSPB1",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "IFNG",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -2573,15 +2573,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ARPC5",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "ARPC4",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "EXOC5",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -2593,11 +2593,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Succinic acid",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "Ascorbic acid",
-        "llm-average": 9.02
+        "llm-average": 4.5
       }
     ]
   },
@@ -2609,27 +2609,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "S,S-(2-Hydroxyethyl)Thiocysteine",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Tromethamine",
-        "llm-average": 4.84
+        "llm-average": 2.4
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 4.18
+        "llm-average": 2.1
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 1.7
+        "llm-average": 0.8
       }
     ]
   },
@@ -2641,11 +2641,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Estramustine",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "Fluorescein",
-        "llm-average": 9.02
+        "llm-average": 4.5
       }
     ]
   },
@@ -2657,15 +2657,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bisphenol A",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "2-(N-morpholino)ethanesulfonic acid",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "2-Pyridinethiol",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -2677,15 +2677,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Resveratrol",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "ATP",
-        "llm-average": 10.33
+        "llm-average": 5.2
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -2697,11 +2697,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -2713,27 +2713,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ZSCAN1",
-        "llm-average": 13.99
+        "llm-average": 7.0
       },
       {
         "entity_name": "HIP2",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "UBE2D2",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "MNAT1",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "MAGEA1",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "UBE2K",
-        "llm-average": 11.63
+        "llm-average": 5.8
       }
     ]
   },
@@ -2745,15 +2745,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RRM1",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "DLD",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "GSR",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -2765,23 +2765,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "(Z,Z)-4-Hydroxy-N,N,N-Trimethyl-10-Oxo-7-[(1-Oxo-9-Octadecenyl)Oxy]-3,5,9-Trioxa-4-Phosphaheptacos-18-En-1-Aminium-4-Oxide",
-        "llm-average": 17.78
+        "llm-average": 8.9
       },
       {
         "entity_name": "9,10-Deepithio-9,10-Didehydroacanthifolicin",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "1,2-diacyl-sn-glycero-3-phosphoinositol",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "Aniracetam",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "ATP",
-        "llm-average": 3.66
+        "llm-average": 1.8
       }
     ]
   },
@@ -2793,11 +2793,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Isoflurophate",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -2809,15 +2809,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "5beta-dihydrotestosterone",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Stanolone",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -2829,11 +2829,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 13.59
+        "llm-average": 6.8
       }
     ]
   },
@@ -2845,35 +2845,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IFNA21",
-        "llm-average": 16.34
+        "llm-average": 8.2
       },
       {
         "entity_name": "CD1B",
-        "llm-average": 16.21
+        "llm-average": 8.1
       },
       {
         "entity_name": "ITGA9",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "LYZL2",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "TEX101",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "LACRT",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "CLU",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "CANX",
-        "llm-average": 7.45
+        "llm-average": 3.7
       }
     ]
   },
@@ -2885,15 +2885,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MGME1",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "GABARAPL2",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "AARSD1",
-        "llm-average": 11.24
+        "llm-average": 5.6
       }
     ]
   },
@@ -2905,31 +2905,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRIM28",
-        "llm-average": 18.04
+        "llm-average": 9.0
       },
       {
         "entity_name": "ALDH16A1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "PRR19",
-        "llm-average": 10.33
+        "llm-average": 5.2
       },
       {
         "entity_name": "FBXW12",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "ALS2CL",
-        "llm-average": 9.54
+        "llm-average": 4.8
       },
       {
         "entity_name": "NGRN",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "DDX27",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -2941,11 +2941,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "C11orf24",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "PPP1CA",
-        "llm-average": 10.98
+        "llm-average": 5.5
       }
     ]
   },
@@ -2957,11 +2957,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sulindac",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 12.16
+        "llm-average": 6.1
       }
     ]
   },
@@ -2973,23 +2973,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "Guanosine-5'-Triphosphate",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "D-Tyrosine",
-        "llm-average": 4.97
+        "llm-average": 2.5
       },
       {
         "entity_name": "Tyrosine",
-        "llm-average": 2.61
+        "llm-average": 1.3
       }
     ]
   },
@@ -3001,15 +3001,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Magnesium",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "ADP",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "Adenosine triphosphate",
-        "llm-average": 5.36
+        "llm-average": 2.7
       }
     ]
   },
@@ -3021,19 +3021,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ICAM1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "HNRNPU",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "NPY2R",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "NTAQ1",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -3045,15 +3045,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP",
-        "llm-average": 9.41
+        "llm-average": 4.7
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Guanosine-5'-Triphosphate",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -3065,35 +3065,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Quercetin",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "Genistein",
-        "llm-average": 15.95
+        "llm-average": 8.0
       },
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 13.99
+        "llm-average": 7.0
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 13.07
+        "llm-average": 6.5
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.58
+        "llm-average": 2.3
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 2.35
+        "llm-average": 1.2
       }
     ]
   },
@@ -3105,11 +3105,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Complement Clr-like EGF-like",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Lectin C-type domain",
-        "llm-average": 10.2
+        "llm-average": 5.1
       }
     ]
   },
@@ -3121,19 +3121,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Quercetin",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.98
+        "llm-average": 5.5
       }
     ]
   },
@@ -3145,15 +3145,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRIM28",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "FBXL19",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "LONRF2",
-        "llm-average": 12.42
+        "llm-average": 6.2
       }
     ]
   },
@@ -3165,11 +3165,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP synthase alpha/beta family, nucleotide-binding domain",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "ATP synthase alpha/beta family, beta-barrel domain",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -3181,11 +3181,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -3197,31 +3197,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PHOX2B",
-        "llm-average": 15.95
+        "llm-average": 8.0
       },
       {
         "entity_name": "DLL3",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "ASCL1",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "NEUROD1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "UNCX",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "NOTCH1",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "FGF2",
-        "llm-average": 9.93
+        "llm-average": 5.0
       }
     ]
   },
@@ -3233,11 +3233,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TCF12",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "HNRNPK",
-        "llm-average": 10.98
+        "llm-average": 5.5
       }
     ]
   },
@@ -3249,27 +3249,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Codeine",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Cacodylic acid",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 3.4
+        "llm-average": 1.7
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 3.27
+        "llm-average": 1.6
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 2.75
+        "llm-average": 1.4
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 1.44
+        "llm-average": 0.7
       }
     ]
   },
@@ -3281,19 +3281,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DISC1",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "PCNA",
-        "llm-average": 13.2
+        "llm-average": 6.6
       },
       {
         "entity_name": "PLAUR",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "FBXO6",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -3305,31 +3305,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KIF2A",
-        "llm-average": 19.08
+        "llm-average": 9.5
       },
       {
         "entity_name": "CEP128",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "CEP170",
-        "llm-average": 13.99
+        "llm-average": 7.0
       },
       {
         "entity_name": "ODF2",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "CNTRL",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "DCTN1",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "NIN",
-        "llm-average": 9.93
+        "llm-average": 5.0
       }
     ]
   },
@@ -3341,11 +3341,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CDC23",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "CENPQ",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -3357,27 +3357,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Clozapine",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 9.15
+        "llm-average": 4.6
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.18
+        "llm-average": 2.1
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 1.44
+        "llm-average": 0.7
       }
     ]
   },
@@ -3389,23 +3389,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SPRY2",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "H2BS1",
-        "llm-average": 7.32
+        "llm-average": 3.7
       },
       {
         "entity_name": "H2BC18",
-        "llm-average": 6.93
+        "llm-average": 3.5
       },
       {
         "entity_name": "H2BC9",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "H1-1",
-        "llm-average": 6.01
+        "llm-average": 3.0
       }
     ]
   },
@@ -3417,31 +3417,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Phosphoaminophosphonic acid guanylate ester",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "Guanosine-3'-monophosphate-5'-diphosphate",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "Cyanocobalamin",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Mercaptoethanol",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 4.18
+        "llm-average": 2.1
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 4.05
+        "llm-average": 2.0
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 2.35
+        "llm-average": 1.2
       }
     ]
   },
@@ -3453,27 +3453,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Calcitriol",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "Melphalan",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 9.41
+        "llm-average": 4.7
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 3.01
+        "llm-average": 1.5
       }
     ]
   },
@@ -3485,11 +3485,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Ademetionine",
-        "llm-average": 10.85
+        "llm-average": 5.4
       },
       {
         "entity_name": "S-adenosyl-L-homocysteine",
-        "llm-average": 8.63
+        "llm-average": 4.3
       }
     ]
   },
@@ -3501,19 +3501,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Propafenone",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate-Rhamnose",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "Brefeldin A",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -3525,15 +3525,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Histamine",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "Cyclic AMP",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Chlorpheniramine",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -3545,15 +3545,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N,N-dimethylarginine",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Isopropyl alcohol",
-        "llm-average": 9.8
+        "llm-average": 4.9
       }
     ]
   },
@@ -3565,15 +3565,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dapagliflozin",
-        "llm-average": 19.48
+        "llm-average": 9.7
       },
       {
         "entity_name": "Telmisartan",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -3585,27 +3585,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "(4r)-2-Methylpentane-2,4-Diol",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "N-Dimethyl-Lysine",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "S-adenosyl-L-homocysteine",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Nicotine",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 2.88
+        "llm-average": 1.4
       }
     ]
   },
@@ -3617,11 +3617,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "oxidoreductase-like domain-containing protein 1 isoform a",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "oxidoreductase like domain containing 1",
-        "llm-average": 9.93
+        "llm-average": 5.0
       }
     ]
   },
@@ -3633,19 +3633,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Balsalazide",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "ATP",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Iron",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -3657,23 +3657,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "EPHA2",
-        "llm-average": 18.43
+        "llm-average": 9.2
       },
       {
         "entity_name": "AATK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "LMTK2",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "PTK7",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "CALD1",
-        "llm-average": 8.37
+        "llm-average": 4.2
       }
     ]
   },
@@ -3685,15 +3685,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -3705,23 +3705,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 10.85
+        "llm-average": 5.4
       },
       {
         "entity_name": "Progesterone",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "Phenobarbital",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 3.79
+        "llm-average": 1.9
       }
     ]
   },
@@ -3733,19 +3733,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NETO2",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "KIF20A",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "YWHAZ",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "CANX",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -3757,35 +3757,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LRRK2",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "PDK1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "ENG",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "HSPD1",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "CT55",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "MGST3",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "SCLT1",
-        "llm-average": 8.1
+        "llm-average": 4.1
       },
       {
         "entity_name": "TRMT61B",
-        "llm-average": 7.58
+        "llm-average": 3.8
       }
     ]
   },
@@ -3797,15 +3797,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "EMC2",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "EMC3",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "EMC8",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -3817,11 +3817,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Folate receptor family",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Glucose / Sorbosone dehydrogenase",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -3833,27 +3833,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADAM10",
-        "llm-average": 18.04
+        "llm-average": 9.0
       },
       {
         "entity_name": "CAV1",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "SCARB1",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "TEAD4",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "CKAP4",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "TEAD3",
-        "llm-average": 9.93
+        "llm-average": 5.0
       }
     ]
   },
@@ -3865,31 +3865,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Calcitriol",
-        "llm-average": 19.87
+        "llm-average": 9.9
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "alpha-D-quinovopyranose",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "alpha-L-fucose",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "beta-L-fucose",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "beta-D-fucose",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "alpha-D-Fucopyranose",
-        "llm-average": 6.54
+        "llm-average": 3.3
       }
     ]
   },
@@ -3901,31 +3901,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SUN1",
-        "llm-average": 15.82
+        "llm-average": 7.9
       },
       {
         "entity_name": "SUN2",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "SYNE3",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "SYNE2",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "SUN3",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "SYNE4",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "SYNE1",
-        "llm-average": 11.5
+        "llm-average": 5.8
       }
     ]
   },
@@ -3937,19 +3937,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Guanosine-5'-Triphosphate",
-        "llm-average": 12.29
+        "llm-average": 6.1
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 3.79
+        "llm-average": 1.9
       }
     ]
   },
@@ -3961,11 +3961,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "bolA family member 2",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "bolA family member 2B",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -3977,23 +3977,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Irinotecan",
-        "llm-average": 17.12
+        "llm-average": 8.6
       },
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -4005,15 +4005,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TOR1AIP1",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "PTPN1",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "EIF1AD",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -4025,31 +4025,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "3-[(3-(2-CARBOXYETHYL)-4-METHYLPYRROL-2-YL)METHYLENE]-2-INDOLINONE",
-        "llm-average": 16.6
+        "llm-average": 8.3
       },
       {
         "entity_name": "Suramin",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Genistein",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Sucrosofate",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 5.23
+        "llm-average": 2.6
       },
       {
         "entity_name": "Ethanol",
-        "llm-average": 4.18
+        "llm-average": 2.1
       }
     ]
   },
@@ -4061,19 +4061,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IL16",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "LENG8",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "RAMAC",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "CSN3",
-        "llm-average": 11.24
+        "llm-average": 5.6
       }
     ]
   },
@@ -4085,11 +4085,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Phosphoadenosine phosphosulfate",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Adenosine 3',5'-diphosphate",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -4101,19 +4101,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIN1",
-        "llm-average": 16.34
+        "llm-average": 8.2
       },
       {
         "entity_name": "HSP90AB1",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "PRKD2",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "CCR4",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -4125,11 +4125,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FBXL19",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "LONRF2",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -4141,11 +4141,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HCFC2",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "CSNK2A1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -4157,35 +4157,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PPP3R1",
-        "llm-average": 15.56
+        "llm-average": 7.8
       },
       {
         "entity_name": "FAM81A",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "TP53BP2",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "MED30",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "CUL1",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "NAP1L5",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "NAP1L3",
-        "llm-average": 9.15
+        "llm-average": 4.6
       },
       {
         "entity_name": "FBL",
-        "llm-average": 9.15
+        "llm-average": 4.6
       }
     ]
   },
@@ -4197,15 +4197,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GSK3B",
-        "llm-average": 12.77
+        "llm-average": 6.4
       },
       {
         "entity_name": "CTNNB1",
-        "llm-average": 10.82
+        "llm-average": 5.4
       },
       {
         "entity_name": "AXIN1",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -4217,11 +4217,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KDR",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "FLT4",
-        "llm-average": 8.85
+        "llm-average": 4.4
       }
     ]
   },
@@ -4233,11 +4233,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JUN",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "ESR1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -4249,11 +4249,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -4265,11 +4265,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -4281,11 +4281,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -4297,15 +4297,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 10.0
+        "llm-average": 5.0
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -4317,11 +4317,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Guanosine-5'-Triphosphate",
-        "llm-average": 8.78
+        "llm-average": 4.4
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -4333,11 +4333,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -4349,23 +4349,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 14.15
+        "llm-average": 7.1
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 8.93
+        "llm-average": 4.5
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -4377,15 +4377,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53BP1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "NBN",
-        "llm-average": 12.17
+        "llm-average": 6.1
       },
       {
         "entity_name": "MRE11",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -4397,31 +4397,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CHTOP",
-        "llm-average": 18.94
+        "llm-average": 9.5
       },
       {
         "entity_name": "WEE1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "EIF4G1",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "EIF4A2",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "EIF4E",
-        "llm-average": 8.9
+        "llm-average": 4.5
       },
       {
         "entity_name": "EIF4A1",
-        "llm-average": 8.83
+        "llm-average": 4.4
       },
       {
         "entity_name": "EEF2",
-        "llm-average": 7.63
+        "llm-average": 3.8
       }
     ]
   },
@@ -4433,11 +4433,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ITGB1",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "SPP1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -4449,15 +4449,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PARP1",
-        "llm-average": 16.8
+        "llm-average": 8.4
       },
       {
         "entity_name": "CREBBP",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "SRC",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -4469,31 +4469,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRLS1",
-        "llm-average": 17.57
+        "llm-average": 8.8
       },
       {
         "entity_name": "CDS2",
-        "llm-average": 15.2
+        "llm-average": 7.6
       },
       {
         "entity_name": "AGPAT5",
-        "llm-average": 15.0
+        "llm-average": 7.5
       },
       {
         "entity_name": "PTPMT1",
-        "llm-average": 13.55
+        "llm-average": 6.8
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 11.1
+        "llm-average": 5.5
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.48
+        "llm-average": 5.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -4505,11 +4505,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AGPAT1",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 15.07
+        "llm-average": 7.5
       }
     ]
   },
@@ -4521,11 +4521,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -4537,23 +4537,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 8.93
+        "llm-average": 4.5
       }
     ]
   },
@@ -4565,19 +4565,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 12.72
+        "llm-average": 6.4
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 7.09
+        "llm-average": 3.5
       }
     ]
   },
@@ -4589,11 +4589,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -4605,11 +4605,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BRAF",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "RAF1",
-        "llm-average": 10.35
+        "llm-average": 5.2
       }
     ]
   },
@@ -4621,19 +4621,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ANXA5",
-        "llm-average": 13.15
+        "llm-average": 6.6
       },
       {
         "entity_name": "ABCG2",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "ABCC1",
-        "llm-average": 7.55
+        "llm-average": 3.8
       },
       {
         "entity_name": "ABCB1",
-        "llm-average": 6.8
+        "llm-average": 3.4
       }
     ]
   },
@@ -4645,11 +4645,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ING1",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "PCNA",
-        "llm-average": 6.27
+        "llm-average": 3.1
       }
     ]
   },
@@ -4661,11 +4661,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MED29",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "MED11",
-        "llm-average": 8.85
+        "llm-average": 4.4
       }
     ]
   },
@@ -4677,11 +4677,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SDHB",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "SDHA",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -4693,23 +4693,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ESR2",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "MAPK3",
-        "llm-average": 10.57
+        "llm-average": 5.3
       },
       {
         "entity_name": "MAPK1",
-        "llm-average": 9.66
+        "llm-average": 4.8
       },
       {
         "entity_name": "HSP90AA1",
-        "llm-average": 9.25
+        "llm-average": 4.6
       },
       {
         "entity_name": "ESR1",
-        "llm-average": 8.06
+        "llm-average": 4.0
       }
     ]
   },
@@ -4721,11 +4721,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NFKBIA",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "RELA",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -4737,11 +4737,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AMOTL1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "ALB",
-        "llm-average": 3.89
+        "llm-average": 1.9
       }
     ]
   },
@@ -4753,11 +4753,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -4769,15 +4769,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SMARCB1",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "PRMT5",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "SMARCA2",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -4789,11 +4789,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -4805,19 +4805,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 17.38
+        "llm-average": 8.7
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.1
+        "llm-average": 5.5
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.86
+        "llm-average": 5.4
       }
     ]
   },
@@ -4829,15 +4829,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RUVBL2",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "TTI1",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "TELO2",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -4849,11 +4849,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GLMN",
-        "llm-average": 15.07
+        "llm-average": 7.5
       },
       {
         "entity_name": "TPM3",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -4865,27 +4865,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AGPAT5",
-        "llm-average": 18.7
+        "llm-average": 9.3
       },
       {
         "entity_name": "PTPMT1",
-        "llm-average": 17.37
+        "llm-average": 8.7
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 16.49
+        "llm-average": 8.2
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 13.65
+        "llm-average": 6.8
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -4897,35 +4897,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 16.07
+        "llm-average": 8.0
       },
       {
         "entity_name": "MYC",
-        "llm-average": 11.03
+        "llm-average": 5.5
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 9.74
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.2
+        "llm-average": 4.1
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 7.82
+        "llm-average": 3.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 6.79
+        "llm-average": 3.4
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 6.38
+        "llm-average": 3.2
       }
     ]
   },
@@ -4937,11 +4937,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4953,11 +4953,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -4969,11 +4969,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 8.59
+        "llm-average": 4.3
       }
     ]
   },
@@ -4985,11 +4985,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5001,31 +5001,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 9.29
+        "llm-average": 4.6
       },
       {
         "entity_name": "CBL",
-        "llm-average": 9.24
+        "llm-average": 4.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 7.13
+        "llm-average": 3.6
       }
     ]
   },
@@ -5037,11 +5037,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "MYC",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -5053,19 +5053,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2L1",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 7.99
+        "llm-average": 4.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 6.22
+        "llm-average": 3.1
       }
     ]
   },
@@ -5077,11 +5077,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5093,31 +5093,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 15.51
+        "llm-average": 7.8
       },
       {
         "entity_name": "CBL",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 9.29
+        "llm-average": 4.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 7.13
+        "llm-average": 3.6
       }
     ]
   },
@@ -5129,11 +5129,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.64
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5145,23 +5145,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 14.46
+        "llm-average": 7.2
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 9.52
+        "llm-average": 4.8
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -5173,11 +5173,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5189,15 +5189,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -5209,15 +5209,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "MDM2",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -5229,23 +5229,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 11.03
+        "llm-average": 5.5
       },
       {
         "entity_name": "CBL",
-        "llm-average": 10.56
+        "llm-average": 5.3
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 10.12
+        "llm-average": 5.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       }
     ]
   },
@@ -5257,27 +5257,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 12.53
+        "llm-average": 6.3
       },
       {
         "entity_name": "CBL",
-        "llm-average": 11.62
+        "llm-average": 5.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 7.13
+        "llm-average": 3.6
       }
     ]
   },
@@ -5289,23 +5289,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SOS1",
-        "llm-average": 10.57
+        "llm-average": 5.3
       },
       {
         "entity_name": "CBL",
-        "llm-average": 10.56
+        "llm-average": 5.3
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 10.14
+        "llm-average": 5.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.62
+        "llm-average": 3.8
       }
     ]
   },
@@ -5317,15 +5317,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "TP53",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5337,11 +5337,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -5353,15 +5353,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.75
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -5373,27 +5373,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 13.71
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 9.37
+        "llm-average": 4.7
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "CBL",
-        "llm-average": 8.4
+        "llm-average": 4.2
       }
     ]
   },
@@ -5405,11 +5405,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.64
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5421,31 +5421,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 17.0
+        "llm-average": 8.5
       },
       {
         "entity_name": "CBL",
-        "llm-average": 15.32
+        "llm-average": 7.7
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -5457,35 +5457,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 10.67
+        "llm-average": 5.3
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 9.35
+        "llm-average": 4.7
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.8
+        "llm-average": 4.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 5.78
+        "llm-average": 2.9
       }
     ]
   },
@@ -5497,35 +5497,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 16.82
+        "llm-average": 8.4
       },
       {
         "entity_name": "MYC",
-        "llm-average": 15.08
+        "llm-average": 7.5
       },
       {
         "entity_name": "TP53",
-        "llm-average": 11.2
+        "llm-average": 5.6
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.59
+        "llm-average": 4.3
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 6.68
+        "llm-average": 3.3
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 6.32
+        "llm-average": 3.2
       }
     ]
   },
@@ -5537,11 +5537,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -5553,11 +5553,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -5569,23 +5569,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 15.96
+        "llm-average": 8.0
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 10.27
+        "llm-average": 5.1
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -5597,19 +5597,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 12.87
+        "llm-average": 6.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 10.99
+        "llm-average": 5.5
       }
     ]
   },
@@ -5621,15 +5621,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 19.25
+        "llm-average": 9.6
       },
       {
         "entity_name": "MDM2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -5641,35 +5641,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 15.08
+        "llm-average": 7.5
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 13.36
+        "llm-average": 6.7
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.5
+        "llm-average": 5.3
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 9.78
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.59
+        "llm-average": 4.3
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 6.68
+        "llm-average": 3.3
       }
     ]
   },
@@ -5681,19 +5681,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 12.38
+        "llm-average": 6.2
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 9.97
+        "llm-average": 5.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "TP53",
-        "llm-average": 9.61
+        "llm-average": 4.8
       }
     ]
   },
@@ -5705,19 +5705,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2L1",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 7.99
+        "llm-average": 4.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 6.22
+        "llm-average": 3.1
       }
     ]
   },
@@ -5729,35 +5729,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 12.61
+        "llm-average": 6.3
       },
       {
         "entity_name": "MYC",
-        "llm-average": 11.03
+        "llm-average": 5.5
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 9.74
+        "llm-average": 4.9
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 9.2
+        "llm-average": 4.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "TP53",
-        "llm-average": 7.51
+        "llm-average": 3.8
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 6.79
+        "llm-average": 3.4
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 6.38
+        "llm-average": 3.2
       }
     ]
   },
@@ -5769,11 +5769,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "MYC",
-        "llm-average": 12.34
+        "llm-average": 6.2
       }
     ]
   },
@@ -5785,15 +5785,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "MYC",
-        "llm-average": 10.99
+        "llm-average": 5.5
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -5805,19 +5805,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SKP2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "STAT5A",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 11.32
+        "llm-average": 5.7
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5829,15 +5829,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.99
+        "llm-average": 5.5
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -5849,31 +5849,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 16.1
+        "llm-average": 8.1
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 13.49
+        "llm-average": 6.7
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 12.18
+        "llm-average": 6.1
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "CBL",
-        "llm-average": 8.67
+        "llm-average": 4.3
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -5885,11 +5885,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -5901,11 +5901,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -5917,15 +5917,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "preassembly of GPI anchor in ER membrane",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "GPI anchor biosynthetic process",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "carbohydrate metabolic process",
-        "llm-average": 9.26
+        "llm-average": 4.6
       }
     ]
   },
@@ -5937,15 +5937,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Translesion synthesis by REV1",
-        "llm-average": 15.72
+        "llm-average": 7.9
       },
       {
         "entity_name": "Translesion synthesis by POLK",
-        "llm-average": 10.8
+        "llm-average": 5.4
       },
       {
         "entity_name": "Translesion synthesis by POLI",
-        "llm-average": 9.12
+        "llm-average": 4.6
       }
     ]
   },
@@ -5957,11 +5957,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "proteolysis",
-        "llm-average": 10.24
+        "llm-average": 5.1
       },
       {
         "entity_name": "cornification",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -5973,11 +5973,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 9.34
+        "llm-average": 4.7
       },
       {
         "entity_name": "Opsins",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -5989,11 +5989,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GLO1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       },
       {
         "entity_name": "GLOD4",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -6005,15 +6005,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ELOVL6",
-        "llm-average": 5.69
+        "llm-average": 2.8
       },
       {
         "entity_name": "ELOVL5",
-        "llm-average": 4.27
+        "llm-average": 2.1
       },
       {
         "entity_name": "HSD17B3",
-        "llm-average": 3.61
+        "llm-average": 1.8
       }
     ]
   },
@@ -6025,15 +6025,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cytosolic tRNA aminoacylation",
-        "llm-average": 7.4
+        "llm-average": 3.7
       },
       {
         "entity_name": "Protein Synthesis: Arginine",
-        "llm-average": 6.54
+        "llm-average": 3.3
       },
       {
         "entity_name": "Selenoamino acid metabolism",
-        "llm-average": 3.45
+        "llm-average": 1.7
       }
     ]
   },
@@ -6045,15 +6045,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTK7",
-        "llm-average": 14.04
+        "llm-average": 7.0
       },
       {
         "entity_name": "PRKCA",
-        "llm-average": 11.53
+        "llm-average": 5.8
       },
       {
         "entity_name": "TLN2",
-        "llm-average": 7.83
+        "llm-average": 3.9
       }
     ]
   },
@@ -6065,35 +6065,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PSPH",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "PSAT1",
-        "llm-average": 11.74
+        "llm-average": 5.9
       },
       {
         "entity_name": "SLC4A4",
-        "llm-average": 8.85
+        "llm-average": 4.4
       },
       {
         "entity_name": "PGAM1",
-        "llm-average": 6.01
+        "llm-average": 3.0
       },
       {
         "entity_name": "PGAM4",
-        "llm-average": 5.69
+        "llm-average": 2.8
       },
       {
         "entity_name": "BPGM",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "EWSR1",
-        "llm-average": 3.06
+        "llm-average": 1.5
       },
       {
         "entity_name": "PFKFB1",
-        "llm-average": 1.55
+        "llm-average": 0.8
       }
     ]
   },
@@ -6105,15 +6105,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lysosphingolipid and LPA receptors",
-        "llm-average": 13.47
+        "llm-average": 6.7
       },
       {
         "entity_name": "Interleukin-4 and Interleukin-13 signaling",
-        "llm-average": 12.23
+        "llm-average": 6.1
       },
       {
         "entity_name": "Potential therapeutics for SARS",
-        "llm-average": 10.67
+        "llm-average": 5.3
       }
     ]
   },
@@ -6125,15 +6125,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Respiratory electron transport",
-        "llm-average": 14.32
+        "llm-average": 7.2
       },
       {
         "entity_name": "TP53 Regulates Metabolic Genes",
-        "llm-average": 13.78
+        "llm-average": 6.9
       },
       {
         "entity_name": "Cytoprotection by HMOX1",
-        "llm-average": 8.66
+        "llm-average": 4.3
       }
     ]
   },
@@ -6145,11 +6145,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Muscarinic acetylcholine receptors",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -6161,23 +6161,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "purine nucleotide biosynthetic process",
-        "llm-average": 12.0
+        "llm-average": 6.0
       },
       {
         "entity_name": "negative regulation of catalytic activity",
-        "llm-average": 11.28
+        "llm-average": 5.6
       },
       {
         "entity_name": "5-phosphoribose 1-diphosphate biosynthetic process",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "nucleoside metabolic process",
-        "llm-average": 5.76
+        "llm-average": 2.9
       },
       {
         "entity_name": "nucleobase-containing compound metabolic process",
-        "llm-average": 5.0
+        "llm-average": 2.5
       }
     ]
   },
@@ -6189,19 +6189,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Excitatory Neural Signalling Through 5-HTR 4 and Serotonin",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "G alpha (s) signalling events",
-        "llm-average": 11.32
+        "llm-average": 5.7
       },
       {
         "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
-        "llm-average": 10.93
+        "llm-average": 5.5
       },
       {
         "entity_name": "Serotonin receptors",
-        "llm-average": 5.65
+        "llm-average": 2.8
       }
     ]
   },
@@ -6213,11 +6213,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RUNX1 and FOXP3 control the development of regulatory T lymphocytes (Tregs)",
-        "llm-average": 16.75
+        "llm-average": 8.4
       },
       {
         "entity_name": "CTLA4 inhibitory signaling",
-        "llm-average": 12.31
+        "llm-average": 6.2
       }
     ]
   },
@@ -6229,19 +6229,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MECP2 regulates neuronal receptors and channels",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "Nalbuphine Action Pathway",
-        "llm-average": 10.67
+        "llm-average": 5.3
       },
       {
         "entity_name": "Peptide ligand-binding receptors",
-        "llm-average": 8.95
+        "llm-average": 4.5
       }
     ]
   },
@@ -6253,23 +6253,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "peptidyl-methionine modification",
-        "llm-average": 16.13
+        "llm-average": 8.1
       },
       {
         "entity_name": "N-terminal protein amino acid modification",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "co-translational protein modification",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "positive regulation of cell population proliferation",
-        "llm-average": 5.65
+        "llm-average": 2.8
       },
       {
         "entity_name": "translation",
-        "llm-average": 2.92
+        "llm-average": 1.5
       }
     ]
   },
@@ -6281,11 +6281,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Neddylation",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "Antigen processing: Ubiquitination & Proteasome degradation",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -6297,15 +6297,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "2-oxoglutarate metabolic process",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "tricarboxylic acid cycle",
-        "llm-average": 6.76
+        "llm-average": 3.4
       },
       {
         "entity_name": "glycolytic process",
-        "llm-average": 4.47
+        "llm-average": 2.2
       }
     ]
   },
@@ -6317,11 +6317,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Glutamate and glutamine metabolism",
-        "llm-average": 14.84
+        "llm-average": 7.4
       },
       {
         "entity_name": "Transcriptional activation of mitochondrial biogenesis",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -6333,11 +6333,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Class I peroxisomal membrane protein import",
-        "llm-average": 13.47
+        "llm-average": 6.7
       },
       {
         "entity_name": "Alpha-oxidation of phytanate",
-        "llm-average": 12.23
+        "llm-average": 6.1
       }
     ]
   },
@@ -6349,27 +6349,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Amyloid fiber formation",
-        "llm-average": 15.22
+        "llm-average": 7.6
       },
       {
         "entity_name": "The canonical retinoid cycle in rods (twilight vision)",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Retinoid metabolism and transport",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "Retinoid cycle disease events",
-        "llm-average": 9.13
+        "llm-average": 4.6
       },
       {
         "entity_name": "Neutrophil degranulation",
-        "llm-average": 6.98
+        "llm-average": 3.5
       },
       {
         "entity_name": "Non-integrin membrane-ECM interactions",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -6381,11 +6381,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Ca2+ pathway",
-        "llm-average": 13.47
+        "llm-average": 6.7
       },
       {
         "entity_name": "Ion Channels and Their Functional Role in Vascular Endothelium",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -6397,23 +6397,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Formation of xylulose-5-phosphate",
-        "llm-average": 13.29
+        "llm-average": 6.6
       },
       {
         "entity_name": "Fructose biosynthesis",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Fructosuria",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Fructose and Mannose Degradation",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "Fructose Intolerance, Hereditary",
-        "llm-average": 5.89
+        "llm-average": 2.9
       }
     ]
   },
@@ -6425,11 +6425,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CTNNA3",
-        "llm-average": 11.08
+        "llm-average": 5.5
       },
       {
         "entity_name": "LRRK1",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -6441,27 +6441,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tristetraprolin (TTP, ZFP36) binds and destabilizes mRNA",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "Butyrate Response Factor 1 (BRF1) binds and destabilizes mRNA",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "KSRP (KHSRP) binds and destabilizes mRNA",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "mRNA decay by 3' to 5' exoribonuclease",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "ATF4 activates genes in response to endoplasmic reticulum  stress",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "Major pathway of rRNA processing in the nucleolus and cytosol",
-        "llm-average": 4.35
+        "llm-average": 2.2
       }
     ]
   },
@@ -6473,15 +6473,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RA biosynthesis pathway",
-        "llm-average": 15.72
+        "llm-average": 7.9
       },
       {
         "entity_name": "Retinol Metabolism",
-        "llm-average": 12.31
+        "llm-average": 6.2
       },
       {
         "entity_name": "Vitamin A Deficiency",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -6493,35 +6493,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RHOT2",
-        "llm-average": 14.95
+        "llm-average": 7.5
       },
       {
         "entity_name": "RHOT1",
-        "llm-average": 14.75
+        "llm-average": 7.4
       },
       {
         "entity_name": "TTN",
-        "llm-average": 13.21
+        "llm-average": 6.6
       },
       {
         "entity_name": "MYL6B",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "MYL4",
-        "llm-average": 8.03
+        "llm-average": 4.0
       },
       {
         "entity_name": "MYL3",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "MYL1",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "MYL6",
-        "llm-average": 6.22
+        "llm-average": 3.1
       }
     ]
   },
@@ -6533,15 +6533,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TIGIT",
-        "llm-average": 17.08
+        "llm-average": 8.5
       },
       {
         "entity_name": "NECTIN3",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "ITGB3",
-        "llm-average": 9.26
+        "llm-average": 4.6
       }
     ]
   },
@@ -6553,35 +6553,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BACH1",
-        "llm-average": 12.5
+        "llm-average": 6.2
       },
       {
         "entity_name": "MAFG",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "NFE2L2",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "NFE2L1",
-        "llm-average": 10.8
+        "llm-average": 5.4
       },
       {
         "entity_name": "NFE2",
-        "llm-average": 7.51
+        "llm-average": 3.8
       },
       {
         "entity_name": "HBE1",
-        "llm-average": 6.54
+        "llm-average": 3.3
       },
       {
         "entity_name": "HBG2",
-        "llm-average": 3.37
+        "llm-average": 1.7
       },
       {
         "entity_name": "HBD",
-        "llm-average": 3.3
+        "llm-average": 1.7
       }
     ]
   },
@@ -6593,35 +6593,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SCG5",
-        "llm-average": 16.18
+        "llm-average": 8.1
       },
       {
         "entity_name": "RXFP2",
-        "llm-average": 11.25
+        "llm-average": 5.6
       },
       {
         "entity_name": "INS",
-        "llm-average": 10.97
+        "llm-average": 5.5
       },
       {
         "entity_name": "RXFP1",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "LGR5",
-        "llm-average": 8.53
+        "llm-average": 4.3
       },
       {
         "entity_name": "LGR4",
-        "llm-average": 5.76
+        "llm-average": 2.9
       },
       {
         "entity_name": "LGR6",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "FN1",
-        "llm-average": 1.55
+        "llm-average": 0.8
       }
     ]
   },
@@ -6633,27 +6633,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GOT1L1",
-        "llm-average": 16.7
+        "llm-average": 8.3
       },
       {
         "entity_name": "TAT",
-        "llm-average": 9.42
+        "llm-average": 4.7
       },
       {
         "entity_name": "DDO",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "COQ2",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "UPB1",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "GOT1",
-        "llm-average": 5.79
+        "llm-average": 2.9
       }
     ]
   },
@@ -6665,19 +6665,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Detoxification of Reactive Oxygen Species",
-        "llm-average": 17.08
+        "llm-average": 8.5
       },
       {
         "entity_name": "STAT5 activation downstream of FLT3 ITD mutants",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "Signaling by FLT3 fusion proteins",
-        "llm-average": 12.61
+        "llm-average": 6.3
       },
       {
         "entity_name": "Thyroid Hormone Synthesis",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -6689,11 +6689,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Orexin and neuropeptides FF and QRFP bind to their respective receptors",
-        "llm-average": 18.45
+        "llm-average": 9.2
       },
       {
         "entity_name": "G alpha (q) signalling events",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -6705,23 +6705,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RNA catabolic process",
-        "llm-average": 15.48
+        "llm-average": 7.7
       },
       {
         "entity_name": "mismatch repair",
-        "llm-average": 9.73
+        "llm-average": 4.9
       },
       {
         "entity_name": "RNA phosphodiester bond hydrolysis, endonucleolytic",
-        "llm-average": 9.64
+        "llm-average": 4.8
       },
       {
         "entity_name": "DNA replication",
-        "llm-average": 9.14
+        "llm-average": 4.6
       },
       {
         "entity_name": "DNA replication, removal of RNA primer",
-        "llm-average": 4.1
+        "llm-average": 2.1
       }
     ]
   },
@@ -6733,15 +6733,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vitamin D (calciferol) metabolism",
-        "llm-average": 15.54
+        "llm-average": 7.8
       },
       {
         "entity_name": "SUMOylation of intracellular receptors",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "Nuclear Receptor transcription pathway",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -6753,11 +6753,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Peptide ligand-binding receptors",
-        "llm-average": 11.53
+        "llm-average": 5.8
       },
       {
         "entity_name": "G alpha (q) signalling events",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -6769,31 +6769,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "4-Hydroxybutyric Aciduria/Succinic Semialdehyde Dehydrogenase Deficiency",
-        "llm-average": 15.22
+        "llm-average": 7.6
       },
       {
         "entity_name": "Degradation of GABA",
-        "llm-average": 11.1
+        "llm-average": 5.6
       },
       {
         "entity_name": "Succinic Semialdehyde Dehydrogenase Deficiency",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "Homocarnosinosis",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "2-Hydroxyglutric Aciduria (D and L Form)",
-        "llm-average": 8.61
+        "llm-average": 4.3
       },
       {
         "entity_name": "Hyperinsulinism-Hyperammonemia Syndrome",
-        "llm-average": 8.47
+        "llm-average": 4.2
       },
       {
         "entity_name": "Glutamate Metabolism",
-        "llm-average": 6.11
+        "llm-average": 3.1
       }
     ]
   },
@@ -6805,11 +6805,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP4F8",
-        "llm-average": 14.18
+        "llm-average": 7.1
       },
       {
         "entity_name": "CYP4F12",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -6821,23 +6821,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BMAL1:CLOCK,NPAS2 activates circadian gene expression",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "SMAD2/SMAD3:SMAD4 heterotrimer regulates transcription",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "ECM proteoglycans",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "Dissolution of Fibrin Clot",
-        "llm-average": 5.65
+        "llm-average": 2.8
       },
       {
         "entity_name": "Platelet degranulation ",
-        "llm-average": 4.35
+        "llm-average": 2.2
       }
     ]
   },
@@ -6849,11 +6849,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Peptide ligand-binding receptors",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "G alpha (q) signalling events",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -6865,31 +6865,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Antigen Presentation: Folding, assembly and peptide loading of class I MHC",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "Immunoregulatory interactions between a Lymphoid and a non-Lymphoid cell",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "ER-Phagosome pathway",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Endosomal/Vacuolar pathway",
-        "llm-average": 10.34
+        "llm-average": 5.2
       },
       {
         "entity_name": "Interferon gamma signaling",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "Interferon alpha/beta signaling",
-        "llm-average": 4.6
+        "llm-average": 2.3
       },
       {
         "entity_name": "Neutrophil degranulation",
-        "llm-average": 3.49
+        "llm-average": 1.7
       }
     ]
   },
@@ -6901,31 +6901,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Glycosphingolipid metabolism",
-        "llm-average": 16.64
+        "llm-average": 8.3
       },
       {
         "entity_name": "Sphingolipid Metabolism",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "Globoid Cell Leukodystrophy",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "Gaucher Disease",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "Krabbe Disease",
-        "llm-average": 8.73
+        "llm-average": 4.4
       },
       {
         "entity_name": "Metachromatic Leukodystrophy (MLD)",
-        "llm-average": 7.24
+        "llm-average": 3.6
       },
       {
         "entity_name": "Fabry Disease",
-        "llm-average": 5.37
+        "llm-average": 2.7
       }
     ]
   },
@@ -6937,23 +6937,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Defective MTRR causes methylmalonic aciduria and homocystinuria type cblE",
-        "llm-average": 16.13
+        "llm-average": 8.1
       },
       {
         "entity_name": "Defective MTR causes methylmalonic aciduria and homocystinuria type cblG",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Cobalamin (Cbl, vitamin B12) transport and metabolism",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "Sulfur amino acid metabolism",
-        "llm-average": 5.76
+        "llm-average": 2.9
       },
       {
         "entity_name": "Methylation",
-        "llm-average": 4.35
+        "llm-average": 2.2
       }
     ]
   },
@@ -6965,27 +6965,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Synthesis, secretion, and deacylation of Ghrelin",
-        "llm-average": 17.42
+        "llm-average": 8.7
       },
       {
         "entity_name": "Neurotransmitter clearance",
-        "llm-average": 10.63
+        "llm-average": 5.3
       },
       {
         "entity_name": "Heroin Metabolism Pathway",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "Irinotecan Metabolism Pathway",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Irinotecan Action Pathway",
-        "llm-average": 7.05
+        "llm-average": 3.5
       },
       {
         "entity_name": "Synthesis of PC",
-        "llm-average": 6.72
+        "llm-average": 3.4
       }
     ]
   },
@@ -6997,15 +6997,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP2E1 reactions",
-        "llm-average": 9.34
+        "llm-average": 4.7
       },
       {
         "entity_name": "Fatty acids",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "Xenobiotics",
-        "llm-average": 2.28
+        "llm-average": 1.1
       }
     ]
   },
@@ -7017,23 +7017,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAFG",
-        "llm-average": 15.53
+        "llm-average": 7.8
       },
       {
         "entity_name": "TBXAS1",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "CYP17A1",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "CYP21A2",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "CYP2R1",
-        "llm-average": 4.66
+        "llm-average": 2.3
       },
       {
         "entity_name": "INS",
@@ -7049,11 +7049,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hydroxycarboxylic acid-binding receptors",
-        "llm-average": 14.17
+        "llm-average": 7.1
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 7.05
+        "llm-average": 3.5
       }
     ]
   },
@@ -7065,11 +7065,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KDSR",
-        "llm-average": 13.14
+        "llm-average": 6.6
       },
       {
         "entity_name": "ORMDL3",
-        "llm-average": 12.49
+        "llm-average": 6.2
       }
     ]
   },
@@ -7081,27 +7081,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NR1H2 & NR1H3 regulate gene expression linked to lipogenesis",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "ChREBP activates metabolic gene expression",
-        "llm-average": 16.5
+        "llm-average": 8.2
       },
       {
         "entity_name": "Activation of gene expression by SREBF (SREBP)",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "Fatty Acid Biosynthesis",
-        "llm-average": 7.33
+        "llm-average": 3.7
       },
       {
         "entity_name": "Fatty acyl-CoA biosynthesis",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "Vitamin B5 (pantothenate) metabolism",
-        "llm-average": 6.54
+        "llm-average": 3.3
       }
     ]
   },
@@ -7113,23 +7113,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADORA2B mediated anti-inflammatory cytokines production",
-        "llm-average": 16.7
+        "llm-average": 8.3
       },
       {
         "entity_name": "Intracellular Signalling Through Adenosine Receptor A2b and Adenosine",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Adenosine P1 receptors",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "Surfactant metabolism",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "G alpha (s) signalling events",
-        "llm-average": 4.09
+        "llm-average": 2.0
       }
     ]
   },
@@ -7141,27 +7141,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Activation of Matrix Metalloproteinases",
-        "llm-average": 11.22
+        "llm-average": 5.6
       },
       {
         "entity_name": "Basigin interactions",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Regulation of Insulin-like Growth Factor (IGF) transport and uptake by Insulin-like Growth Factor Binding Proteins (IGFBPs)",
-        "llm-average": 9.51
+        "llm-average": 4.8
       },
       {
         "entity_name": "Interleukin-4 and Interleukin-13 signaling",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "Collagen degradation",
-        "llm-average": 9.08
+        "llm-average": 4.5
       },
       {
         "entity_name": "Degradation of the extracellular matrix",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -7173,35 +7173,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PRPSAP1",
-        "llm-average": 17.94
+        "llm-average": 9.0
       },
       {
         "entity_name": "G6PD",
-        "llm-average": 13.8
+        "llm-average": 6.9
       },
       {
         "entity_name": "NUDT5",
-        "llm-average": 13.66
+        "llm-average": 6.8
       },
       {
         "entity_name": "PRPS1L1",
-        "llm-average": 11.09
+        "llm-average": 5.5
       },
       {
         "entity_name": "PGM2",
-        "llm-average": 9.24
+        "llm-average": 4.6
       },
       {
         "entity_name": "H6PD",
-        "llm-average": 8.09
+        "llm-average": 4.0
       },
       {
         "entity_name": "TKT",
-        "llm-average": 8.09
+        "llm-average": 4.0
       },
       {
         "entity_name": "PRPS2",
-        "llm-average": 5.65
+        "llm-average": 2.8
       }
     ]
   },
@@ -7213,11 +7213,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RET signaling",
-        "llm-average": 16.9
+        "llm-average": 8.5
       },
       {
         "entity_name": "RAF/MAP kinase cascade",
-        "llm-average": 8.88
+        "llm-average": 4.4
       }
     ]
   },
@@ -7229,27 +7229,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Amplification  of signal from unattached  kinetochores via a MAD2  inhibitory signal",
-        "llm-average": 17.02
+        "llm-average": 8.5
       },
       {
         "entity_name": "EML4 and NUDC in mitotic spindle formation",
-        "llm-average": 14.28
+        "llm-average": 7.1
       },
       {
         "entity_name": "Separation of Sister Chromatids",
-        "llm-average": 12.11
+        "llm-average": 6.1
       },
       {
         "entity_name": "Mitotic Prometaphase",
-        "llm-average": 10.16
+        "llm-average": 5.1
       },
       {
         "entity_name": "Resolution of Sister Chromatid Cohesion",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "RHO GTPases Activate Formins",
-        "llm-average": 8.47
+        "llm-average": 4.2
       }
     ]
   },
@@ -7261,11 +7261,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cytochrome P450 - arranged by substrate type",
-        "llm-average": 10.17
+        "llm-average": 5.1
       },
       {
         "entity_name": "Doxorubicin Metabolism Pathway",
-        "llm-average": 9.12
+        "llm-average": 4.6
       }
     ]
   },
@@ -7277,19 +7277,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "positive regulation of cold-induced thermogenesis",
-        "llm-average": 17.08
+        "llm-average": 8.5
       },
       {
         "entity_name": "regulation of meiotic nuclear division",
-        "llm-average": 15.48
+        "llm-average": 7.7
       },
       {
         "entity_name": "adenylate cyclase-activating G protein-coupled receptor signaling pathway",
-        "llm-average": 10.17
+        "llm-average": 5.1
       },
       {
         "entity_name": "regulation of metabolic process",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -7301,15 +7301,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Antimicrobial peptides",
-        "llm-average": 15.54
+        "llm-average": 7.8
       },
       {
         "entity_name": "Amyloid fiber formation",
-        "llm-average": 10.67
+        "llm-average": 5.3
       },
       {
         "entity_name": "Neutrophil degranulation",
-        "llm-average": 10.17
+        "llm-average": 5.1
       }
     ]
   },
@@ -7321,19 +7321,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "extracellular matrix disassembly",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "positive regulation of antibacterial peptide production",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "epidermis development",
-        "llm-average": 11.19
+        "llm-average": 5.6
       },
       {
         "entity_name": "proteolysis",
-        "llm-average": 3.7
+        "llm-average": 1.8
       }
     ]
   },
@@ -7345,15 +7345,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PCTP",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "CETP",
-        "llm-average": 11.42
+        "llm-average": 5.7
       },
       {
         "entity_name": "APOA1",
-        "llm-average": 10.73
+        "llm-average": 5.4
       }
     ]
   },
@@ -7365,15 +7365,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC3A1",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "AMY2B",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "SLC3A2",
-        "llm-average": 9.99
+        "llm-average": 5.0
       }
     ]
   },
@@ -7385,23 +7385,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MT-CYB",
-        "llm-average": 15.52
+        "llm-average": 7.8
       },
       {
         "entity_name": "TMBIM6",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "SUPV3L1",
-        "llm-average": 13.92
+        "llm-average": 7.0
       },
       {
         "entity_name": "YARS2",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "REN",
-        "llm-average": 7.5
+        "llm-average": 3.7
       }
     ]
   },
@@ -7413,27 +7413,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TYW1",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "NDOR1",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "MTRR",
-        "llm-average": 11.42
+        "llm-average": 5.7
       },
       {
         "entity_name": "NOS2",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "NOS3",
-        "llm-average": 9.48
+        "llm-average": 4.7
       },
       {
         "entity_name": "POR",
-        "llm-average": 8.92
+        "llm-average": 4.5
       }
     ]
   },
@@ -7445,11 +7445,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "adenosine A3 receptor",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "serpin family F member 1",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -7461,15 +7461,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC35B2",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "CA2",
-        "llm-average": 12.53
+        "llm-average": 6.3
       },
       {
         "entity_name": "DSG1",
-        "llm-average": 12.14
+        "llm-average": 6.1
       }
     ]
   },
@@ -7481,35 +7481,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PHEX",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "OPRD1",
-        "llm-average": 10.55
+        "llm-average": 5.3
       },
       {
         "entity_name": "ECEL1",
-        "llm-average": 10.32
+        "llm-average": 5.2
       },
       {
         "entity_name": "OPRM1",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "KEL",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "MMEL1",
-        "llm-average": 8.9
+        "llm-average": 4.4
       },
       {
         "entity_name": "ECE1",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "ACE",
-        "llm-average": 6.26
+        "llm-average": 3.1
       }
     ]
   },
@@ -7521,19 +7521,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cyclin dependent kinase 5",
-        "llm-average": 14.1
+        "llm-average": 7.0
       },
       {
         "entity_name": "glycogen synthase kinase 3 alpha",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "cyclin dependent kinase 2",
-        "llm-average": 11.45
+        "llm-average": 5.7
       },
       {
         "entity_name": "cyclin dependent kinase 1",
-        "llm-average": 11.28
+        "llm-average": 5.6
       }
     ]
   },
@@ -7545,19 +7545,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CTSL",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "CTSK",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "CTSS",
-        "llm-average": 13.23
+        "llm-average": 6.6
       },
       {
         "entity_name": "CAPN2",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -7569,31 +7569,31 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LCK proto-oncogene, Src family tyrosine kinase",
-        "llm-average": 16.26
+        "llm-average": 8.1
       },
       {
         "entity_name": "LYN proto-oncogene, Src family tyrosine kinase",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "YES proto-oncogene 1, Src family tyrosine kinase",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "aurora kinase C",
-        "llm-average": 13.9
+        "llm-average": 6.9
       },
       {
         "entity_name": "SRC proto-oncogene, non-receptor tyrosine kinase",
-        "llm-average": 13.23
+        "llm-average": 6.6
       },
       {
         "entity_name": "BR serine/threonine kinase 2",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "aurora kinase B",
-        "llm-average": 11.76
+        "llm-average": 5.9
       }
     ]
   },
@@ -7605,11 +7605,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LACTBL1",
-        "llm-average": 14.97
+        "llm-average": 7.5
       },
       {
         "entity_name": "LACTB",
-        "llm-average": 12.14
+        "llm-average": 6.1
       }
     ]
   },
@@ -7621,27 +7621,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "checkpoint kinase 1",
-        "llm-average": 18.03
+        "llm-average": 9.0
       },
       {
         "entity_name": "Rho associated coiled-coil containing protein kinase 1",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "MAPK activated protein kinase 2",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "ribosomal protein S6 kinase A1",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "casein kinase 1 gamma 1",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "protein kinase cAMP-dependent type II regulatory subunit beta",
-        "llm-average": 9.28
+        "llm-average": 4.6
       }
     ]
   },
@@ -7653,23 +7653,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 4",
-        "llm-average": 10.0
+        "llm-average": 5.0
       },
       {
         "entity_name": "cholinergic receptor muscarinic 5",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "cholinergic receptor muscarinic 2",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "cholinergic receptor muscarinic 3",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -7681,27 +7681,27 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ERCC1",
-        "llm-average": 14.31
+        "llm-average": 7.2
       },
       {
         "entity_name": "BNIP3",
-        "llm-average": 13.18
+        "llm-average": 6.6
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "MFSD9",
-        "llm-average": 9.96
+        "llm-average": 5.0
       },
       {
         "entity_name": "SPP1",
-        "llm-average": 9.27
+        "llm-average": 4.6
       },
       {
         "entity_name": "MFSD10",
-        "llm-average": 8.35
+        "llm-average": 4.2
       }
     ]
   },
@@ -7713,11 +7713,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TLR7",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "PTGES2",
-        "llm-average": 8.22
+        "llm-average": 4.1
       }
     ]
   },
@@ -7729,11 +7729,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SGK1",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "ITGB4",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -7745,11 +7745,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CD163",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "MAEA",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -7761,15 +7761,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CETP",
-        "llm-average": 13.02
+        "llm-average": 6.5
       },
       {
         "entity_name": "APOA1",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "PCTP",
-        "llm-average": 9.99
+        "llm-average": 5.0
       }
     ]
   },
@@ -7781,19 +7781,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Isoflurane",
-        "llm-average": 10.58
+        "llm-average": 5.3
       },
       {
         "entity_name": "Sevoflurane",
-        "llm-average": 10.42
+        "llm-average": 5.2
       },
       {
         "entity_name": "Desflurane",
-        "llm-average": 10.32
+        "llm-average": 5.2
       },
       {
         "entity_name": "Enflurane",
-        "llm-average": 10.22
+        "llm-average": 5.1
       }
     ]
   },
@@ -7805,15 +7805,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "D-1,4-dithiothreitol",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Dithioerythritol",
-        "llm-average": 5.55
+        "llm-average": 2.8
       },
       {
         "entity_name": "1,4-Dithiothreitol",
-        "llm-average": 5.45
+        "llm-average": 2.7
       }
     ]
   },
@@ -7825,15 +7825,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Carbenoxolone",
-        "llm-average": 15.44
+        "llm-average": 7.7
       },
       {
         "entity_name": "Caprylic alcohol",
-        "llm-average": 13.72
+        "llm-average": 6.9
       },
       {
         "entity_name": "Flufenamic acid",
-        "llm-average": 12.34
+        "llm-average": 6.2
       }
     ]
   },
@@ -7845,19 +7845,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Methyl alpha-D-mannoside",
-        "llm-average": 9.24
+        "llm-average": 4.6
       },
       {
         "entity_name": "Methyl alpha-galactoside",
-        "llm-average": 7.3
+        "llm-average": 3.6
       },
       {
         "entity_name": "methyl beta-D-glucopyranoside",
-        "llm-average": 5.81
+        "llm-average": 2.9
       },
       {
         "entity_name": "Methyl beta-galactoside",
-        "llm-average": 5.71
+        "llm-average": 2.9
       }
     ]
   },
@@ -7869,15 +7869,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Miglitol",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Acarbose",
-        "llm-average": 8.75
+        "llm-average": 4.4
       },
       {
         "entity_name": "Voglibose",
-        "llm-average": 7.35
+        "llm-average": 3.7
       }
     ]
   },
@@ -7889,35 +7889,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Raloxifene",
-        "llm-average": 13.07
+        "llm-average": 6.5
       },
       {
         "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
-        "llm-average": 11.25
+        "llm-average": 5.6
       },
       {
         "entity_name": "Phylloquinone",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "alpha-N-Acetyl-D-galactosamine",
-        "llm-average": 9.18
+        "llm-average": 4.6
       },
       {
         "entity_name": "N-acetyl-alpha-D-glucosamine",
-        "llm-average": 8.94
+        "llm-average": 4.5
       },
       {
         "entity_name": "5beta-dihydrotestosterone",
-        "llm-average": 5.94
+        "llm-average": 3.0
       },
       {
         "entity_name": "Stanolone",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 2.71
+        "llm-average": 1.4
       }
     ]
   },
@@ -7929,15 +7929,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Flufenamic acid",
-        "llm-average": 16.54
+        "llm-average": 8.3
       },
       {
         "entity_name": "Carbenoxolone",
-        "llm-average": 15.04
+        "llm-average": 7.5
       },
       {
         "entity_name": "Caprylic alcohol",
-        "llm-average": 10.49
+        "llm-average": 5.2
       }
     ]
   },
@@ -7949,35 +7949,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N-acetyl-alpha-D-glucosamine",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "2-acetylamino-2-deoxy-b-D-allopyranose",
-        "llm-average": 13.66
+        "llm-average": 6.8
       },
       {
         "entity_name": "alpha-D-quinovopyranose",
-        "llm-average": 13.29
+        "llm-average": 6.6
       },
       {
         "entity_name": "alpha-N-Acetyl-D-galactosamine",
-        "llm-average": 12.5
+        "llm-average": 6.2
       },
       {
         "entity_name": "alpha-D-Fucopyranose",
-        "llm-average": 10.55
+        "llm-average": 5.3
       },
       {
         "entity_name": "alpha-L-fucose",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "beta-D-fucose",
-        "llm-average": 9.3
+        "llm-average": 4.6
       },
       {
         "entity_name": "beta-L-fucose",
-        "llm-average": 7.98
+        "llm-average": 4.0
       }
     ]
   },
@@ -7989,23 +7989,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vorinostat",
-        "llm-average": 16.54
+        "llm-average": 8.3
       },
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 15.77
+        "llm-average": 7.9
       },
       {
         "entity_name": "Colistimethate",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "D-tartaric acid",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "N,N-dimethylformamide",
-        "llm-average": 5.08
+        "llm-average": 2.5
       }
     ]
   },
@@ -8017,35 +8017,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Y-27632",
-        "llm-average": 17.92
+        "llm-average": 9.0
       },
       {
         "entity_name": "Quercetin",
-        "llm-average": 11.49
+        "llm-average": 5.7
       },
       {
         "entity_name": "S-Hydroxycysteine",
-        "llm-average": 10.95
+        "llm-average": 5.5
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.7
+        "llm-average": 5.3
       },
       {
         "entity_name": "Kojic acid",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "Dodecyldimethylamine N-oxide",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Mercaptoethanol",
-        "llm-average": 5.41
+        "llm-average": 2.7
       },
       {
         "entity_name": "D-tartaric acid",
-        "llm-average": 4.25
+        "llm-average": 2.1
       }
     ]
   },
@@ -8057,23 +8057,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "adhesion G protein-coupled receptor B1",
-        "llm-average": 12.28
+        "llm-average": 6.1
       },
       {
         "entity_name": "glutamate metabotropic receptor 8",
-        "llm-average": 7.03
+        "llm-average": 3.5
       },
       {
         "entity_name": "glutamate metabotropic receptor 4",
-        "llm-average": 5.81
+        "llm-average": 2.9
       },
       {
         "entity_name": "glutamate metabotropic receptor 7",
-        "llm-average": 5.74
+        "llm-average": 2.9
       },
       {
         "entity_name": "glutamate metabotropic receptor 6",
-        "llm-average": 4.46
+        "llm-average": 2.2
       }
     ]
   },
@@ -8085,15 +8085,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
-        "llm-average": 11.65
+        "llm-average": 5.8
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
-        "llm-average": 10.89
+        "llm-average": 5.4
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
-        "llm-average": 8.02
+        "llm-average": 4.0
       }
     ]
   },
@@ -8105,23 +8105,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 4",
-        "llm-average": 5.87
+        "llm-average": 2.9
       },
       {
         "entity_name": "cholinergic receptor muscarinic 5",
-        "llm-average": 5.15
+        "llm-average": 2.6
       },
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 2.34
+        "llm-average": 1.2
       },
       {
         "entity_name": "cholinergic receptor muscarinic 3",
-        "llm-average": 1.78
+        "llm-average": 0.9
       },
       {
         "entity_name": "cholinergic receptor muscarinic 2",
-        "llm-average": 1.62
+        "llm-average": 0.8
       }
     ]
   },
@@ -8133,15 +8133,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "free fatty acid receptor 1",
-        "llm-average": 12.57
+        "llm-average": 6.3
       },
       {
         "entity_name": "dopamine receptor D5",
-        "llm-average": 5.08
+        "llm-average": 2.5
       },
       {
         "entity_name": "dopamine receptor D1",
-        "llm-average": 2.34
+        "llm-average": 1.2
       }
     ]
   },
@@ -8153,19 +8153,19 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "adenylate cyclase 1",
-        "llm-average": 10.3
+        "llm-average": 5.1
       },
       {
         "entity_name": "galanin receptor 3",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "galanin receptor 1",
-        "llm-average": 6.93
+        "llm-average": 3.5
       },
       {
         "entity_name": "galanin receptor 2",
-        "llm-average": 6.9
+        "llm-average": 3.4
       }
     ]
   },
@@ -8177,11 +8177,11 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "mRNA Editing: C to U Conversion",
-        "llm-average": 12.05
+        "llm-average": 6.0
       },
       {
         "entity_name": "Formation of the Editosome",
-        "llm-average": 10.5
+        "llm-average": 5.2
       }
     ]
   },
@@ -8193,15 +8193,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cyclin dependent kinase 1",
-        "llm-average": 9.01
+        "llm-average": 4.5
       },
       {
         "entity_name": "cyclin dependent kinase 2",
-        "llm-average": 8.38
+        "llm-average": 4.2
       },
       {
         "entity_name": "fms related receptor tyrosine kinase 1",
-        "llm-average": 8.02
+        "llm-average": 4.0
       }
     ]
   },
@@ -8213,23 +8213,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 4",
-        "llm-average": 10.13
+        "llm-average": 5.1
       },
       {
         "entity_name": "cholinergic receptor muscarinic 5",
-        "llm-average": 8.61
+        "llm-average": 4.3
       },
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 6.2
+        "llm-average": 3.1
       },
       {
         "entity_name": "cholinergic receptor muscarinic 2",
-        "llm-average": 4.69
+        "llm-average": 2.3
       },
       {
         "entity_name": "cholinergic receptor muscarinic 3",
-        "llm-average": 4.46
+        "llm-average": 2.2
       }
     ]
   },
@@ -8241,15 +8241,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
-        "llm-average": 11.65
+        "llm-average": 5.8
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
-        "llm-average": 10.89
+        "llm-average": 5.4
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
-        "llm-average": 8.02
+        "llm-average": 4.0
       }
     ]
   },
@@ -8261,15 +8261,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 19 subfamily A member 1",
-        "llm-average": 12.18
+        "llm-average": 6.1
       },
       {
         "entity_name": "cytochrome P450 family 3 subfamily A member 5",
-        "llm-average": 9.31
+        "llm-average": 4.7
       },
       {
         "entity_name": "cytochrome P450 family 1 subfamily B member 1",
-        "llm-average": 6.44
+        "llm-average": 3.2
       }
     ]
   },
@@ -8281,15 +8281,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cyclin dependent kinase 2",
-        "llm-average": 6.9
+        "llm-average": 3.4
       },
       {
         "entity_name": "fms related receptor tyrosine kinase 1",
-        "llm-average": 6.44
+        "llm-average": 3.2
       },
       {
         "entity_name": "cyclin dependent kinase 1",
-        "llm-average": 6.04
+        "llm-average": 3.0
       }
     ]
   },
@@ -8301,15 +8301,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
-        "llm-average": 15.12
+        "llm-average": 7.6
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
-        "llm-average": 10.5
+        "llm-average": 5.2
       }
     ]
   },
@@ -8321,15 +8321,15 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 19 subfamily A member 1",
-        "llm-average": 14.26
+        "llm-average": 7.1
       },
       {
         "entity_name": "cytochrome P450 family 3 subfamily A member 5",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "cytochrome P450 family 1 subfamily B member 1",
-        "llm-average": 10.5
+        "llm-average": 5.2
       }
     ]
   },
@@ -8341,23 +8341,23 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 4",
-        "llm-average": 10.13
+        "llm-average": 5.1
       },
       {
         "entity_name": "cholinergic receptor muscarinic 5",
-        "llm-average": 8.61
+        "llm-average": 4.3
       },
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 6.2
+        "llm-average": 3.1
       },
       {
         "entity_name": "cholinergic receptor muscarinic 2",
-        "llm-average": 4.69
+        "llm-average": 2.3
       },
       {
         "entity_name": "cholinergic receptor muscarinic 3",
-        "llm-average": 4.46
+        "llm-average": 2.2
       }
     ]
   },
@@ -8369,35 +8369,35 @@ export const batch3: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "free fatty acid receptor 2",
-        "llm-average": 17.33
+        "llm-average": 8.7
       },
       {
         "entity_name": "hydroxycarboxylic acid receptor 2",
-        "llm-average": 15.91
+        "llm-average": 8.0
       },
       {
         "entity_name": "5-hydroxytryptamine receptor 5A",
-        "llm-average": 14.13
+        "llm-average": 7.1
       },
       {
         "entity_name": "histone deacetylase 1",
-        "llm-average": 10.5
+        "llm-average": 5.2
       },
       {
         "entity_name": "histone deacetylase 2",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "histone deacetylase 3",
-        "llm-average": 8.09
+        "llm-average": 4.0
       },
       {
         "entity_name": "adenosine deaminase RNA specific B2 (inactive)",
-        "llm-average": 8.02
+        "llm-average": 4.0
       },
       {
         "entity_name": "histone deacetylase 8",
-        "llm-average": 6.17
+        "llm-average": 3.1
       }
     ]
   }

--- a/lib/batches/batch4.ts
+++ b/lib/batches/batch4.ts
@@ -9,19 +9,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2L1",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "LTB4R2",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "SCLT1",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "MAX",
-        "llm-average": 11.63
+        "llm-average": 5.8
       }
     ]
   },
@@ -33,11 +33,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATM",
-        "llm-average": 13.59
+        "llm-average": 6.8
       },
       {
         "entity_name": "TRIM28",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -49,19 +49,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Propylthiouracil",
-        "llm-average": 12.29
+        "llm-average": 6.1
       },
       {
         "entity_name": "Methimazole",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Carbimazole",
-        "llm-average": 9.67
+        "llm-average": 4.8
       },
       {
         "entity_name": "Tretinoin",
-        "llm-average": 9.02
+        "llm-average": 4.5
       }
     ]
   },
@@ -73,35 +73,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Paclitaxel",
-        "llm-average": 17.65
+        "llm-average": 8.8
       },
       {
         "entity_name": "Mitomycin",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Butyric Acid",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Dithioerythritol",
-        "llm-average": 5.1
+        "llm-average": 2.5
       },
       {
         "entity_name": "1,4-Dithiothreitol",
-        "llm-average": 4.97
+        "llm-average": 2.5
       },
       {
         "entity_name": "D-1,4-dithiothreitol",
-        "llm-average": 3.4
+        "llm-average": 1.7
       },
       {
         "entity_name": "Beta-D-Fructopyranose",
-        "llm-average": 2.88
+        "llm-average": 1.4
       }
     ]
   },
@@ -113,35 +113,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HGF",
-        "llm-average": 13.07
+        "llm-average": 6.5
       },
       {
         "entity_name": "LGALS1",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "C5",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "SERPINE1",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "CHRD",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "TGFB1",
-        "llm-average": 11.24
+        "llm-average": 5.6
       },
       {
         "entity_name": "TIMP1",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "LAMB1",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -153,15 +153,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "F2R",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "F2RL2",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "F2RL3",
-        "llm-average": 10.2
+        "llm-average": 5.1
       }
     ]
   },
@@ -173,15 +173,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vincristine",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -193,11 +193,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SGTA",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "HAT1",
-        "llm-average": 12.03
+        "llm-average": 6.0
       }
     ]
   },
@@ -209,27 +209,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TGFBR2",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "CHD4",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "CDH1",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "JPH3",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "COPS5",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "NEK7",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -241,11 +241,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TIMP3",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "AGT",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -257,11 +257,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lithium",
-        "llm-average": 4.58
+        "llm-average": 2.3
       },
       {
         "entity_name": "Sodium",
-        "llm-average": 2.35
+        "llm-average": 1.2
       }
     ]
   },
@@ -273,15 +273,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SCIMP",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "CD53",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "CD37",
-        "llm-average": 12.16
+        "llm-average": 6.1
       }
     ]
   },
@@ -293,11 +293,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CUL5",
-        "llm-average": 18.82
+        "llm-average": 9.4
       },
       {
         "entity_name": "WFDC1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       }
     ]
   },
@@ -309,11 +309,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PLEKHA7",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "YWHAE",
-        "llm-average": 12.42
+        "llm-average": 6.2
       }
     ]
   },
@@ -325,19 +325,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "D-Tyrosine",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Tyrosine",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "Furosemide",
-        "llm-average": 7.06
+        "llm-average": 3.5
       },
       {
         "entity_name": "Chlorothiazide",
-        "llm-average": 6.54
+        "llm-average": 3.3
       }
     ]
   },
@@ -349,15 +349,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 16.08
+        "llm-average": 8.0
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "Formaldehyde",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -369,35 +369,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "POLE3",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "POLE",
-        "llm-average": 18.17
+        "llm-average": 9.1
       },
       {
         "entity_name": "POLE2",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "QTRT1",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "RPS27",
-        "llm-average": 9.15
+        "llm-average": 4.6
       },
       {
         "entity_name": "NFYB",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "ARL4C",
-        "llm-average": 7.32
+        "llm-average": 3.7
       },
       {
         "entity_name": "FXYD1",
-        "llm-average": 5.62
+        "llm-average": 2.8
       }
     ]
   },
@@ -409,15 +409,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Quercetin",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -429,11 +429,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Irinotecan",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Paclitaxel",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -445,35 +445,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "D-arginine",
-        "llm-average": 10.85
+        "llm-average": 5.4
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Phosphoaminophosphonic Acid-Adenylate Ester",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "ATP",
-        "llm-average": 7.19
+        "llm-average": 3.6
       },
       {
         "entity_name": "Adenosine phosphate",
-        "llm-average": 5.75
+        "llm-average": 2.9
       },
       {
         "entity_name": "Pyrophosphoric acid",
-        "llm-average": 4.71
+        "llm-average": 2.4
       },
       {
         "entity_name": "Arginine",
-        "llm-average": 3.53
+        "llm-average": 1.8
       }
     ]
   },
@@ -485,11 +485,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "spermatogenesis associated 12",
-        "llm-average": 5.75
+        "llm-average": 2.9
       },
       {
         "entity_name": "spermatogenesis-associated protein 12",
-        "llm-average": 5.1
+        "llm-average": 2.5
       }
     ]
   },
@@ -501,35 +501,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Abametapir",
-        "llm-average": 17.52
+        "llm-average": 8.8
       },
       {
         "entity_name": "Ritonavir",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Cenobamate",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "Tucatinib",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Satralizumab",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "Pitolisant",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "Metreleptin",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "Haloperidol",
-        "llm-average": 4.44
+        "llm-average": 2.2
       }
     ]
   },
@@ -541,15 +541,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Plerixafor",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Trichostatin A",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -561,11 +561,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAGE family member A2B",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "MAGE family member A2",
-        "llm-average": 14.51
+        "llm-average": 7.3
       }
     ]
   },
@@ -577,11 +577,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Coenzyme A",
-        "llm-average": 8.5
+        "llm-average": 4.2
       },
       {
         "entity_name": "Vitamin E",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -593,11 +593,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Glutathione disulfide",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Sucrose",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -609,23 +609,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Rifaximin",
-        "llm-average": 12.54
+        "llm-average": 6.3
       },
       {
         "entity_name": "Neomycin",
-        "llm-average": 9.08
+        "llm-average": 4.5
       },
       {
         "entity_name": "Omeprazole",
-        "llm-average": 8.73
+        "llm-average": 4.4
       },
       {
         "entity_name": "Framycetin",
-        "llm-average": 8.56
+        "llm-average": 4.3
       },
       {
         "entity_name": "Lactulose",
-        "llm-average": 6.23
+        "llm-average": 3.1
       }
     ]
   },
@@ -637,11 +637,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Modafinil",
-        "llm-average": 17.44
+        "llm-average": 8.7
       },
       {
         "entity_name": "Lorazepam",
-        "llm-average": 6.51
+        "llm-average": 3.3
       }
     ]
   },
@@ -653,15 +653,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Clomifene",
-        "llm-average": 16.47
+        "llm-average": 8.2
       },
       {
         "entity_name": "Metronidazole",
-        "llm-average": 12.54
+        "llm-average": 6.3
       },
       {
         "entity_name": "Carmustine",
-        "llm-average": 11.41
+        "llm-average": 5.7
       }
     ]
   },
@@ -673,31 +673,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Mifepristone",
-        "llm-average": 14.19
+        "llm-average": 7.1
       },
       {
         "entity_name": "Felbamate",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "Paliperidone",
-        "llm-average": 5.42
+        "llm-average": 2.7
       },
       {
         "entity_name": "Citalopram",
-        "llm-average": 5.18
+        "llm-average": 2.6
       },
       {
         "entity_name": "Escitalopram",
-        "llm-average": 4.36
+        "llm-average": 2.2
       },
       {
         "entity_name": "Risperidone",
-        "llm-average": 4.19
+        "llm-average": 2.1
       },
       {
         "entity_name": "Cetirizine",
-        "llm-average": 1.73
+        "llm-average": 0.9
       },
       {
         "entity_name": "Bisoprolol",
@@ -713,11 +713,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.39
+        "llm-average": 5.2
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.92
+        "llm-average": 2.5
       }
     ]
   },
@@ -729,35 +729,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PPARG",
-        "llm-average": 16.13
+        "llm-average": 8.1
       },
       {
         "entity_name": "SFPQ",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "EGR1",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "YY1",
-        "llm-average": 12.31
+        "llm-average": 6.2
       },
       {
         "entity_name": "CBX2",
-        "llm-average": 11.56
+        "llm-average": 5.8
       },
       {
         "entity_name": "JUN",
-        "llm-average": 9.87
+        "llm-average": 4.9
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.44
+        "llm-average": 4.2
       },
       {
         "entity_name": "H3-2",
-        "llm-average": 5.92
+        "llm-average": 3.0
       }
     ]
   },
@@ -769,11 +769,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DBN1",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "CAPZA2",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -785,31 +785,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PRKAR2B",
-        "llm-average": 19.42
+        "llm-average": 9.7
       },
       {
         "entity_name": "DNMT1",
-        "llm-average": 15.61
+        "llm-average": 7.8
       },
       {
         "entity_name": "PARP1",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "BUB1B",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "NUP50",
-        "llm-average": 11.54
+        "llm-average": 5.8
       },
       {
         "entity_name": "CCNA2",
-        "llm-average": 11.1
+        "llm-average": 5.5
       },
       {
         "entity_name": "MAD2L1",
-        "llm-average": 10.37
+        "llm-average": 5.2
       }
     ]
   },
@@ -821,19 +821,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RERG",
-        "llm-average": 15.28
+        "llm-average": 7.6
       },
       {
         "entity_name": "IGF1R",
-        "llm-average": 14.56
+        "llm-average": 7.3
       },
       {
         "entity_name": "RAF1",
-        "llm-average": 12.83
+        "llm-average": 6.4
       },
       {
         "entity_name": "KRAS",
-        "llm-average": 8.04
+        "llm-average": 4.0
       }
     ]
   },
@@ -845,15 +845,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OTUD6B",
-        "llm-average": 15.24
+        "llm-average": 7.6
       },
       {
         "entity_name": "PLEKHA7",
-        "llm-average": 12.28
+        "llm-average": 6.1
       },
       {
         "entity_name": "KLHL15",
-        "llm-average": 10.41
+        "llm-average": 5.2
       }
     ]
   },
@@ -865,11 +865,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PLXNA2",
-        "llm-average": 14.1
+        "llm-average": 7.1
       },
       {
         "entity_name": "DLG4",
-        "llm-average": 14.09
+        "llm-average": 7.0
       }
     ]
   },
@@ -881,11 +881,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DNMT1",
-        "llm-average": 12.28
+        "llm-average": 6.1
       },
       {
         "entity_name": "MAD2L1",
-        "llm-average": 10.41
+        "llm-average": 5.2
       }
     ]
   },
@@ -897,11 +897,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRIM41",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "RNF114",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -913,11 +913,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RBM8A",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "ZNF408",
-        "llm-average": 14.09
+        "llm-average": 7.0
       }
     ]
   },
@@ -929,11 +929,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ZNRF1",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "TSEN15",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -945,23 +945,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OSM",
-        "llm-average": 17.59
+        "llm-average": 8.8
       },
       {
         "entity_name": "PRL",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "EGF",
-        "llm-average": 10.09
+        "llm-average": 5.0
       },
       {
         "entity_name": "CSF3",
-        "llm-average": 8.31
+        "llm-average": 4.2
       },
       {
         "entity_name": "IL3",
-        "llm-average": 4.03
+        "llm-average": 2.0
       }
     ]
   },
@@ -973,11 +973,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CROCC",
-        "llm-average": 15.4
+        "llm-average": 7.7
       },
       {
         "entity_name": "CCDC102B",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -989,11 +989,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Acetic acid",
-        "llm-average": 8.19
+        "llm-average": 4.1
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 4.03
+        "llm-average": 2.0
       }
     ]
   },
@@ -1005,11 +1005,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IGLL1",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "JCHAIN",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -1021,15 +1021,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CEACAM5",
-        "llm-average": 17.05
+        "llm-average": 8.5
       },
       {
         "entity_name": "CNTN4",
-        "llm-average": 13.24
+        "llm-average": 6.6
       },
       {
         "entity_name": "CD52",
-        "llm-average": 12.83
+        "llm-average": 6.4
       }
     ]
   },
@@ -1041,15 +1041,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "Sulindac",
-        "llm-average": 10.15
+        "llm-average": 5.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 9.04
+        "llm-average": 4.5
       }
     ]
   },
@@ -1061,11 +1061,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "STAT2",
-        "llm-average": 11.68
+        "llm-average": 5.8
       },
       {
         "entity_name": "ZNF521",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -1077,11 +1077,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.2
+        "llm-average": 6.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 10.32
+        "llm-average": 5.2
       }
     ]
   },
@@ -1093,11 +1093,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CUL3",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "CUL1",
-        "llm-average": 7.95
+        "llm-average": 4.0
       }
     ]
   },
@@ -1109,19 +1109,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Troglitazone",
-        "llm-average": 18.87
+        "llm-average": 9.4
       },
       {
         "entity_name": "Resveratrol",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 12.67
+        "llm-average": 6.3
       },
       {
         "entity_name": "Enalapril",
-        "llm-average": 10.37
+        "llm-average": 5.2
       }
     ]
   },
@@ -1133,19 +1133,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPAR1",
-        "llm-average": 14.92
+        "llm-average": 7.5
       },
       {
         "entity_name": "SLC22A9",
-        "llm-average": 13.3
+        "llm-average": 6.6
       },
       {
         "entity_name": "CD79A",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "SSMEM1",
-        "llm-average": 9.61
+        "llm-average": 4.8
       }
     ]
   },
@@ -1157,11 +1157,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ITGA9",
-        "llm-average": 15.92
+        "llm-average": 8.0
       },
       {
         "entity_name": "VEGFD",
-        "llm-average": 13.11
+        "llm-average": 6.6
       }
     ]
   },
@@ -1173,27 +1173,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ROGDI",
-        "llm-average": 13.35
+        "llm-average": 6.7
       },
       {
         "entity_name": "CAPN7",
-        "llm-average": 12.33
+        "llm-average": 6.2
       },
       {
         "entity_name": "DAXX",
-        "llm-average": 12.2
+        "llm-average": 6.1
       },
       {
         "entity_name": "TSG101",
-        "llm-average": 11.99
+        "llm-average": 6.0
       },
       {
         "entity_name": "TBC1D22B",
-        "llm-average": 7.92
+        "llm-average": 4.0
       },
       {
         "entity_name": "POLR3C",
-        "llm-average": 6.81
+        "llm-average": 3.4
       }
     ]
   },
@@ -1205,15 +1205,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RAB5C",
-        "llm-average": 12.21
+        "llm-average": 6.1
       },
       {
         "entity_name": "XRCC5",
-        "llm-average": 9.54
+        "llm-average": 4.8
       },
       {
         "entity_name": "CLTC",
-        "llm-average": 7.76
+        "llm-average": 3.9
       }
     ]
   },
@@ -1225,15 +1225,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Conjugated estrogens",
-        "llm-average": 7.98
+        "llm-average": 4.0
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 6.91
+        "llm-average": 3.5
       },
       {
         "entity_name": "Estrone sulfate",
-        "llm-average": 6.45
+        "llm-average": 3.2
       }
     ]
   },
@@ -1245,31 +1245,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NCAN",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "CSPG4",
-        "llm-average": 14.09
+        "llm-average": 7.0
       },
       {
         "entity_name": "VCAN",
-        "llm-average": 12.61
+        "llm-average": 6.3
       },
       {
         "entity_name": "HMOX1",
-        "llm-average": 11.34
+        "llm-average": 5.7
       },
       {
         "entity_name": "BCAN",
-        "llm-average": 11.03
+        "llm-average": 5.5
       },
       {
         "entity_name": "BGN",
-        "llm-average": 7.43
+        "llm-average": 3.7
       },
       {
         "entity_name": "DCN",
-        "llm-average": 6.31
+        "llm-average": 3.2
       }
     ]
   },
@@ -1281,19 +1281,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RTP4",
-        "llm-average": 12.28
+        "llm-average": 6.1
       },
       {
         "entity_name": "GNGT1",
-        "llm-average": 11.61
+        "llm-average": 5.8
       },
       {
         "entity_name": "GNG13",
-        "llm-average": 10.41
+        "llm-average": 5.2
       },
       {
         "entity_name": "RTP3",
-        "llm-average": 10.37
+        "llm-average": 5.2
       }
     ]
   },
@@ -1305,11 +1305,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BEST1",
-        "llm-average": 17.05
+        "llm-average": 8.5
       },
       {
         "entity_name": "GLRA2",
-        "llm-average": 15.6
+        "llm-average": 7.8
       }
     ]
   },
@@ -1321,11 +1321,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "F2RL3",
-        "llm-average": 15.6
+        "llm-average": 7.8
       },
       {
         "entity_name": "F2R",
-        "llm-average": 15.4
+        "llm-average": 7.7
       }
     ]
   },
@@ -1337,11 +1337,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBX2",
-        "llm-average": 17.05
+        "llm-average": 8.5
       },
       {
         "entity_name": "YY1",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -1353,31 +1353,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KAT2B",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "KAT2A",
-        "llm-average": 13.76
+        "llm-average": 6.9
       },
       {
         "entity_name": "DNMT1",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "EP300",
-        "llm-average": 12.84
+        "llm-average": 6.4
       },
       {
         "entity_name": "TP53",
-        "llm-average": 12.82
+        "llm-average": 6.4
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "H3-2",
-        "llm-average": 6.79
+        "llm-average": 3.4
       }
     ]
   },
@@ -1389,19 +1389,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CETP",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "PON1",
-        "llm-average": 12.26
+        "llm-average": 6.1
       },
       {
         "entity_name": "APOB",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "APOC3",
-        "llm-average": 5.92
+        "llm-average": 3.0
       }
     ]
   },
@@ -1413,19 +1413,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LIME1",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "SEC22A",
-        "llm-average": 11.54
+        "llm-average": 5.8
       },
       {
         "entity_name": "DNAJC30",
-        "llm-average": 9.61
+        "llm-average": 4.8
       },
       {
         "entity_name": "USE1",
-        "llm-average": 7.77
+        "llm-average": 3.9
       }
     ]
   },
@@ -1437,23 +1437,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAGEA1",
-        "llm-average": 17.59
+        "llm-average": 8.8
       },
       {
         "entity_name": "ING4",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "ING3",
-        "llm-average": 12.73
+        "llm-average": 6.4
       },
       {
         "entity_name": "H2BC1",
-        "llm-average": 5.92
+        "llm-average": 3.0
       },
       {
         "entity_name": "RPL10",
-        "llm-average": 5.89
+        "llm-average": 2.9
       }
     ]
   },
@@ -1465,11 +1465,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PLEKHA7",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "UNC119",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -1481,11 +1481,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sirolimus",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "Tacrolimus",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -1497,15 +1497,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "YWHAQ",
-        "llm-average": 13.35
+        "llm-average": 6.7
       },
       {
         "entity_name": "YWHAB",
-        "llm-average": 10.15
+        "llm-average": 5.1
       },
       {
         "entity_name": "HCK",
-        "llm-average": 9.56
+        "llm-average": 4.8
       }
     ]
   },
@@ -1517,15 +1517,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RBM8A",
-        "llm-average": 13.96
+        "llm-average": 7.0
       },
       {
         "entity_name": "FRG1",
-        "llm-average": 12.28
+        "llm-average": 6.1
       },
       {
         "entity_name": "SNRPB",
-        "llm-average": 11.68
+        "llm-average": 5.8
       }
     ]
   },
@@ -1537,11 +1537,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RDH12",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "EIF4E2",
-        "llm-average": 8.04
+        "llm-average": 4.0
       }
     ]
   },
@@ -1553,19 +1553,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "OSMR",
-        "llm-average": 12.18
+        "llm-average": 6.1
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 11.61
+        "llm-average": 5.8
       },
       {
         "entity_name": "SRC",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "EGF",
-        "llm-average": 7.08
+        "llm-average": 3.5
       }
     ]
   },
@@ -1577,11 +1577,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HIF1AN",
-        "llm-average": 15.92
+        "llm-average": 8.0
       },
       {
         "entity_name": "ECH1",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -1593,11 +1593,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAD2L2",
-        "llm-average": 15.6
+        "llm-average": 7.8
       },
       {
         "entity_name": "ZDHHC5",
-        "llm-average": 15.4
+        "llm-average": 7.7
       }
     ]
   },
@@ -1609,11 +1609,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LONRF2",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "FBXL19",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -1625,35 +1625,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KAT2B",
-        "llm-average": 15.78
+        "llm-average": 7.9
       },
       {
         "entity_name": "KAT2A",
-        "llm-average": 13.94
+        "llm-average": 7.0
       },
       {
         "entity_name": "EP300",
-        "llm-average": 13.35
+        "llm-average": 6.7
       },
       {
         "entity_name": "CBX2",
-        "llm-average": 13.19
+        "llm-average": 6.6
       },
       {
         "entity_name": "CREBBP",
-        "llm-average": 11.94
+        "llm-average": 6.0
       },
       {
         "entity_name": "UBE2I",
-        "llm-average": 11.12
+        "llm-average": 5.6
       },
       {
         "entity_name": "DNMT1",
-        "llm-average": 7.88
+        "llm-average": 3.9
       },
       {
         "entity_name": "MAD2L1",
-        "llm-average": 6.34
+        "llm-average": 3.2
       }
     ]
   },
@@ -1665,11 +1665,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ARRB1",
-        "llm-average": 15.6
+        "llm-average": 7.8
       },
       {
         "entity_name": "GRK2",
-        "llm-average": 15.4
+        "llm-average": 7.7
       }
     ]
   },
@@ -1681,19 +1681,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RAMP2",
-        "llm-average": 13.11
+        "llm-average": 6.6
       },
       {
         "entity_name": "IAPP",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "RAMP1",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "RAMP3",
-        "llm-average": 8.83
+        "llm-average": 4.4
       }
     ]
   },
@@ -1705,15 +1705,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PPIG",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "KHDRBS3",
-        "llm-average": 15.78
+        "llm-average": 7.9
       },
       {
         "entity_name": "HNRNPD",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -1725,11 +1725,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sphingosine 1-phosphate",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "Sphingosine",
-        "llm-average": 8.8
+        "llm-average": 4.4
       }
     ]
   },
@@ -1741,11 +1741,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FLT4",
-        "llm-average": 15.4
+        "llm-average": 7.7
       },
       {
         "entity_name": "KDR",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -1757,19 +1757,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FURIN",
-        "llm-average": 15.78
+        "llm-average": 7.9
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "FN1",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "TP53",
-        "llm-average": 5.53
+        "llm-average": 2.8
       }
     ]
   },
@@ -1781,11 +1781,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "METTL3",
-        "llm-average": 15.6
+        "llm-average": 7.8
       },
       {
         "entity_name": "MATR3",
-        "llm-average": 14.86
+        "llm-average": 7.4
       }
     ]
   },
@@ -1797,7 +1797,7 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Iron",
-        "llm-average": 1.62
+        "llm-average": 0.8
       },
       {
         "entity_name": "Magnesium cation",
@@ -1813,23 +1813,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRAF3IP3",
-        "llm-average": 11.12
+        "llm-average": 5.6
       },
       {
         "entity_name": "APPBP2",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "PIP4P1",
-        "llm-average": 9.21
+        "llm-average": 4.6
       },
       {
         "entity_name": "NTAQ1",
-        "llm-average": 4.42
+        "llm-average": 2.2
       },
       {
         "entity_name": "SEC22A",
-        "llm-average": 4.03
+        "llm-average": 2.0
       }
     ]
   },
@@ -1841,11 +1841,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PRKAR1A",
-        "llm-average": 15.4
+        "llm-average": 7.7
       },
       {
         "entity_name": "JUN",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -1857,11 +1857,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Lithium cation",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "Hydrochlorothiazide",
-        "llm-average": 8.34
+        "llm-average": 4.2
       }
     ]
   },
@@ -1873,11 +1873,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "R,S-Warfarin alcohol",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "S,R-Warfarin alcohol",
-        "llm-average": 11.24
+        "llm-average": 5.6
       }
     ]
   },
@@ -1889,19 +1889,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 14.92
+        "llm-average": 7.5
       },
       {
         "entity_name": "CCNA1",
-        "llm-average": 8.34
+        "llm-average": 4.2
       },
       {
         "entity_name": "CDK2",
-        "llm-average": 8.1
+        "llm-average": 4.1
       },
       {
         "entity_name": "CCNA2",
-        "llm-average": 7.1
+        "llm-average": 3.5
       }
     ]
   },
@@ -1913,11 +1913,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 15.78
+        "llm-average": 7.9
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 8.71
+        "llm-average": 4.4
       }
     ]
   },
@@ -1929,15 +1929,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RET",
-        "llm-average": 17.59
+        "llm-average": 8.8
       },
       {
         "entity_name": "NOTCH1",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "EGFR",
-        "llm-average": 7.95
+        "llm-average": 4.0
       }
     ]
   },
@@ -1949,11 +1949,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 10.39
+        "llm-average": 5.2
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 6.63
+        "llm-average": 3.3
       }
     ]
   },
@@ -1965,23 +1965,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CEP290",
-        "llm-average": 18.87
+        "llm-average": 9.4
       },
       {
         "entity_name": "USP49",
-        "llm-average": 13.51
+        "llm-average": 6.8
       },
       {
         "entity_name": "POC5",
-        "llm-average": 13.41
+        "llm-average": 6.7
       },
       {
         "entity_name": "TBCCD1",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "ZFAND5",
-        "llm-average": 6.81
+        "llm-average": 3.4
       }
     ]
   },
@@ -1993,11 +1993,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GNAQ",
-        "llm-average": 17.59
+        "llm-average": 8.8
       },
       {
         "entity_name": "WNT1",
-        "llm-average": 11.98
+        "llm-average": 6.0
       }
     ]
   },
@@ -2009,11 +2009,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Troglitazone",
-        "llm-average": 15.6
+        "llm-average": 7.8
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 13.58
+        "llm-average": 6.8
       }
     ]
   },
@@ -2025,11 +2025,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SRC",
-        "llm-average": 12.83
+        "llm-average": 6.4
       },
       {
         "entity_name": "BUB1B",
-        "llm-average": 9.84
+        "llm-average": 4.9
       }
     ]
   },
@@ -2041,15 +2041,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FOXE1",
-        "llm-average": 15.24
+        "llm-average": 7.6
       },
       {
         "entity_name": "SYNE1",
-        "llm-average": 11.43
+        "llm-average": 5.7
       },
       {
         "entity_name": "ZNF408",
-        "llm-average": 10.41
+        "llm-average": 5.2
       }
     ]
   },
@@ -2061,11 +2061,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KRAS",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "HRAS",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -2077,31 +2077,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DUSP10",
-        "llm-average": 11.14
+        "llm-average": 5.6
       },
       {
         "entity_name": "OTUD7B",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "POLD4",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "TRMT9B",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "TMEM205",
-        "llm-average": 5.65
+        "llm-average": 2.8
       },
       {
         "entity_name": "ZNF212",
-        "llm-average": 5.3
+        "llm-average": 2.7
       },
       {
         "entity_name": "ACAD8",
-        "llm-average": 4.22
+        "llm-average": 2.1
       }
     ]
   },
@@ -2113,19 +2113,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "APP",
-        "llm-average": 14.09
+        "llm-average": 7.0
       },
       {
         "entity_name": "P2RY14",
-        "llm-average": 12.26
+        "llm-average": 6.1
       },
       {
         "entity_name": "P2RY13",
-        "llm-average": 11.66
+        "llm-average": 5.8
       },
       {
         "entity_name": "GNRHR",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -2137,15 +2137,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 14.1
+        "llm-average": 7.1
       },
       {
         "entity_name": "Resveratrol",
-        "llm-average": 14.09
+        "llm-average": 7.0
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.78
+        "llm-average": 2.4
       }
     ]
   },
@@ -2157,27 +2157,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Flutamide",
-        "llm-average": 13.62
+        "llm-average": 6.8
       },
       {
         "entity_name": "Bendroflumethiazide",
-        "llm-average": 9.92
+        "llm-average": 5.0
       },
       {
         "entity_name": "Amiloride",
-        "llm-average": 8.2
+        "llm-average": 4.1
       },
       {
         "entity_name": "Indapamide",
-        "llm-average": 7.9
+        "llm-average": 3.9
       },
       {
         "entity_name": "Rabeprazole",
-        "llm-average": 7.03
+        "llm-average": 3.5
       },
       {
         "entity_name": "Furosemide",
-        "llm-average": 6.02
+        "llm-average": 3.0
       }
     ]
   },
@@ -2189,23 +2189,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IMP3",
-        "llm-average": 13.54
+        "llm-average": 6.8
       },
       {
         "entity_name": "MRPL28",
-        "llm-average": 10.0
+        "llm-average": 5.0
       },
       {
         "entity_name": "MRPS2",
-        "llm-average": 9.72
+        "llm-average": 4.9
       },
       {
         "entity_name": "RPSA",
-        "llm-average": 5.5
+        "llm-average": 2.8
       },
       {
         "entity_name": "RPL10A",
-        "llm-average": 5.26
+        "llm-average": 2.6
       }
     ]
   },
@@ -2217,15 +2217,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ABCB6",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "LAMP2",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "B2M",
-        "llm-average": 5.41
+        "llm-average": 2.7
       }
     ]
   },
@@ -2237,23 +2237,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "(S)-Fluoxetine",
-        "llm-average": 17.59
+        "llm-average": 8.8
       },
       {
         "entity_name": "(R)-Fluoxetine",
-        "llm-average": 16.3
+        "llm-average": 8.1
       },
       {
         "entity_name": "Mirtazapine",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Paroxetine",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Fluoxetine",
-        "llm-average": 8.32
+        "llm-average": 4.2
       }
     ]
   },
@@ -2265,15 +2265,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NFKB1",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "GNAQ",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "GNG2",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2285,11 +2285,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NCR3",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "CD247",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -2301,11 +2301,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HDAC2",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "HDAC1",
-        "llm-average": 8.85
+        "llm-average": 4.4
       }
     ]
   },
@@ -2317,23 +2317,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 15.77
+        "llm-average": 7.9
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 14.22
+        "llm-average": 7.1
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -2345,11 +2345,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Olanzapine",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "Paroxetine",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2361,11 +2361,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2377,15 +2377,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 16.3
+        "llm-average": 8.1
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 13.45
+        "llm-average": 6.7
       }
     ]
   },
@@ -2397,11 +2397,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2413,15 +2413,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GUCA1B",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "PDE1B",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "GUCY1B1",
-        "llm-average": 7.66
+        "llm-average": 3.8
       }
     ]
   },
@@ -2433,35 +2433,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTGFR",
-        "llm-average": 16.49
+        "llm-average": 8.2
       },
       {
         "entity_name": "APLNR",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "GRM1",
-        "llm-average": 13.68
+        "llm-average": 6.8
       },
       {
         "entity_name": "GNAQ",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "HRAS",
-        "llm-average": 10.48
+        "llm-average": 5.2
       },
       {
         "entity_name": "EDN3",
-        "llm-average": 9.86
+        "llm-average": 4.9
       },
       {
         "entity_name": "GNA11",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "EDN2",
-        "llm-average": 9.25
+        "llm-average": 4.6
       }
     ]
   },
@@ -2473,11 +2473,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRLS1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2489,11 +2489,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 15.07
+        "llm-average": 7.5
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 13.65
+        "llm-average": 6.8
       }
     ]
   },
@@ -2505,31 +2505,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Aripiprazole",
-        "llm-average": 10.99
+        "llm-average": 5.5
       },
       {
         "entity_name": "Lamotrigine",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "Ziprasidone",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "Quetiapine",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Olanzapine",
-        "llm-average": 7.44
+        "llm-average": 3.7
       },
       {
         "entity_name": "Paroxetine",
-        "llm-average": 7.33
+        "llm-average": 3.7
       },
       {
         "entity_name": "Escitalopram",
-        "llm-average": 6.55
+        "llm-average": 3.3
       }
     ]
   },
@@ -2541,11 +2541,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SPEN",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "RBPJ",
-        "llm-average": 10.79
+        "llm-average": 5.4
       }
     ]
   },
@@ -2557,31 +2557,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "UPF3B",
-        "llm-average": 17.89
+        "llm-average": 8.9
       },
       {
         "entity_name": "RNPS1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "UPF2",
-        "llm-average": 14.93
+        "llm-average": 7.5
       },
       {
         "entity_name": "RBM8A",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "ALYREF",
-        "llm-average": 8.7
+        "llm-average": 4.3
       },
       {
         "entity_name": "NXF1",
-        "llm-average": 8.11
+        "llm-average": 4.1
       },
       {
         "entity_name": "SRRM1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -2593,15 +2593,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "VAPB",
-        "llm-average": 16.09
+        "llm-average": 8.0
       },
       {
         "entity_name": "SCN2B",
-        "llm-average": 9.92
+        "llm-average": 5.0
       },
       {
         "entity_name": "CHRM3",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -2613,19 +2613,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 13.24
+        "llm-average": 6.6
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.23
+        "llm-average": 4.6
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 8.19
+        "llm-average": 4.1
       }
     ]
   },
@@ -2637,15 +2637,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ANXA2",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "SRC",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "RACK1",
-        "llm-average": 9.83
+        "llm-average": 4.9
       }
     ]
   },
@@ -2657,11 +2657,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CREBBP",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "STAT1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2673,11 +2673,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diclofenac",
-        "llm-average": 7.57
+        "llm-average": 3.8
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -2689,23 +2689,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Methyldopa",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Cyclobenzaprine",
-        "llm-average": 9.81
+        "llm-average": 4.9
       },
       {
         "entity_name": "Escitalopram",
-        "llm-average": 9.23
+        "llm-average": 4.6
       },
       {
         "entity_name": "Ziprasidone",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Citalopram",
-        "llm-average": 8.3
+        "llm-average": 4.2
       }
     ]
   },
@@ -2717,31 +2717,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AGPAT5",
-        "llm-average": 18.93
+        "llm-average": 9.5
       },
       {
         "entity_name": "PTPMT1",
-        "llm-average": 16.38
+        "llm-average": 8.2
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 16.02
+        "llm-average": 8.0
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "CDS2",
-        "llm-average": 10.9
+        "llm-average": 5.5
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2753,15 +2753,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "VPS51",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "VPS52",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "VPS53",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2773,19 +2773,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 9.21
+        "llm-average": 4.6
       }
     ]
   },
@@ -2797,15 +2797,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Diazepam",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "Ibuprofen",
-        "llm-average": 1.98
+        "llm-average": 1.0
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 1.14
+        "llm-average": 0.6
       }
     ]
   },
@@ -2817,15 +2817,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SEMA3F",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "DRAXIN",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "PTPN11",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -2837,11 +2837,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ESR1",
-        "llm-average": 13.65
+        "llm-average": 6.8
       },
       {
         "entity_name": "RELA",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2853,35 +2853,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HDAC4",
-        "llm-average": 14.54
+        "llm-average": 7.3
       },
       {
         "entity_name": "SPI1",
-        "llm-average": 14.2
+        "llm-average": 7.1
       },
       {
         "entity_name": "CSNK2A1",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "MAPK14",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "FGF2",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "GATA5",
-        "llm-average": 10.3
+        "llm-average": 5.2
       },
       {
         "entity_name": "HNF1A",
-        "llm-average": 9.72
+        "llm-average": 4.9
       },
       {
         "entity_name": "MYOD1",
-        "llm-average": 6.26
+        "llm-average": 3.1
       }
     ]
   },
@@ -2893,19 +2893,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "EHMT1",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "SMG1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "HCFC1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "TAF1",
-        "llm-average": 8.93
+        "llm-average": 4.5
       }
     ]
   },
@@ -2917,15 +2917,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NGF",
-        "llm-average": 14.68
+        "llm-average": 7.3
       },
       {
         "entity_name": "MAPK8",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "TGFB1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2937,23 +2937,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 15.75
+        "llm-average": 7.9
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 14.63
+        "llm-average": 7.3
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 9.72
+        "llm-average": 4.9
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -2965,11 +2965,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ITGB3",
-        "llm-average": 11.71
+        "llm-average": 5.9
       },
       {
         "entity_name": "ITGAV",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -2981,23 +2981,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 10.99
+        "llm-average": 5.5
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -3009,15 +3009,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "APAF1",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "CYCS",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "CASP9",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -3029,23 +3029,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "COPS3",
-        "llm-average": 15.46
+        "llm-average": 7.7
       },
       {
         "entity_name": "COPS5",
-        "llm-average": 14.61
+        "llm-average": 7.3
       },
       {
         "entity_name": "RBX1",
-        "llm-average": 9.81
+        "llm-average": 4.9
       },
       {
         "entity_name": "DDB1",
-        "llm-average": 9.48
+        "llm-average": 4.7
       },
       {
         "entity_name": "POLR2A",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -3057,23 +3057,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Deferiprone",
-        "llm-average": 14.59
+        "llm-average": 7.3
       },
       {
         "entity_name": "Quinidine",
-        "llm-average": 13.71
+        "llm-average": 6.9
       },
       {
         "entity_name": "Quinine",
-        "llm-average": 11.95
+        "llm-average": 6.0
       },
       {
         "entity_name": "Doxepin",
-        "llm-average": 7.02
+        "llm-average": 3.5
       },
       {
         "entity_name": "Sertraline",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -3085,11 +3085,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Topotecan",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "Irinotecan",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -3101,15 +3101,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KRAS",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "HRAS",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -3121,11 +3121,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 12.42
+        "llm-average": 6.2
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.54
+        "llm-average": 5.8
       }
     ]
   },
@@ -3137,15 +3137,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GABPA",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "CYCS",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.87
+        "llm-average": 5.4
       }
     ]
   },
@@ -3157,15 +3157,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MNDA",
-        "llm-average": 15.62
+        "llm-average": 7.8
       },
       {
         "entity_name": "MECP2",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "CLCN2",
-        "llm-average": 9.28
+        "llm-average": 4.6
       }
     ]
   },
@@ -3177,19 +3177,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GNB1",
-        "llm-average": 14.59
+        "llm-average": 7.3
       },
       {
         "entity_name": "GNAQ",
-        "llm-average": 12.13
+        "llm-average": 6.1
       },
       {
         "entity_name": "GNA11",
-        "llm-average": 8.7
+        "llm-average": 4.3
       },
       {
         "entity_name": "GNA15",
-        "llm-average": 8.62
+        "llm-average": 4.3
       }
     ]
   },
@@ -3201,11 +3201,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SART1",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "CD2BP2",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -3217,23 +3217,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "THBS1",
-        "llm-average": 14.67
+        "llm-average": 7.3
       },
       {
         "entity_name": "COL18A1",
-        "llm-average": 9.81
+        "llm-average": 4.9
       },
       {
         "entity_name": "KDR",
-        "llm-average": 9.76
+        "llm-average": 4.9
       },
       {
         "entity_name": "ICAM1",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "ITGAM",
-        "llm-average": 8.4
+        "llm-average": 4.2
       }
     ]
   },
@@ -3245,35 +3245,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DYNLRB1",
-        "llm-average": 18.42
+        "llm-average": 9.2
       },
       {
         "entity_name": "RAC2",
-        "llm-average": 15.25
+        "llm-average": 7.6
       },
       {
         "entity_name": "HSPB8",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "OCLN",
-        "llm-average": 11.65
+        "llm-average": 5.8
       },
       {
         "entity_name": "IL1B",
-        "llm-average": 11.36
+        "llm-average": 5.7
       },
       {
         "entity_name": "EMP3",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "CTNNB1",
-        "llm-average": 9.76
+        "llm-average": 4.9
       },
       {
         "entity_name": "EGF",
-        "llm-average": 5.78
+        "llm-average": 2.9
       }
     ]
   },
@@ -3285,11 +3285,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -3301,11 +3301,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPHA2",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "ST8SIA4",
-        "llm-average": 8.85
+        "llm-average": 4.4
       }
     ]
   },
@@ -3317,11 +3317,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "VTN",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "CD34",
-        "llm-average": 13.08
+        "llm-average": 6.5
       }
     ]
   },
@@ -3333,15 +3333,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KDM1A",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "HDAC2",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "HDAC1",
-        "llm-average": 8.93
+        "llm-average": 4.5
       }
     ]
   },
@@ -3353,11 +3353,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FH",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "FXN",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -3369,35 +3369,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "2-Fluoroadenosine",
-        "llm-average": 16.04
+        "llm-average": 8.0
       },
       {
         "entity_name": "Tacrolimus",
-        "llm-average": 11.01
+        "llm-average": 5.5
       },
       {
         "entity_name": "Ifosfamide",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "Fludarabine",
-        "llm-average": 9.43
+        "llm-average": 4.7
       },
       {
         "entity_name": "Acitretin",
-        "llm-average": 9.34
+        "llm-average": 4.7
       },
       {
         "entity_name": "Gemcitabine",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "Mitoxantrone",
-        "llm-average": 7.39
+        "llm-average": 3.7
       },
       {
         "entity_name": "Methotrexate",
-        "llm-average": 4.42
+        "llm-average": 2.2
       }
     ]
   },
@@ -3409,19 +3409,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dantrolene",
-        "llm-average": 13.01
+        "llm-average": 6.5
       },
       {
         "entity_name": "Cyclobenzaprine",
-        "llm-average": 8.19
+        "llm-average": 4.1
       },
       {
         "entity_name": "Baclofen",
-        "llm-average": 7.03
+        "llm-average": 3.5
       },
       {
         "entity_name": "Diazepam",
-        "llm-average": 4.66
+        "llm-average": 2.3
       }
     ]
   },
@@ -3433,11 +3433,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ZFP36L1",
-        "llm-average": 11.86
+        "llm-average": 5.9
       },
       {
         "entity_name": "HNRNPD",
-        "llm-average": 8.42
+        "llm-average": 4.2
       }
     ]
   },
@@ -3449,23 +3449,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FLT4",
-        "llm-average": 14.67
+        "llm-average": 7.3
       },
       {
         "entity_name": "EPO",
-        "llm-average": 9.81
+        "llm-average": 4.9
       },
       {
         "entity_name": "VEGFA",
-        "llm-average": 9.23
+        "llm-average": 4.6
       },
       {
         "entity_name": "ERBB2",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "FN1",
-        "llm-average": 8.93
+        "llm-average": 4.5
       }
     ]
   },
@@ -3477,35 +3477,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADORA2B",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "RHOA",
-        "llm-average": 11.55
+        "llm-average": 5.8
       },
       {
         "entity_name": "VEGFA",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "MYC",
-        "llm-average": 10.3
+        "llm-average": 5.2
       },
       {
         "entity_name": "FN1",
-        "llm-average": 9.62
+        "llm-average": 4.8
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.69
+        "llm-average": 4.3
       },
       {
         "entity_name": "GAPDH",
-        "llm-average": 4.02
+        "llm-average": 2.0
       }
     ]
   },
@@ -3517,11 +3517,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -3533,23 +3533,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Itraconazole",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "Posaconazole",
-        "llm-average": 10.0
+        "llm-average": 5.0
       },
       {
         "entity_name": "Epitestosterone",
-        "llm-average": 9.84
+        "llm-average": 4.9
       },
       {
         "entity_name": "Paroxetine",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 4.12
+        "llm-average": 2.1
       }
     ]
   },
@@ -3561,19 +3561,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "REL",
-        "llm-average": 14.61
+        "llm-average": 7.3
       },
       {
         "entity_name": "EP300",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "ATM",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "RANBP2",
-        "llm-average": 13.24
+        "llm-average": 6.6
       }
     ]
   },
@@ -3585,19 +3585,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 16.95
+        "llm-average": 8.5
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 12.39
+        "llm-average": 6.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 10.3
+        "llm-average": 5.2
       }
     ]
   },
@@ -3609,31 +3609,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FGF9",
-        "llm-average": 12.84
+        "llm-average": 6.4
       },
       {
         "entity_name": "FGF18",
-        "llm-average": 12.1
+        "llm-average": 6.0
       },
       {
         "entity_name": "FGFR2",
-        "llm-average": 9.17
+        "llm-average": 4.6
       },
       {
         "entity_name": "FGF3",
-        "llm-average": 9.03
+        "llm-average": 4.5
       },
       {
         "entity_name": "FGF7",
-        "llm-average": 7.04
+        "llm-average": 3.5
       },
       {
         "entity_name": "FGF2",
-        "llm-average": 3.6
+        "llm-average": 1.8
       },
       {
         "entity_name": "FGF1",
-        "llm-average": 2.91
+        "llm-average": 1.5
       }
     ]
   },
@@ -3645,11 +3645,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -3661,11 +3661,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -3677,15 +3677,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CKAP4",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "WNK1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "UBC",
-        "llm-average": 9.29
+        "llm-average": 4.6
       }
     ]
   },
@@ -3697,15 +3697,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLC35A1",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "SRD5A3",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "SLC35C1",
-        "llm-average": 9.28
+        "llm-average": 4.6
       }
     ]
   },
@@ -3717,15 +3717,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IL1RL1",
-        "llm-average": 14.3
+        "llm-average": 7.2
       },
       {
         "entity_name": "IL1RAP",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "KIT",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -3737,19 +3737,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Chloroquine",
-        "llm-average": 17.71
+        "llm-average": 8.9
       },
       {
         "entity_name": "Rabeprazole",
-        "llm-average": 10.3
+        "llm-average": 5.2
       },
       {
         "entity_name": "Diclofenac",
-        "llm-average": 7.36
+        "llm-average": 3.7
       },
       {
         "entity_name": "Naproxen",
-        "llm-average": 5.95
+        "llm-average": 3.0
       }
     ]
   },
@@ -3761,11 +3761,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Carbamazepine",
-        "llm-average": 9.38
+        "llm-average": 4.7
       },
       {
         "entity_name": "Ifosfamide",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -3777,11 +3777,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 15.07
+        "llm-average": 7.5
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 13.65
+        "llm-average": 6.8
       }
     ]
   },
@@ -3793,11 +3793,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NOS3",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "HSP90AA1",
-        "llm-average": 9.38
+        "llm-average": 4.7
       }
     ]
   },
@@ -3809,11 +3809,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 15.07
+        "llm-average": 7.5
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 13.65
+        "llm-average": 6.8
       }
     ]
   },
@@ -3825,35 +3825,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 12.83
+        "llm-average": 6.4
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 12.61
+        "llm-average": 6.3
       },
       {
         "entity_name": "TP53",
-        "llm-average": 9.76
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 9.29
+        "llm-average": 4.6
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.59
+        "llm-average": 4.3
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 6.95
+        "llm-average": 3.5
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 5.93
+        "llm-average": 3.0
       }
     ]
   },
@@ -3865,15 +3865,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 19.25
+        "llm-average": 9.6
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -3885,11 +3885,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -3901,35 +3901,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 13.52
+        "llm-average": 6.8
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.56
+        "llm-average": 5.3
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 6.68
+        "llm-average": 3.3
       }
     ]
   },
@@ -3941,35 +3941,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 15.02
+        "llm-average": 7.5
       },
       {
         "entity_name": "MYC",
-        "llm-average": 9.84
+        "llm-average": 4.9
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 9.37
+        "llm-average": 4.7
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 8.49
+        "llm-average": 4.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "TP53",
-        "llm-average": 7.57
+        "llm-average": 3.8
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       }
     ]
   },
@@ -3981,11 +3981,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -3997,35 +3997,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 13.7
+        "llm-average": 6.8
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "TP53",
-        "llm-average": 9.01
+        "llm-average": 4.5
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 7.13
+        "llm-average": 3.6
       }
     ]
   },
@@ -4037,11 +4037,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4053,11 +4053,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 12.63
+        "llm-average": 6.3
       }
     ]
   },
@@ -4069,11 +4069,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4085,35 +4085,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 13.52
+        "llm-average": 6.8
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.56
+        "llm-average": 5.3
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.04
+        "llm-average": 5.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "CDKN1B",
-        "llm-average": 6.68
+        "llm-average": 3.3
       }
     ]
   },
@@ -4125,11 +4125,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.11
+        "llm-average": 4.6
       }
     ]
   },
@@ -4141,19 +4141,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "EPH-ephrin mediated repulsion of cells",
-        "llm-average": 9.73
+        "llm-average": 4.9
       },
       {
         "entity_name": "EPHB-mediated forward signaling",
-        "llm-average": 5.65
+        "llm-average": 2.8
       },
       {
         "entity_name": "Ephrin signaling",
-        "llm-average": 5.13
+        "llm-average": 2.6
       },
       {
         "entity_name": "EPH-Ephrin signaling",
-        "llm-average": 2.54
+        "llm-average": 1.3
       }
     ]
   },
@@ -4165,11 +4165,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MCEE",
-        "llm-average": 13.13
+        "llm-average": 6.6
       },
       {
         "entity_name": "CRP",
-        "llm-average": 5.89
+        "llm-average": 2.9
       }
     ]
   },
@@ -4181,31 +4181,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "skeletal system development",
-        "llm-average": 16.39
+        "llm-average": 8.2
       },
       {
         "entity_name": "cholesterol biosynthetic process via lathosterol",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "xenobiotic transport",
-        "llm-average": 10.28
+        "llm-average": 5.1
       },
       {
         "entity_name": "cholesterol biosynthetic process via desmosterol",
-        "llm-average": 9.27
+        "llm-average": 4.6
       },
       {
         "entity_name": "sterol biosynthetic process",
-        "llm-average": 6.67
+        "llm-average": 3.3
       },
       {
         "entity_name": "cholesterol metabolic process",
-        "llm-average": 4.8
+        "llm-average": 2.4
       },
       {
         "entity_name": "cholesterol biosynthetic process",
-        "llm-average": 4.1
+        "llm-average": 2.1
       }
     ]
   },
@@ -4217,23 +4217,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PNMT",
-        "llm-average": 12.64
+        "llm-average": 6.3
       },
       {
         "entity_name": "ADRA2A",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "ADRA2C",
-        "llm-average": 6.95
+        "llm-average": 3.5
       },
       {
         "entity_name": "MAOA",
-        "llm-average": 6.03
+        "llm-average": 3.0
       },
       {
         "entity_name": "MAOB",
-        "llm-average": 5.66
+        "llm-average": 2.8
       }
     ]
   },
@@ -4245,15 +4245,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "F2RL1",
-        "llm-average": 7.97
+        "llm-average": 4.0
       },
       {
         "entity_name": "F2R",
-        "llm-average": 5.89
+        "llm-average": 2.9
       },
       {
         "entity_name": "F2RL2",
-        "llm-average": 5.38
+        "llm-average": 2.7
       }
     ]
   },
@@ -4265,15 +4265,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SGCB",
-        "llm-average": 12.57
+        "llm-average": 6.3
       },
       {
         "entity_name": "CYP2C9",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "CYP3A4",
-        "llm-average": 5.5
+        "llm-average": 2.8
       }
     ]
   },
@@ -4285,11 +4285,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP2C9",
-        "llm-average": 6.82
+        "llm-average": 3.4
       },
       {
         "entity_name": "CYP3A4",
-        "llm-average": 5.65
+        "llm-average": 2.8
       }
     ]
   },
@@ -4301,27 +4301,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FIBCD1",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "DOCK8",
-        "llm-average": 12.31
+        "llm-average": 6.2
       },
       {
         "entity_name": "F2RL2",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "F2R",
-        "llm-average": 9.26
+        "llm-average": 4.6
       },
       {
         "entity_name": "CHRNA4",
-        "llm-average": 7.9
+        "llm-average": 3.9
       },
       {
         "entity_name": "CHRNA2",
-        "llm-average": 7.83
+        "llm-average": 3.9
       }
     ]
   },
@@ -4333,35 +4333,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPN1",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "ATP6V1A",
-        "llm-average": 12.22
+        "llm-average": 6.1
       },
       {
         "entity_name": "MMP13",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "MMP27",
-        "llm-average": 8.92
+        "llm-average": 4.5
       },
       {
         "entity_name": "MMP8",
-        "llm-average": 6.01
+        "llm-average": 3.0
       },
       {
         "entity_name": "MMP3",
-        "llm-average": 2.78
+        "llm-average": 1.4
       },
       {
         "entity_name": "MMP1",
-        "llm-average": 2.07
+        "llm-average": 1.0
       },
       {
         "entity_name": "MMP10",
-        "llm-average": 1.55
+        "llm-average": 0.8
       }
     ]
   },
@@ -4373,15 +4373,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TUBA4A",
-        "llm-average": 11.53
+        "llm-average": 5.8
       },
       {
         "entity_name": "TUBB1",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "AR",
-        "llm-average": 9.38
+        "llm-average": 4.7
       }
     ]
   },
@@ -4393,27 +4393,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIP3 activates AKT signaling",
-        "llm-average": 12.57
+        "llm-average": 6.3
       },
       {
         "entity_name": "PI5P, PP2A and IER3 Regulate PI3K/AKT Signaling",
-        "llm-average": 12.24
+        "llm-average": 6.1
       },
       {
         "entity_name": "Constitutive Signaling by Aberrant PI3K in Cancer",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Signaling by PDGF",
-        "llm-average": 10.19
+        "llm-average": 5.1
       },
       {
         "entity_name": "RAF/MAP kinase cascade",
-        "llm-average": 6.03
+        "llm-average": 3.0
       },
       {
         "entity_name": "Downstream signal transduction",
-        "llm-average": 3.44
+        "llm-average": 1.7
       }
     ]
   },
@@ -4425,23 +4425,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP2E1 reactions",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "Xenobiotics",
-        "llm-average": 11.35
+        "llm-average": 5.7
       },
       {
         "entity_name": "Vitamin A Deficiency",
-        "llm-average": 6.54
+        "llm-average": 3.3
       },
       {
         "entity_name": "Retinol Metabolism",
-        "llm-average": 5.65
+        "llm-average": 2.8
       },
       {
         "entity_name": "Fatty acids",
-        "llm-average": 0.78
+        "llm-average": 0.4
       }
     ]
   },
@@ -4453,19 +4453,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP2B6",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "CYP3A4",
-        "llm-average": 5.91
+        "llm-average": 3.0
       },
       {
         "entity_name": "CYP2D6",
-        "llm-average": 5.39
+        "llm-average": 2.7
       },
       {
         "entity_name": "CYP1A2",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -4477,23 +4477,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAFG",
-        "llm-average": 14.88
+        "llm-average": 7.4
       },
       {
         "entity_name": "CYP17A1",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "TBXAS1",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CYP21A2",
-        "llm-average": 5.17
+        "llm-average": 2.6
       },
       {
         "entity_name": "CYP2R1",
-        "llm-average": 4.66
+        "llm-average": 2.3
       },
       {
         "entity_name": "INS",
@@ -4509,11 +4509,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CACNA1I",
-        "llm-average": 9.4
+        "llm-average": 4.7
       },
       {
         "entity_name": "CACNA1G",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -4525,15 +4525,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TOP2A",
-        "llm-average": 13.29
+        "llm-average": 6.6
       },
       {
         "entity_name": "TOP2B",
-        "llm-average": 12.12
+        "llm-average": 6.1
       },
       {
         "entity_name": "NPL",
-        "llm-average": 4.1
+        "llm-average": 2.1
       }
     ]
   },
@@ -4545,31 +4545,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "fibroblast growth factor receptor 3",
-        "llm-average": 14.83
+        "llm-average": 7.4
       },
       {
         "entity_name": "fibroblast growth factor receptor 2",
-        "llm-average": 12.89
+        "llm-average": 6.4
       },
       {
         "entity_name": "fibroblast growth factor receptor 1",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "epidermal growth factor receptor",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "fibroblast growth factor receptor 4",
-        "llm-average": 12.26
+        "llm-average": 6.1
       },
       {
         "entity_name": "KRAS proto-oncogene, GTPase",
-        "llm-average": 11.96
+        "llm-average": 6.0
       },
       {
         "entity_name": "kinase insert domain receptor",
-        "llm-average": 8.21
+        "llm-average": 4.1
       }
     ]
   },
@@ -4581,23 +4581,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP2D6",
-        "llm-average": 12.37
+        "llm-average": 6.2
       },
       {
         "entity_name": "CYP1A2",
-        "llm-average": 7.97
+        "llm-average": 4.0
       },
       {
         "entity_name": "CYP4V2",
-        "llm-average": 6.16
+        "llm-average": 3.1
       },
       {
         "entity_name": "ACSF3",
-        "llm-average": 3.83
+        "llm-average": 1.9
       },
       {
         "entity_name": "R3HDM4",
-        "llm-average": 2.66
+        "llm-average": 1.3
       }
     ]
   },
@@ -4609,15 +4609,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ITGAM",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "VEGFA",
-        "llm-average": 13.78
+        "llm-average": 6.9
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 9.12
+        "llm-average": 4.6
       }
     ]
   },
@@ -4629,11 +4629,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRP channels",
-        "llm-average": 13.47
+        "llm-average": 6.7
       },
       {
         "entity_name": "Role of second messengers in netrin-1 signaling",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -4645,31 +4645,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CHRFAM7A",
-        "llm-average": 17.53
+        "llm-average": 8.8
       },
       {
         "entity_name": "CYP2C19",
-        "llm-average": 16.51
+        "llm-average": 8.3
       },
       {
         "entity_name": "GRIK2",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "GABRA4",
-        "llm-average": 10.57
+        "llm-average": 5.3
       },
       {
         "entity_name": "GABRA5",
-        "llm-average": 8.88
+        "llm-average": 4.4
       },
       {
         "entity_name": "CHRNA4",
-        "llm-average": 8.74
+        "llm-average": 4.4
       },
       {
         "entity_name": "GABRA6",
-        "llm-average": 7.56
+        "llm-average": 3.8
       }
     ]
   },
@@ -4681,15 +4681,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "WTAP",
-        "llm-average": 14.97
+        "llm-average": 7.5
       },
       {
         "entity_name": "ADRA1B",
-        "llm-average": 13.22
+        "llm-average": 6.6
       },
       {
         "entity_name": "SLC6A3",
-        "llm-average": 9.14
+        "llm-average": 4.6
       }
     ]
   },
@@ -4701,31 +4701,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Type II diabetes mellitus",
-        "llm-average": 12.21
+        "llm-average": 6.1
       },
       {
         "entity_name": "Pancreatitis",
-        "llm-average": 9.43
+        "llm-average": 4.7
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 7.47
+        "llm-average": 3.7
       },
       {
         "entity_name": "Reactive hypoglycemia",
-        "llm-average": 6.78
+        "llm-average": 3.4
       },
       {
         "entity_name": "Diabetic ketoacidosis",
-        "llm-average": 5.31
+        "llm-average": 2.7
       },
       {
         "entity_name": "Type I diabetes mellitus",
-        "llm-average": 1.94
+        "llm-average": 1.0
       },
       {
         "entity_name": "Hypoglycemia",
-        "llm-average": 1.24
+        "llm-average": 0.6
       }
     ]
   },
@@ -4737,35 +4737,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Uterine leiomyoma",
-        "llm-average": 11.41
+        "llm-average": 5.7
       },
       {
         "entity_name": "Endometriosis",
-        "llm-average": 11.08
+        "llm-average": 5.5
       },
       {
         "entity_name": "Prostate cancer",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "Metrorrhagia",
-        "llm-average": 9.44
+        "llm-average": 4.7
       },
       {
         "entity_name": "Menorrhagia",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "Anemia",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "Neoplasm",
-        "llm-average": 6.26
+        "llm-average": 3.1
       },
       {
         "entity_name": "Pain",
-        "llm-average": 2.86
+        "llm-average": 1.4
       }
     ]
   },
@@ -4777,31 +4777,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Pleural effusion",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "Choriocarcinoma",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Squamous cell carcinoma",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Hodgkin lymphoma",
-        "llm-average": 6.97
+        "llm-average": 3.5
       },
       {
         "entity_name": "Lymphoma",
-        "llm-average": 6.08
+        "llm-average": 3.0
       },
       {
         "entity_name": "Non-Hodgkin lymphoma",
-        "llm-average": 5.53
+        "llm-average": 2.8
       },
       {
         "entity_name": "Neoplasm",
-        "llm-average": 2.33
+        "llm-average": 1.2
       }
     ]
   },
@@ -4813,27 +4813,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP binding cassette subfamily C member 8",
-        "llm-average": 15.52
+        "llm-average": 7.8
       },
       {
         "entity_name": "potassium inwardly rectifying channel subfamily J member 11",
-        "llm-average": 14.97
+        "llm-average": 7.5
       },
       {
         "entity_name": "potassium inwardly rectifying channel subfamily J member 10",
-        "llm-average": 12.47
+        "llm-average": 6.2
       },
       {
         "entity_name": "potassium inwardly rectifying channel subfamily J member 1",
-        "llm-average": 11.94
+        "llm-average": 6.0
       },
       {
         "entity_name": "glucose-6-phosphate dehydrogenase",
-        "llm-average": 11.09
+        "llm-average": 5.5
       },
       {
         "entity_name": "solute carrier family 2 member 4",
-        "llm-average": 11.06
+        "llm-average": 5.5
       }
     ]
   },
@@ -4845,19 +4845,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cutaneous melanoma",
-        "llm-average": 13.09
+        "llm-average": 6.5
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 7.27
+        "llm-average": 3.6
       },
       {
         "entity_name": "Abnormal pulmonary Interstitial morphology",
-        "llm-average": 4.96
+        "llm-average": 2.5
       },
       {
         "entity_name": "Pneumonia",
-        "llm-average": 4.27
+        "llm-average": 2.1
       }
     ]
   },
@@ -4869,15 +4869,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "dihydroorotate dehydrogenase (quinone)",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "C-X-C motif chemokine ligand 8",
-        "llm-average": 9.63
+        "llm-average": 4.8
       },
       {
         "entity_name": "matrix metallopeptidase 1",
-        "llm-average": 8.22
+        "llm-average": 4.1
       }
     ]
   },
@@ -4889,23 +4889,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Glioblastoma multiforme",
-        "llm-average": 17.85
+        "llm-average": 8.9
       },
       {
         "entity_name": "Astrocytoma",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "Glioma",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Cutaneous melanoma",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Neoplasm",
-        "llm-average": 2.5
+        "llm-average": 1.2
       }
     ]
   },
@@ -4917,11 +4917,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Narcolepsy",
-        "llm-average": 10.37
+        "llm-average": 5.2
       },
       {
         "entity_name": "Cataplexy",
-        "llm-average": 9.99
+        "llm-average": 5.0
       }
     ]
   },
@@ -4933,23 +4933,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Agitation",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "Hypersomnia",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "Insomnia",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "Anxiety",
-        "llm-average": 6.26
+        "llm-average": 3.1
       },
       {
         "entity_name": "Fatigue",
-        "llm-average": 6.06
+        "llm-average": 3.0
       }
     ]
   },
@@ -4961,19 +4961,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Low back pain",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "Chronic pain",
-        "llm-average": 8.59
+        "llm-average": 4.3
       },
       {
         "entity_name": "Osteoarthritis",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Pain",
-        "llm-average": 4.83
+        "llm-average": 2.4
       }
     ]
   },
@@ -4985,31 +4985,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "potassium inwardly rectifying channel subfamily J member 11",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "ATP binding cassette subfamily C member 8",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "potassium inwardly rectifying channel subfamily J member 1",
-        "llm-average": 13.92
+        "llm-average": 7.0
       },
       {
         "entity_name": "cholecystokinin A receptor",
-        "llm-average": 11.42
+        "llm-average": 5.7
       },
       {
         "entity_name": "insulin receptor substrate 1",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "glucose-6-phosphate dehydrogenase",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "tumor necrosis factor",
-        "llm-average": 5.36
+        "llm-average": 2.7
       }
     ]
   },
@@ -5021,11 +5021,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cancer",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "thyroid gland disease",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -5037,27 +5037,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "high mobility group box 1",
-        "llm-average": 18.56
+        "llm-average": 9.3
       },
       {
         "entity_name": "NAD(P)H quinone dehydrogenase 1",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "luteinizing hormone/choriogonadotropin receptor",
-        "llm-average": 13.74
+        "llm-average": 6.9
       },
       {
         "entity_name": "interleukin 2",
-        "llm-average": 13.19
+        "llm-average": 6.6
       },
       {
         "entity_name": "ATP binding cassette subfamily G member 2 (Junior blood group)",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "ATP binding cassette subfamily B member 1",
-        "llm-average": 10.72
+        "llm-average": 5.4
       }
     ]
   },
@@ -5069,31 +5069,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Status epilepticus",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "Seizure",
-        "llm-average": 18.05
+        "llm-average": 9.0
       },
       {
         "entity_name": "Encephalopathy",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "Psychosis",
-        "llm-average": 5.69
+        "llm-average": 2.8
       },
       {
         "entity_name": "Confusion",
-        "llm-average": 5.35
+        "llm-average": 2.7
       },
       {
         "entity_name": "Elevated hepatic transaminase",
-        "llm-average": 2.67
+        "llm-average": 1.3
       },
       {
         "entity_name": "Hyperglycemia",
-        "llm-average": 0.17
+        "llm-average": 0.1
       }
     ]
   },
@@ -5105,19 +5105,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tardive dyskinesia",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "Hemiballismus",
-        "llm-average": 9.63
+        "llm-average": 4.8
       },
       {
         "entity_name": "Chorea",
-        "llm-average": 8.06
+        "llm-average": 4.0
       },
       {
         "entity_name": "Abnormality of movement",
-        "llm-average": 3.05
+        "llm-average": 1.5
       }
     ]
   },
@@ -5129,19 +5129,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glutamate metabotropic receptor 2",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "Fas cell surface death receptor",
-        "llm-average": 14.1
+        "llm-average": 7.0
       },
       {
         "entity_name": "Fc fragment of IgG receptor IIIb",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "vitamin D receptor",
-        "llm-average": 9.15
+        "llm-average": 4.6
       }
     ]
   },
@@ -5153,23 +5153,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hyperkinetic movements",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "Behavioral abnormality",
-        "llm-average": 9.63
+        "llm-average": 4.8
       },
       {
         "entity_name": "Mood changes",
-        "llm-average": 8.72
+        "llm-average": 4.4
       },
       {
         "entity_name": "Schizophrenia",
-        "llm-average": 8.06
+        "llm-average": 4.0
       },
       {
         "entity_name": "Psychosis",
-        "llm-average": 8.05
+        "llm-average": 4.0
       }
     ]
   },
@@ -5181,15 +5181,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "carnitine palmitoyltransferase 2",
-        "llm-average": 13.74
+        "llm-average": 6.9
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 1",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 2",
-        "llm-average": 8.06
+        "llm-average": 4.0
       }
     ]
   },
@@ -5201,35 +5201,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Gout",
-        "llm-average": 16.42
+        "llm-average": 8.2
       },
       {
         "entity_name": "Nephrolithiasis",
-        "llm-average": 16.41
+        "llm-average": 8.2
       },
       {
         "entity_name": "Nephropathy",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "Renal tubular acidosis",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "Agitation",
-        "llm-average": 6.76
+        "llm-average": 3.4
       },
       {
         "entity_name": "Metabolic acidosis",
-        "llm-average": 6.26
+        "llm-average": 3.1
       },
       {
         "entity_name": "Alkalosis",
-        "llm-average": 5.35
+        "llm-average": 2.7
       },
       {
         "entity_name": "Acidosis",
-        "llm-average": 4.12
+        "llm-average": 2.1
       }
     ]
   },
@@ -5241,15 +5241,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Focal-onset seizure",
-        "llm-average": 9.99
+        "llm-average": 5.0
       },
       {
         "entity_name": "Anxiety",
-        "llm-average": 8.6
+        "llm-average": 4.3
       },
       {
         "entity_name": "Seizure",
-        "llm-average": 7.14
+        "llm-average": 3.6
       }
     ]
   },
@@ -5261,15 +5261,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "hepatic veno-occlusive disease",
-        "llm-average": 13.18
+        "llm-average": 6.6
       },
       {
         "entity_name": "cancer",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "liver disease",
-        "llm-average": 10.73
+        "llm-average": 5.4
       }
     ]
   },
@@ -5281,35 +5281,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Type II diabetes mellitus",
-        "llm-average": 13.6
+        "llm-average": 6.8
       },
       {
         "entity_name": "Nephropathy",
-        "llm-average": 10.66
+        "llm-average": 5.3
       },
       {
         "entity_name": "Peripheral neuropathy",
-        "llm-average": 10.13
+        "llm-average": 5.1
       },
       {
         "entity_name": "Ketosis",
-        "llm-average": 8.16
+        "llm-average": 4.1
       },
       {
         "entity_name": "Obesity",
-        "llm-average": 7.63
+        "llm-average": 3.8
       },
       {
         "entity_name": "Hyperglycemia",
-        "llm-average": 7.34
+        "llm-average": 3.7
       },
       {
         "entity_name": "Diabetes mellitus",
-        "llm-average": 6.28
+        "llm-average": 3.1
       },
       {
         "entity_name": "Type I diabetes mellitus",
-        "llm-average": 5.68
+        "llm-average": 2.8
       }
     ]
   },
@@ -5321,15 +5321,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "hepatic veno-occlusive disease",
-        "llm-average": 13.18
+        "llm-average": 6.6
       },
       {
         "entity_name": "cancer",
-        "llm-average": 10.21
+        "llm-average": 5.1
       },
       {
         "entity_name": "liver disease",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -5341,23 +5341,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Type II diabetes mellitus",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "Pancreatitis",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "Diabetic ketoacidosis",
-        "llm-average": 5.69
+        "llm-average": 2.8
       },
       {
         "entity_name": "Type I diabetes mellitus",
-        "llm-average": 4.27
+        "llm-average": 2.1
       }
     ]
   },
@@ -5369,11 +5369,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cancer",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "ischemia",
-        "llm-average": 7.14
+        "llm-average": 3.6
       }
     ]
   },
@@ -5385,35 +5385,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Pyelonephritis",
-        "llm-average": 12.51
+        "llm-average": 6.3
       },
       {
         "entity_name": "Recurrent lower respiratory tract infections",
-        "llm-average": 11.46
+        "llm-average": 5.7
       },
       {
         "entity_name": "Meningitis",
-        "llm-average": 11.42
+        "llm-average": 5.7
       },
       {
         "entity_name": "Sepsis",
-        "llm-average": 9.84
+        "llm-average": 4.9
       },
       {
         "entity_name": "Peritonitis",
-        "llm-average": 7.86
+        "llm-average": 3.9
       },
       {
         "entity_name": "Pneumonia",
-        "llm-average": 5.9
+        "llm-average": 3.0
       },
       {
         "entity_name": "Urinary bladder inflammation",
-        "llm-average": 5.52
+        "llm-average": 2.8
       },
       {
         "entity_name": "Bronchitis",
-        "llm-average": 3.94
+        "llm-average": 2.0
       }
     ]
   },
@@ -5425,15 +5425,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "calcium voltage-gated channel subunit alpha1 H",
-        "llm-average": 11.61
+        "llm-average": 5.8
       },
       {
         "entity_name": "calcium voltage-gated channel subunit alpha1 I",
-        "llm-average": 10.0
+        "llm-average": 5.0
       },
       {
         "entity_name": "calcium voltage-gated channel subunit alpha1 G",
-        "llm-average": 9.99
+        "llm-average": 5.0
       }
     ]
   },
@@ -5445,15 +5445,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "testicular cancer",
-        "llm-average": 17.33
+        "llm-average": 8.7
       },
       {
         "entity_name": "liver cancer",
-        "llm-average": 12.86
+        "llm-average": 6.4
       },
       {
         "entity_name": "cancer",
-        "llm-average": 5.55
+        "llm-average": 2.8
       }
     ]
   },
@@ -5465,31 +5465,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Osteopenia",
-        "llm-average": 14.1
+        "llm-average": 7.0
       },
       {
         "entity_name": "Generalized osteoporosis",
-        "llm-average": 12.87
+        "llm-average": 6.4
       },
       {
         "entity_name": "Vertebral compression fractures",
-        "llm-average": 12.86
+        "llm-average": 6.4
       },
       {
         "entity_name": "Neoplasm",
-        "llm-average": 11.74
+        "llm-average": 5.9
       },
       {
         "entity_name": "Abnormality of the gastrointestinal tract",
-        "llm-average": 5.89
+        "llm-average": 2.9
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 4.99
+        "llm-average": 2.5
       },
       {
         "entity_name": "Peptic ulcer",
-        "llm-average": 4.64
+        "llm-average": 2.3
       }
     ]
   },
@@ -5501,23 +5501,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Acrocyanosis",
-        "llm-average": 10.66
+        "llm-average": 5.3
       },
       {
         "entity_name": "Growth hormone excess",
-        "llm-average": 9.43
+        "llm-average": 4.7
       },
       {
         "entity_name": "Craniopharyngioma",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "Panhypopituitarism",
-        "llm-average": 4.63
+        "llm-average": 2.3
       },
       {
         "entity_name": "Pituitary dwarfism",
-        "llm-average": 4.47
+        "llm-average": 2.2
       }
     ]
   },
@@ -5529,23 +5529,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Fructose intolerance",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "Cerebral edema",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "Ocular hypertension",
-        "llm-average": 9.27
+        "llm-average": 4.6
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 4.83
+        "llm-average": 2.4
       },
       {
         "entity_name": "Acute kidney injury",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -5557,11 +5557,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Recurrent lower respiratory tract infections",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -5573,23 +5573,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Reduced blood folate concentration",
-        "llm-average": 8.94
+        "llm-average": 4.5
       },
       {
         "entity_name": "Megaloblastic anemia",
-        "llm-average": 8.79
+        "llm-average": 4.4
       },
       {
         "entity_name": "Gluten intolerance",
-        "llm-average": 8.35
+        "llm-average": 4.2
       },
       {
         "entity_name": "Seizure",
-        "llm-average": 6.4
+        "llm-average": 3.2
       },
       {
         "entity_name": "Anemia",
-        "llm-average": 4.83
+        "llm-average": 2.4
       }
     ]
   },
@@ -5601,27 +5601,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cerebral palsy",
-        "llm-average": 12.49
+        "llm-average": 6.2
       },
       {
         "entity_name": "Hyperkinetic movements",
-        "llm-average": 12.47
+        "llm-average": 6.2
       },
       {
         "entity_name": "Spasticity",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "Myelopathy",
-        "llm-average": 9.27
+        "llm-average": 4.6
       },
       {
         "entity_name": "Pain",
-        "llm-average": 6.98
+        "llm-average": 3.5
       },
       {
         "entity_name": "Morphological central nervous system abnormality",
-        "llm-average": 4.63
+        "llm-average": 2.3
       }
     ]
   },
@@ -5633,31 +5633,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vertebral compression fractures",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Neoplasm",
-        "llm-average": 10.13
+        "llm-average": 5.1
       },
       {
         "entity_name": "Generalized osteoporosis",
-        "llm-average": 8.43
+        "llm-average": 4.2
       },
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 7.99
+        "llm-average": 4.0
       },
       {
         "entity_name": "Osteopenia",
-        "llm-average": 7.7
+        "llm-average": 3.8
       },
       {
         "entity_name": "Abnormality of the gastrointestinal tract",
-        "llm-average": 5.35
+        "llm-average": 2.7
       },
       {
         "entity_name": "Peptic ulcer",
-        "llm-average": 4.81
+        "llm-average": 2.4
       }
     ]
   },
@@ -5669,11 +5669,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Pollakisuria",
-        "llm-average": 7.51
+        "llm-average": 3.8
       },
       {
         "entity_name": "Urinary urgency",
-        "llm-average": 7.14
+        "llm-average": 3.6
       }
     ]
   },
@@ -5685,11 +5685,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Typical absence seizure",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "Seizure",
-        "llm-average": 3.75
+        "llm-average": 1.9
       }
     ]
   },
@@ -5701,11 +5701,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cancer",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "ischemia",
-        "llm-average": 7.14
+        "llm-average": 3.6
       }
     ]
   },
@@ -5717,27 +5717,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TTK",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "ACVR1",
-        "llm-average": 12.3
+        "llm-average": 6.2
       },
       {
         "entity_name": "PON1",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "ACVRL1",
-        "llm-average": 10.51
+        "llm-average": 5.3
       },
       {
         "entity_name": "ACHE",
-        "llm-average": 9.49
+        "llm-average": 4.7
       },
       {
         "entity_name": "BCHE",
-        "llm-average": 7.86
+        "llm-average": 3.9
       }
     ]
   },
@@ -5749,23 +5749,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Renal insufficiency",
-        "llm-average": 13.54
+        "llm-average": 6.8
       },
       {
         "entity_name": "Duodenal ulcer",
-        "llm-average": 9.63
+        "llm-average": 4.8
       },
       {
         "entity_name": "Gastric ulcer",
-        "llm-average": 8.56
+        "llm-average": 4.3
       },
       {
         "entity_name": "Gastroesophageal reflux",
-        "llm-average": 7.87
+        "llm-average": 3.9
       },
       {
         "entity_name": "Esophagitis",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -5777,23 +5777,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Increased body weight",
-        "llm-average": 10.31
+        "llm-average": 5.2
       },
       {
         "entity_name": "Agitation",
-        "llm-average": 8.19
+        "llm-average": 4.1
       },
       {
         "entity_name": "Hypersomnia",
-        "llm-average": 6.91
+        "llm-average": 3.5
       },
       {
         "entity_name": "Fatigue",
-        "llm-average": 3.55
+        "llm-average": 1.8
       },
       {
         "entity_name": "Insomnia",
-        "llm-average": 1.24
+        "llm-average": 0.6
       }
     ]
   },
@@ -5805,19 +5805,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N-acetyltransferase 1",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "solute carrier family 6 member 2",
-        "llm-average": 10.36
+        "llm-average": 5.2
       },
       {
         "entity_name": "solute carrier family 6 member 3",
-        "llm-average": 7.86
+        "llm-average": 3.9
       },
       {
         "entity_name": "solute carrier family 6 member 4",
-        "llm-average": 6.8
+        "llm-average": 3.4
       }
     ]
   },
@@ -5829,15 +5829,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "testicular cancer",
-        "llm-average": 17.33
+        "llm-average": 8.7
       },
       {
         "entity_name": "liver cancer",
-        "llm-average": 12.86
+        "llm-average": 6.4
       },
       {
         "entity_name": "cancer",
-        "llm-average": 5.55
+        "llm-average": 2.8
       }
     ]
   },
@@ -5849,15 +5849,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "hepatic veno-occlusive disease",
-        "llm-average": 13.18
+        "llm-average": 6.6
       },
       {
         "entity_name": "cancer",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "liver disease",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -5869,19 +5869,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Schizophrenia",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "Bipolar affective disorder",
-        "llm-average": 13.94
+        "llm-average": 7.0
       },
       {
         "entity_name": "Mania",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Dementia",
-        "llm-average": 2.67
+        "llm-average": 1.3
       }
     ]
   },
@@ -5893,19 +5893,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N-acetyltransferase 1",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "solute carrier family 6 member 4",
-        "llm-average": 14.81
+        "llm-average": 7.4
       },
       {
         "entity_name": "solute carrier family 6 member 2",
-        "llm-average": 10.72
+        "llm-average": 5.4
       },
       {
         "entity_name": "solute carrier family 6 member 3",
-        "llm-average": 10.35
+        "llm-average": 5.2
       }
     ]
   },
@@ -5917,27 +5917,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tranexamic acid",
-        "llm-average": 15.44
+        "llm-average": 7.7
       },
       {
         "entity_name": "Danazol",
-        "llm-average": 13.3
+        "llm-average": 6.6
       },
       {
         "entity_name": "Desmopressin",
-        "llm-average": 12.99
+        "llm-average": 6.5
       },
       {
         "entity_name": "Mefenamic acid",
-        "llm-average": 11.71
+        "llm-average": 5.9
       },
       {
         "entity_name": "Levonorgestrel",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Goserelin",
-        "llm-average": 10.29
+        "llm-average": 5.1
       }
     ]
   },
@@ -5949,15 +5949,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TNNI3",
-        "llm-average": 15.44
+        "llm-average": 7.7
       },
       {
         "entity_name": "TNNT2",
-        "llm-average": 14.46
+        "llm-average": 7.2
       },
       {
         "entity_name": "NPPB",
-        "llm-average": 10.49
+        "llm-average": 5.2
       }
     ]
   },
@@ -5969,19 +5969,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sumatriptan",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "Almotriptan",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "Diclofenac",
-        "llm-average": 7.1
+        "llm-average": 3.5
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 4.33
+        "llm-average": 2.2
       }
     ]
   },
@@ -5993,27 +5993,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "INHBA",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "TRH",
-        "llm-average": 9.81
+        "llm-average": 4.9
       },
       {
         "entity_name": "IGF1",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "FSHB",
-        "llm-average": 7.65
+        "llm-average": 3.8
       },
       {
         "entity_name": "SHBG",
-        "llm-average": 7.35
+        "llm-average": 3.7
       },
       {
         "entity_name": "PRL",
-        "llm-average": 6.44
+        "llm-average": 3.2
       }
     ]
   },
@@ -6025,15 +6025,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Riluzole",
-        "llm-average": 10.58
+        "llm-average": 5.3
       },
       {
         "entity_name": "Gadoteridol",
-        "llm-average": 9.6
+        "llm-average": 4.8
       },
       {
         "entity_name": "Gadodiamide",
-        "llm-average": 9.03
+        "llm-average": 4.5
       }
     ]
   },
@@ -6045,19 +6045,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Olanzapine",
-        "llm-average": 12.22
+        "llm-average": 6.1
       },
       {
         "entity_name": "Quetiapine",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "Trihexyphenidyl",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Benzatropine",
-        "llm-average": 9.83
+        "llm-average": 4.9
       }
     ]
   },
@@ -6069,15 +6069,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Nesiritide",
-        "llm-average": 17.92
+        "llm-average": 9.0
       },
       {
         "entity_name": "Erythrityl tetranitrate",
-        "llm-average": 11.68
+        "llm-average": 5.8
       },
       {
         "entity_name": "Ketoprofen",
-        "llm-average": 4.33
+        "llm-average": 2.2
       }
     ]
   },
@@ -6089,15 +6089,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Mirtazapine",
-        "llm-average": 8.58
+        "llm-average": 4.3
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 5.74
+        "llm-average": 2.9
       },
       {
         "entity_name": "Gabapentin",
-        "llm-average": 5.71
+        "llm-average": 2.9
       }
     ]
   },
@@ -6109,23 +6109,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Mifepristone",
-        "llm-average": 14.31
+        "llm-average": 7.2
       },
       {
         "entity_name": "Dinoprost tromethamine",
-        "llm-average": 10.52
+        "llm-average": 5.3
       },
       {
         "entity_name": "Dinoprostone",
-        "llm-average": 9.96
+        "llm-average": 5.0
       },
       {
         "entity_name": "Cabergoline",
-        "llm-average": 8.9
+        "llm-average": 4.4
       },
       {
         "entity_name": "Bromocriptine",
-        "llm-average": 5.71
+        "llm-average": 2.9
       }
     ]
   },
@@ -6137,35 +6137,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Venlafaxine",
-        "llm-average": 13.1
+        "llm-average": 6.5
       },
       {
         "entity_name": "Paroxetine",
-        "llm-average": 12.66
+        "llm-average": 6.3
       },
       {
         "entity_name": "(S)-Fluoxetine",
-        "llm-average": 11.68
+        "llm-average": 5.8
       },
       {
         "entity_name": "(R)-Fluoxetine",
-        "llm-average": 11.12
+        "llm-average": 5.6
       },
       {
         "entity_name": "Fluoxetine",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Sertraline",
-        "llm-average": 10.11
+        "llm-average": 5.1
       },
       {
         "entity_name": "Clonazepam",
-        "llm-average": 10.08
+        "llm-average": 5.0
       },
       {
         "entity_name": "Alprazolam",
-        "llm-average": 9.4
+        "llm-average": 4.7
       }
     ]
   },
@@ -6177,35 +6177,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "(3-Carboxy-2-(R)-Hydroxy-Propyl)-Trimethyl-Ammonium",
-        "llm-average": 19.1
+        "llm-average": 9.6
       },
       {
         "entity_name": "Thiamine",
-        "llm-average": 15.58
+        "llm-average": 7.8
       },
       {
         "entity_name": "Edetic acid",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "Ifosfamide",
-        "llm-average": 13.2
+        "llm-average": 6.6
       },
       {
         "entity_name": "Levocarnitine",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 10.39
+        "llm-average": 5.2
       },
       {
         "entity_name": "Fosphenytoin",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Minoxidil",
-        "llm-average": 5.81
+        "llm-average": 2.9
       }
     ]
   },
@@ -6217,19 +6217,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Calcium",
-        "llm-average": 18.9
+        "llm-average": 9.5
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 15.44
+        "llm-average": 7.7
       },
       {
         "entity_name": "Magnesium sulfate",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "Erythromycin",
-        "llm-average": 1.25
+        "llm-average": 0.6
       }
     ]
   },
@@ -6241,15 +6241,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Topiramate",
-        "llm-average": 17.52
+        "llm-average": 8.8
       },
       {
         "entity_name": "Citric acid",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Norfloxacin",
-        "llm-average": 4.52
+        "llm-average": 2.3
       }
     ]
   },
@@ -6261,19 +6261,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Fluoxymesterone",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "Epitestosterone",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "Methyltestosterone",
-        "llm-average": 9.2
+        "llm-average": 4.6
       },
       {
         "entity_name": "Testosterone",
-        "llm-average": 8.38
+        "llm-average": 4.2
       }
     ]
   },
@@ -6285,15 +6285,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Desflurane",
-        "llm-average": 12.35
+        "llm-average": 6.2
       },
       {
         "entity_name": "Sevoflurane",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "Enflurane",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -6305,27 +6305,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Epicaptopril",
-        "llm-average": 14.52
+        "llm-average": 7.3
       },
       {
         "entity_name": "Captopril",
-        "llm-average": 11.61
+        "llm-average": 5.8
       },
       {
         "entity_name": "Atorvastatin",
-        "llm-average": 11.31
+        "llm-average": 5.7
       },
       {
         "entity_name": "Minoxidil",
-        "llm-average": 9.89
+        "llm-average": 4.9
       },
       {
         "entity_name": "Repaglinide",
-        "llm-average": 6.27
+        "llm-average": 3.1
       },
       {
         "entity_name": "Glimepiride",
-        "llm-average": 5.71
+        "llm-average": 2.9
       }
     ]
   },
@@ -6337,27 +6337,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cinacalcet",
-        "llm-average": 15.38
+        "llm-average": 7.7
       },
       {
         "entity_name": "Ramipril",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Sevelamer",
-        "llm-average": 14.06
+        "llm-average": 7.0
       },
       {
         "entity_name": "Paricalcitol",
-        "llm-average": 13.72
+        "llm-average": 6.9
       },
       {
         "entity_name": "Ezetimibe",
-        "llm-average": 13.06
+        "llm-average": 6.5
       },
       {
         "entity_name": "Hydrochlorothiazide",
-        "llm-average": 6.99
+        "llm-average": 3.5
       }
     ]
   },
@@ -6369,19 +6369,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cladribine",
-        "llm-average": 14.17
+        "llm-average": 7.1
       },
       {
         "entity_name": "Fludarabine",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "Camptothecin",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "2'-Deoxycytidine",
-        "llm-average": 7.55
+        "llm-average": 3.8
       }
     ]
   },
@@ -6393,11 +6393,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Streptozocin",
-        "llm-average": 10.77
+        "llm-average": 5.4
       },
       {
         "entity_name": "Rosiglitazone",
-        "llm-average": 10.02
+        "llm-average": 5.0
       }
     ]
   },
@@ -6409,31 +6409,31 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Ethosuximide",
-        "llm-average": 14.29
+        "llm-average": 7.1
       },
       {
         "entity_name": "Trimethadione",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "Methsuximide",
-        "llm-average": 11.68
+        "llm-average": 5.8
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 9.83
+        "llm-average": 4.9
       },
       {
         "entity_name": "Clonazepam",
-        "llm-average": 8.9
+        "llm-average": 4.5
       },
       {
         "entity_name": "Acetazolamide",
-        "llm-average": 7.91
+        "llm-average": 4.0
       },
       {
         "entity_name": "Carbamazepine",
-        "llm-average": 3.14
+        "llm-average": 1.6
       }
     ]
   },
@@ -6445,35 +6445,35 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hydroxy-Phenyl-Acetic Acid 8-Methyl-8-Aza-Bicyclo[3.2.1]Oct-3-Yl Ester",
-        "llm-average": 18.9
+        "llm-average": 9.5
       },
       {
         "entity_name": "Travoprost",
-        "llm-average": 10.88
+        "llm-average": 5.4
       },
       {
         "entity_name": "Dexamethasone",
-        "llm-average": 8.25
+        "llm-average": 4.1
       },
       {
         "entity_name": "Prednisolone",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "Betamethasone",
-        "llm-average": 5.94
+        "llm-average": 3.0
       },
       {
         "entity_name": "Prednisone",
-        "llm-average": 5.72
+        "llm-average": 2.9
       },
       {
         "entity_name": "Methylprednisolone",
-        "llm-average": 5.71
+        "llm-average": 2.9
       },
       {
         "entity_name": "Hydrocortisone",
-        "llm-average": 4.45
+        "llm-average": 2.2
       }
     ]
   },
@@ -6485,27 +6485,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vigabatrin",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 16.54
+        "llm-average": 8.3
       },
       {
         "entity_name": "Tiagabine",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "Pyridoxal phosphate",
-        "llm-average": 10.03
+        "llm-average": 5.0
       },
       {
         "entity_name": "Pyruvic acid",
-        "llm-average": 6.37
+        "llm-average": 3.2
       },
       {
         "entity_name": "Alanine",
-        "llm-average": 4.55
+        "llm-average": 2.3
       }
     ]
   },
@@ -6517,19 +6517,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "polycystin 2 like 1, transient receptor potential cation channel",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "cholinergic receptor muscarinic 4",
-        "llm-average": 7.92
+        "llm-average": 4.0
       },
       {
         "entity_name": "sigma non-opioid intracellular receptor 1",
-        "llm-average": 7.1
+        "llm-average": 3.5
       }
     ]
   },
@@ -6541,11 +6541,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Free fatty acid receptors",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "G alpha (i) signalling events",
-        "llm-average": 6.63
+        "llm-average": 3.3
       }
     ]
   },
@@ -6557,15 +6557,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "adenylate cyclase-activating G protein-coupled receptor signaling pathway",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "G protein-coupled receptor signaling pathway",
-        "llm-average": 5.64
+        "llm-average": 2.8
       },
       {
         "entity_name": "cell surface receptor signaling pathway",
-        "llm-average": 4.32
+        "llm-average": 2.2
       }
     ]
   },
@@ -6577,23 +6577,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "negative regulation of inflammatory response",
-        "llm-average": 12.67
+        "llm-average": 6.3
       },
       {
         "entity_name": "response to acidic pH",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "response to molecule of bacterial origin",
-        "llm-average": 11.32
+        "llm-average": 5.7
       },
       {
         "entity_name": "G protein-coupled receptor signaling pathway",
-        "llm-average": 7.95
+        "llm-average": 4.0
       },
       {
         "entity_name": "lipid metabolic process",
-        "llm-average": 5.81
+        "llm-average": 2.9
       }
     ]
   },
@@ -6605,19 +6605,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ABL proto-oncogene 1, non-receptor tyrosine kinase",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "interleukin 10",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "solute carrier family 15 member 1",
-        "llm-average": 9.31
+        "llm-average": 4.7
       },
       {
         "entity_name": "DNA nucleotidylexotransferase",
-        "llm-average": 4.46
+        "llm-average": 2.2
       }
     ]
   },
@@ -6629,19 +6629,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "polycystin 2 like 1, transient receptor potential cation channel",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "cholinergic receptor muscarinic 4",
-        "llm-average": 7.52
+        "llm-average": 3.8
       },
       {
         "entity_name": "sigma non-opioid intracellular receptor 1",
-        "llm-average": 6.7
+        "llm-average": 3.3
       }
     ]
   },
@@ -6653,11 +6653,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "positive regulation of flagellated sperm motility",
-        "llm-average": 15.74
+        "llm-average": 7.9
       },
       {
         "entity_name": "glycolytic process",
-        "llm-average": 5.21
+        "llm-average": 2.6
       }
     ]
   },
@@ -6669,19 +6669,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2C",
-        "llm-average": 15.51
+        "llm-average": 7.8
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2B",
-        "llm-average": 13.66
+        "llm-average": 6.8
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 2A",
-        "llm-average": 12.87
+        "llm-average": 6.4
       },
       {
         "entity_name": "glutamate ionotropic receptor NMDA type subunit 3A",
-        "llm-average": 10.5
+        "llm-average": 5.2
       }
     ]
   },
@@ -6693,23 +6693,23 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "response to activity",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "response to alkaloid",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "oxidative phosphorylation",
-        "llm-average": 8.15
+        "llm-average": 4.1
       },
       {
         "entity_name": "mitochondrial electron transport, ubiquinol to cytochrome c",
-        "llm-average": 7.0
+        "llm-average": 3.5
       },
       {
         "entity_name": "aerobic respiration",
-        "llm-average": 5.91
+        "llm-average": 3.0
       }
     ]
   },
@@ -6721,19 +6721,19 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cholinergic receptor muscarinic 1",
-        "llm-average": 11.75
+        "llm-average": 5.9
       },
       {
         "entity_name": "polycystin 2 like 1, transient receptor potential cation channel",
-        "llm-average": 10.1
+        "llm-average": 5.0
       },
       {
         "entity_name": "sigma non-opioid intracellular receptor 1",
-        "llm-average": 7.69
+        "llm-average": 3.8
       },
       {
         "entity_name": "cholinergic receptor muscarinic 4",
-        "llm-average": 6.44
+        "llm-average": 3.2
       }
     ]
   },
@@ -6745,15 +6745,15 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "estrogen receptor 2",
-        "llm-average": 14.16
+        "llm-average": 7.1
       },
       {
         "entity_name": "estrogen receptor 1",
-        "llm-average": 12.08
+        "llm-average": 6.0
       },
       {
         "entity_name": "fibroblast growth factor receptor 1",
-        "llm-average": 4.32
+        "llm-average": 2.2
       }
     ]
   },
@@ -6765,27 +6765,27 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "phospholipase A2 group IIA",
-        "llm-average": 13.17
+        "llm-average": 6.6
       },
       {
         "entity_name": "carnitine palmitoyltransferase 2",
-        "llm-average": 9.7
+        "llm-average": 4.9
       },
       {
         "entity_name": "gamma-glutamyltransferase 1",
-        "llm-average": 9.34
+        "llm-average": 4.7
       },
       {
         "entity_name": "cytochrome P450 family 2 subfamily C member 9",
-        "llm-average": 7.69
+        "llm-average": 3.8
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 2",
-        "llm-average": 6.8
+        "llm-average": 3.4
       },
       {
         "entity_name": "prostaglandin-endoperoxide synthase 1",
-        "llm-average": 4.49
+        "llm-average": 2.2
       }
     ]
   },
@@ -6797,11 +6797,11 @@ export const batch4: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sensory processing of sound by outer hair cells of the cochlea",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Sensory processing of sound by inner hair cells of the cochlea",
-        "llm-average": 8.02
+        "llm-average": 4.0
       }
     ]
   }

--- a/lib/batches/batch5.ts
+++ b/lib/batches/batch5.ts
@@ -9,27 +9,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBX7",
-        "llm-average": 15.42
+        "llm-average": 7.7
       },
       {
         "entity_name": "L3MBTL2",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "SCML2",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "MAPK14",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "PCGF1",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "RBX1",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -41,27 +41,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bufotenine",
-        "llm-average": 12.94
+        "llm-average": 6.5
       },
       {
         "entity_name": "2-(N-morpholino)ethanesulfonic acid",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "Balsalazide",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Meropenem",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Succinic acid",
-        "llm-average": 8.1
+        "llm-average": 4.1
       },
       {
         "entity_name": "Acetic acid",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -73,15 +73,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Ethinylestradiol",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Acetylsalicylic acid",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -93,19 +93,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dasatinib",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Valproic acid",
-        "llm-average": 4.97
+        "llm-average": 2.5
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 2.22
+        "llm-average": 1.1
       }
     ]
   },
@@ -117,11 +117,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 7.06
+        "llm-average": 3.5
       }
     ]
   },
@@ -133,19 +133,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPC1",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "FBLN1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "FARSA",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "AP2S1",
-        "llm-average": 8.89
+        "llm-average": 4.4
       }
     ]
   },
@@ -157,31 +157,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N\u03b1-[(2S)-2-{[(S)-[(1S)-1-{[(Benzyloxy)carbonyl]amino}-2-phenylethyl](hydroxy)phosphoryl]methyl}-5-phenylpentanoyl]-L-tryptophanamide",
-        "llm-average": 18.43
+        "llm-average": 9.2
       },
       {
         "entity_name": "Guanosine-5'-Triphosphate",
-        "llm-average": 9.54
+        "llm-average": 4.8
       },
       {
         "entity_name": "ATP",
-        "llm-average": 7.45
+        "llm-average": 3.7
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate",
-        "llm-average": 6.14
+        "llm-average": 3.1
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 3.4
+        "llm-average": 1.7
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 2.88
+        "llm-average": 1.4
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 2.75
+        "llm-average": 1.4
       }
     ]
   },
@@ -193,31 +193,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "7-methyl-5'-guanylic acid",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Guanosine-5'-Triphosphate",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "Fructose -6-Phosphate",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "D-glucitol 6-phosphate",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "Beta-D-Glucose",
-        "llm-average": 5.1
+        "llm-average": 2.5
       },
       {
         "entity_name": "D-Allopyranose",
-        "llm-average": 4.97
+        "llm-average": 2.5
       },
       {
         "entity_name": "ATP",
-        "llm-average": 4.05
+        "llm-average": 2.0
       }
     ]
   },
@@ -229,15 +229,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 3.79
+        "llm-average": 1.9
       },
       {
         "entity_name": "Calcium",
-        "llm-average": 3.66
+        "llm-average": 1.8
       }
     ]
   },
@@ -249,11 +249,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TXNDC5",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "GMPPA",
-        "llm-average": 9.67
+        "llm-average": 4.8
       }
     ]
   },
@@ -265,11 +265,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Leucine rich repeat C-terminal domain",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "Leucine rich repeat",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -281,11 +281,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Doramapimod",
-        "llm-average": 15.69
+        "llm-average": 7.8
       },
       {
         "entity_name": "Bisphenol A",
-        "llm-average": 14.51
+        "llm-average": 7.3
       }
     ]
   },
@@ -297,11 +297,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Squalene epoxidase",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "NAD(P)-binding Rossmann-like domain",
-        "llm-average": 6.67
+        "llm-average": 3.3
       }
     ]
   },
@@ -313,23 +313,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PICK1",
-        "llm-average": 19.08
+        "llm-average": 9.5
       },
       {
         "entity_name": "TCF12",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "ZSCAN1",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "PTGER4",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "INTS13",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -341,35 +341,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dasatinib",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Progesterone",
-        "llm-average": 11.76
+        "llm-average": 5.9
       },
       {
         "entity_name": "ATP",
-        "llm-average": 6.8
-      },
-      {
-        "entity_name": "Zinc",
-        "llm-average": 3.92
-      },
-      {
-        "entity_name": "Vitamin E",
         "llm-average": 3.4
       },
       {
+        "entity_name": "Zinc",
+        "llm-average": 2.0
+      },
+      {
+        "entity_name": "Vitamin E",
+        "llm-average": 1.7
+      },
+      {
         "entity_name": "Calcium",
-        "llm-average": 2.88
+        "llm-average": 1.4
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 2.35
+        "llm-average": 1.2
       }
     ]
   },
@@ -381,11 +381,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SIAH1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "KCNJ16",
-        "llm-average": 13.59
+        "llm-average": 6.8
       }
     ]
   },
@@ -397,35 +397,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 14.38
+        "llm-average": 7.2
       },
       {
         "entity_name": "Flavin-N7 protonated-adenine dinucleotide",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Flavin adenine dinucleotide",
-        "llm-average": 11.9
+        "llm-average": 5.9
       },
       {
         "entity_name": "Atrazine",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "D-tartaric acid",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "NADH",
-        "llm-average": 8.76
+        "llm-average": 4.4
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -437,15 +437,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N-Dimethyl-Lysine",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Capric acid",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Codeine",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -457,11 +457,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Valproic acid",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 10.2
+        "llm-average": 5.1
       }
     ]
   },
@@ -473,11 +473,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PRNP",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "IQCB1",
-        "llm-average": 13.59
+        "llm-average": 6.8
       }
     ]
   },
@@ -489,15 +489,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Importin beta binding domain",
-        "llm-average": 18.43
+        "llm-average": 9.2
       },
       {
         "entity_name": "Atypical Arm repeat",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Armadillo/beta-catenin-like repeat",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -509,19 +509,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "IL36B",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "IL36G",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "IL36A",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "IL2",
-        "llm-average": 3.4
+        "llm-average": 1.7
       }
     ]
   },
@@ -533,23 +533,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N-Acetyllactosamine",
-        "llm-average": 18.3
+        "llm-average": 9.2
       },
       {
         "entity_name": "Uridine diphosphategalactose",
-        "llm-average": 17.25
+        "llm-average": 8.6
       },
       {
         "entity_name": "N-Acetyl-D-glucosamine",
-        "llm-average": 10.72
+        "llm-average": 5.4
       },
       {
         "entity_name": "Uridine 5'-diphosphate",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Manganese",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -561,35 +561,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "N-Acetyl-D-mannosamine 6-phosphate",
-        "llm-average": 12.16
+        "llm-average": 6.1
       },
       {
         "entity_name": "Beta-D-Fructose 2-phosphate",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "N-Acetylmannosamine",
-        "llm-average": 10.59
+        "llm-average": 5.3
       },
       {
         "entity_name": "Phosphate",
-        "llm-average": 4.97
+        "llm-average": 2.5
       },
       {
         "entity_name": "D-Fructose",
-        "llm-average": 4.84
+        "llm-average": 2.4
       },
       {
         "entity_name": "NADP",
-        "llm-average": 4.44
+        "llm-average": 2.2
       },
       {
         "entity_name": "NAD",
-        "llm-average": 3.4
+        "llm-average": 1.7
       },
       {
         "entity_name": "Water",
-        "llm-average": 0.26
+        "llm-average": 0.1
       }
     ]
   },
@@ -601,15 +601,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Guanosine-5'-Triphosphate",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "Dihydrogenphosphate",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -621,11 +621,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CCNDBP1",
-        "llm-average": 14.12
+        "llm-average": 7.1
       },
       {
         "entity_name": "ACTBL2",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -637,23 +637,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CREB3",
-        "llm-average": 19.48
+        "llm-average": 9.7
       },
       {
         "entity_name": "GRINA",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "SLC10A6",
-        "llm-average": 14.25
+        "llm-average": 7.1
       },
       {
         "entity_name": "MFSD14B",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "REEP4",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -665,31 +665,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "WNT11",
-        "llm-average": 19.08
+        "llm-average": 9.5
       },
       {
         "entity_name": "CUL3",
-        "llm-average": 14.9
+        "llm-average": 7.5
       },
       {
         "entity_name": "GPR37",
-        "llm-average": 11.11
+        "llm-average": 5.6
       },
       {
         "entity_name": "GPRC5B",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "MEOX2",
-        "llm-average": 10.85
+        "llm-average": 5.4
       },
       {
         "entity_name": "HSCB",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "FUCA1",
-        "llm-average": 5.75
+        "llm-average": 2.9
       }
     ]
   },
@@ -701,11 +701,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bisphenol A",
-        "llm-average": 10.2
+        "llm-average": 5.1
       },
       {
         "entity_name": "ATP",
-        "llm-average": 8.5
+        "llm-average": 4.2
       }
     ]
   },
@@ -717,27 +717,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R2",
-        "llm-average": 15.29
+        "llm-average": 7.6
       },
       {
         "entity_name": "PIK3CB",
-        "llm-average": 13.99
+        "llm-average": 7.0
       },
       {
         "entity_name": "PIK3CA",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "LGALS3",
-        "llm-average": 10.98
+        "llm-average": 5.5
       },
       {
         "entity_name": "ZAP70",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "CD4",
-        "llm-average": 6.93
+        "llm-average": 3.5
       }
     ]
   },
@@ -749,27 +749,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "5-(5-CHLORO-2,4-DIHYDROXYPHENYL)-N-ETHYL-4-(4-METHOXYPHENYL)ISOXAZOLE-3-CARBOXAMIDE",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "Doxycycline",
-        "llm-average": 9.15
+        "llm-average": 4.6
       },
       {
         "entity_name": "Lacosamide",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Iron",
-        "llm-average": 2.88
+        "llm-average": 1.4
       },
       {
         "entity_name": "Isopropyl alcohol",
-        "llm-average": 2.61
+        "llm-average": 1.3
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 1.44
+        "llm-average": 0.7
       }
     ]
   },
@@ -781,15 +781,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Plexin cytoplasmic RasGAP domain",
-        "llm-average": 18.43
+        "llm-average": 9.2
       },
       {
         "entity_name": "Sema domain",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "Plexin repeat",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -801,19 +801,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TLL1",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "PCOLCE",
-        "llm-average": 12.55
+        "llm-average": 6.3
       },
       {
         "entity_name": "LOX",
-        "llm-average": 12.03
+        "llm-average": 6.0
       },
       {
         "entity_name": "LOXL4",
-        "llm-average": 9.67
+        "llm-average": 4.8
       }
     ]
   },
@@ -825,27 +825,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Phosphoaminophosphonic acid guanylate ester",
-        "llm-average": 13.73
+        "llm-average": 6.9
       },
       {
         "entity_name": "Guanosine-5'-Diphosphate",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "N-Ethylmaleimide",
-        "llm-average": 9.02
+        "llm-average": 4.5
       },
       {
         "entity_name": "Tromethamine",
-        "llm-average": 5.62
+        "llm-average": 2.8
       },
       {
         "entity_name": "Palmitic Acid",
-        "llm-average": 4.97
+        "llm-average": 2.5
       },
       {
         "entity_name": "Magnesium cation",
-        "llm-average": 3.4
+        "llm-average": 1.7
       }
     ]
   },
@@ -857,19 +857,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Phosphatidyl serine",
-        "llm-average": 15.56
+        "llm-average": 7.8
       },
       {
         "entity_name": "D-Serine",
-        "llm-average": 9.8
+        "llm-average": 4.9
       },
       {
         "entity_name": "Serine",
-        "llm-average": 8.37
+        "llm-average": 4.2
       },
       {
         "entity_name": "Choline",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -881,19 +881,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Arsenous acid",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Isobutyric acid",
-        "llm-average": 8.24
+        "llm-average": 4.1
       },
       {
         "entity_name": "Tromethamine",
-        "llm-average": 7.97
+        "llm-average": 4.0
       },
       {
         "entity_name": "Zinc",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -905,23 +905,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ST3GAL3",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "LALBA",
-        "llm-average": 13.33
+        "llm-average": 6.7
       },
       {
         "entity_name": "OGN",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "LUM",
-        "llm-average": 11.5
+        "llm-average": 5.8
       },
       {
         "entity_name": "KERA",
-        "llm-average": 10.98
+        "llm-average": 5.5
       }
     ]
   },
@@ -933,15 +933,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "2-Amino-1-methyl-6-phenylimidazo(4,5-b)pyridine",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "Vincristine",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "Acetaminophen",
-        "llm-average": 4.97
+        "llm-average": 2.5
       }
     ]
   },
@@ -953,11 +953,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ESR1",
-        "llm-average": 15.28
+        "llm-average": 7.6
       },
       {
         "entity_name": "CNOT1",
-        "llm-average": 14.19
+        "llm-average": 7.1
       }
     ]
   },
@@ -969,15 +969,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Erlotinib",
-        "llm-average": 18.84
+        "llm-average": 9.4
       },
       {
         "entity_name": "Ketoconazole",
-        "llm-average": 12.27
+        "llm-average": 6.1
       },
       {
         "entity_name": "Metronidazole",
-        "llm-average": 6.51
+        "llm-average": 3.3
       }
     ]
   },
@@ -989,15 +989,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tacrolimus",
-        "llm-average": 15.56
+        "llm-average": 7.8
       },
       {
         "entity_name": "Methoxsalen",
-        "llm-average": 14.37
+        "llm-average": 7.2
       },
       {
         "entity_name": "Methotrexate",
-        "llm-average": 6.51
+        "llm-average": 3.3
       }
     ]
   },
@@ -1009,35 +1009,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Selumetinib",
-        "llm-average": 12.86
+        "llm-average": 6.4
       },
       {
         "entity_name": "Everolimus",
-        "llm-average": 12.53
+        "llm-average": 6.3
       },
       {
         "entity_name": "Temsirolimus",
-        "llm-average": 10.78
+        "llm-average": 5.4
       },
       {
         "entity_name": "Octreotide",
-        "llm-average": 9.44
+        "llm-average": 4.7
       },
       {
         "entity_name": "Lapatinib",
-        "llm-average": 7.84
+        "llm-average": 3.9
       },
       {
         "entity_name": "Erlotinib",
-        "llm-average": 7.71
+        "llm-average": 3.9
       },
       {
         "entity_name": "Imatinib",
-        "llm-average": 6.45
+        "llm-average": 3.2
       },
       {
         "entity_name": "Carboplatin",
-        "llm-average": 6.23
+        "llm-average": 3.1
       }
     ]
   },
@@ -1049,11 +1049,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Binimetinib",
-        "llm-average": 11.98
+        "llm-average": 6.0
       },
       {
         "entity_name": "Selumetinib",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -1065,11 +1065,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Doxycycline",
-        "llm-average": 10.46
+        "llm-average": 5.2
       },
       {
         "entity_name": "Lacosamide",
-        "llm-average": 9.65
+        "llm-average": 4.8
       }
     ]
   },
@@ -1081,11 +1081,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tositumomab",
-        "llm-average": 13.79
+        "llm-average": 6.9
       },
       {
         "entity_name": "Rituximab",
-        "llm-average": 11.16
+        "llm-average": 5.6
       }
     ]
   },
@@ -1097,15 +1097,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Sirolimus",
-        "llm-average": 14.64
+        "llm-average": 7.3
       },
       {
         "entity_name": "Flutamide",
-        "llm-average": 13.35
+        "llm-average": 6.7
       },
       {
         "entity_name": "Estradiol",
-        "llm-average": 7.19
+        "llm-average": 3.6
       }
     ]
   },
@@ -1117,15 +1117,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vorinostat",
-        "llm-average": 15.92
+        "llm-average": 8.0
       },
       {
         "entity_name": "Gallium nitrate",
-        "llm-average": 8.57
+        "llm-average": 4.3
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 8.52
+        "llm-average": 4.3
       }
     ]
   },
@@ -1137,23 +1137,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Infliximab",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "Nelfinavir",
-        "llm-average": 8.84
+        "llm-average": 4.4
       },
       {
         "entity_name": "Ritonavir",
-        "llm-average": 8.28
+        "llm-average": 4.1
       },
       {
         "entity_name": "Saquinavir",
-        "llm-average": 8.26
+        "llm-average": 4.1
       },
       {
         "entity_name": "Ethanol",
-        "llm-average": 5.49
+        "llm-average": 2.7
       }
     ]
   },
@@ -1165,11 +1165,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Estradiol",
-        "llm-average": 10.39
+        "llm-average": 5.2
       },
       {
         "entity_name": "Glucosamine",
-        "llm-average": 9.04
+        "llm-average": 4.5
       }
     ]
   },
@@ -1181,15 +1181,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vorinostat",
-        "llm-average": 15.78
+        "llm-average": 7.9
       },
       {
         "entity_name": "Cyclosporine",
-        "llm-average": 11.68
+        "llm-average": 5.8
       },
       {
         "entity_name": "Gallium nitrate",
-        "llm-average": 10.46
+        "llm-average": 5.2
       }
     ]
   },
@@ -1201,11 +1201,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Docetaxel",
-        "llm-average": 9.85
+        "llm-average": 4.9
       },
       {
         "entity_name": "Paclitaxel",
-        "llm-average": 9.04
+        "llm-average": 4.5
       }
     ]
   },
@@ -1217,11 +1217,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Rabeprazole",
-        "llm-average": 13.27
+        "llm-average": 6.6
       },
       {
         "entity_name": "Tacrolimus",
-        "llm-average": 12.2
+        "llm-average": 6.1
       }
     ]
   },
@@ -1233,23 +1233,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Astemizole",
-        "llm-average": 18.67
+        "llm-average": 9.3
       },
       {
         "entity_name": "Dofetilide",
-        "llm-average": 17.05
+        "llm-average": 8.5
       },
       {
         "entity_name": "Terfenadine",
-        "llm-average": 13.39
+        "llm-average": 6.7
       },
       {
         "entity_name": "Haloperidol",
-        "llm-average": 12.83
+        "llm-average": 6.4
       },
       {
         "entity_name": "Imipramine",
-        "llm-average": 8.04
+        "llm-average": 4.0
       }
     ]
   },
@@ -1261,11 +1261,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Conjugated estrogens",
-        "llm-average": 6.89
+        "llm-average": 3.4
       },
       {
         "entity_name": "Estrone sulfate",
-        "llm-average": 6.45
+        "llm-average": 3.2
       }
     ]
   },
@@ -1277,19 +1277,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Haloperidol",
-        "llm-average": 13.87
+        "llm-average": 6.9
       },
       {
         "entity_name": "Cocaine",
-        "llm-average": 9.44
+        "llm-average": 4.7
       },
       {
         "entity_name": "Dopamine",
-        "llm-average": 6.81
+        "llm-average": 3.4
       },
       {
         "entity_name": "Dextroamphetamine",
-        "llm-average": 6.45
+        "llm-average": 3.2
       }
     ]
   },
@@ -1301,15 +1301,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vorinostat",
-        "llm-average": 15.78
+        "llm-average": 7.9
       },
       {
         "entity_name": "Panobinostat",
-        "llm-average": 15.6
+        "llm-average": 7.8
       },
       {
         "entity_name": "Palbociclib",
-        "llm-average": 10.93
+        "llm-average": 5.5
       }
     ]
   },
@@ -1321,11 +1321,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NOS3",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "HSP90AA1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -1337,11 +1337,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CTNNB1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "ESR1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -1353,11 +1353,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GRK3",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "GRK2",
-        "llm-average": 8.85
+        "llm-average": 4.4
       }
     ]
   },
@@ -1369,11 +1369,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Fentanyl",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "Etoricoxib",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -1385,11 +1385,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CTSG",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "SERPINA1",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -1401,19 +1401,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 14.61
+        "llm-average": 7.3
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 12.71
+        "llm-average": 6.4
       }
     ]
   },
@@ -1425,11 +1425,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -1441,27 +1441,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 16.83
+        "llm-average": 8.4
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 14.2
+        "llm-average": 7.1
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "AGPAT5",
-        "llm-average": 11.34
+        "llm-average": 5.7
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -1473,11 +1473,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LGALS3",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "CSF2",
-        "llm-average": 15.07
+        "llm-average": 7.5
       }
     ]
   },
@@ -1489,23 +1489,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SIRT2",
-        "llm-average": 12.62
+        "llm-average": 6.3
       },
       {
         "entity_name": "SIRT1",
-        "llm-average": 11.75
+        "llm-average": 5.9
       },
       {
         "entity_name": "SIRT3",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "HDAC3",
-        "llm-average": 9.48
+        "llm-average": 4.7
       },
       {
         "entity_name": "H3-2",
-        "llm-average": 6.03
+        "llm-average": 3.0
       }
     ]
   },
@@ -1517,19 +1517,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DIP2B",
-        "llm-average": 9.95
+        "llm-average": 5.0
       },
       {
         "entity_name": "PKD1L2",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "SH2B3",
-        "llm-average": 5.75
+        "llm-average": 2.9
       },
       {
         "entity_name": "FER1L6",
-        "llm-average": 4.89
+        "llm-average": 2.4
       }
     ]
   },
@@ -1541,15 +1541,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRH",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "ACE",
-        "llm-average": 10.82
+        "llm-average": 5.4
       },
       {
         "entity_name": "BLMH",
-        "llm-average": 10.81
+        "llm-average": 5.4
       }
     ]
   },
@@ -1561,15 +1561,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CLIP4",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "ABL1",
-        "llm-average": 10.82
+        "llm-average": 5.4
       },
       {
         "entity_name": "HDAC6",
-        "llm-average": 10.81
+        "llm-average": 5.4
       }
     ]
   },
@@ -1581,15 +1581,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 7.66
+        "llm-average": 3.8
       }
     ]
   },
@@ -1601,19 +1601,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SETX",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "ETV6",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "BHLHE40",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "ELK1",
-        "llm-average": 10.01
+        "llm-average": 5.0
       }
     ]
   },
@@ -1625,31 +1625,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bortezomib",
-        "llm-average": 13.54
+        "llm-average": 6.8
       },
       {
         "entity_name": "Lenalidomide",
-        "llm-average": 12.38
+        "llm-average": 6.2
       },
       {
         "entity_name": "Pramipexole",
-        "llm-average": 9.48
+        "llm-average": 4.7
       },
       {
         "entity_name": "Bupropion",
-        "llm-average": 8.69
+        "llm-average": 4.3
       },
       {
         "entity_name": "Tramadol",
-        "llm-average": 4.57
+        "llm-average": 2.3
       },
       {
         "entity_name": "Clonazepam",
-        "llm-average": 3.6
+        "llm-average": 1.8
       },
       {
         "entity_name": "Ciprofloxacin",
-        "llm-average": 3.29
+        "llm-average": 1.6
       }
     ]
   },
@@ -1661,15 +1661,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Glycerol 3-phosphate",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "Dihydroxyacetone phosphate",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Cytidine monophosphate",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -1681,15 +1681,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CD81",
-        "llm-average": 13.1
+        "llm-average": 6.5
       },
       {
         "entity_name": "ITGB1",
-        "llm-average": 10.33
+        "llm-average": 5.2
       },
       {
         "entity_name": "ITGA4",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -1701,15 +1701,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Clarithromycin",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "Escitalopram",
-        "llm-average": 7.01
+        "llm-average": 3.5
       },
       {
         "entity_name": "Citalopram",
-        "llm-average": 6.8
+        "llm-average": 3.4
       }
     ]
   },
@@ -1721,19 +1721,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MAP3K7",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "ACTB",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "PRKDC",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "HDAC1",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -1745,11 +1745,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NOTCH1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "ANKRD44",
-        "llm-average": 10.77
+        "llm-average": 5.4
       }
     ]
   },
@@ -1761,11 +1761,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CDKN1B",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "SRC",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -1777,15 +1777,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DPM2",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "PIGP",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "PIGC",
-        "llm-average": 5.5
+        "llm-average": 2.8
       }
     ]
   },
@@ -1797,11 +1797,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Citalopram",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "Escitalopram",
-        "llm-average": 8.47
+        "llm-average": 4.2
       }
     ]
   },
@@ -1813,11 +1813,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPAM",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 8.85
+        "llm-average": 4.4
       }
     ]
   },
@@ -1829,23 +1829,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HGF",
-        "llm-average": 16.41
+        "llm-average": 8.2
       },
       {
         "entity_name": "SMAD4",
-        "llm-average": 15.73
+        "llm-average": 7.9
       },
       {
         "entity_name": "SPP1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "KIT",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "FUT4",
-        "llm-average": 9.21
+        "llm-average": 4.6
       }
     ]
   },
@@ -1857,15 +1857,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADIPOQ",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "PPARA",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "MEAF6",
-        "llm-average": 12.39
+        "llm-average": 6.2
       }
     ]
   },
@@ -1877,15 +1877,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HAPLN2",
-        "llm-average": 16.09
+        "llm-average": 8.0
       },
       {
         "entity_name": "GFAP",
-        "llm-average": 9.92
+        "llm-average": 5.0
       },
       {
         "entity_name": "EGF",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -1897,23 +1897,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 14.24
+        "llm-average": 7.1
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 13.02
+        "llm-average": 6.5
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 12.39
+        "llm-average": 6.2
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 7.3
+        "llm-average": 3.7
       }
     ]
   },
@@ -1925,11 +1925,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ZNF652",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "KIF26A",
-        "llm-average": 15.07
+        "llm-average": 7.5
       }
     ]
   },
@@ -1941,15 +1941,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SC5D",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "DHCR7",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "ACP6",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -1961,27 +1961,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PPARGC1A",
-        "llm-average": 15.73
+        "llm-average": 7.9
       },
       {
         "entity_name": "SERPINB3",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "NCOR1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "NCKAP5L",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "ASCL1",
-        "llm-average": 9.46
+        "llm-average": 4.7
       },
       {
         "entity_name": "PHOX2B",
-        "llm-average": 9.25
+        "llm-average": 4.6
       }
     ]
   },
@@ -1993,11 +1993,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SPATA5",
-        "llm-average": 14.21
+        "llm-average": 7.1
       },
       {
         "entity_name": "ACOT8",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -2009,19 +2009,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PRKN",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "TRIM21",
-        "llm-average": 13.24
+        "llm-average": 6.6
       },
       {
         "entity_name": "SNX14",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "KBTBD6",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2033,15 +2033,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "C1S",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "ACTA1",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "GRN",
-        "llm-average": 12.42
+        "llm-average": 6.2
       }
     ]
   },
@@ -2053,11 +2053,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HOXB5",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "ACBD7",
-        "llm-average": 15.07
+        "llm-average": 7.5
       }
     ]
   },
@@ -2069,11 +2069,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "DGAT1",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2085,11 +2085,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTX3",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "FGF2",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2101,11 +2101,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KIF21A",
-        "llm-average": 15.07
+        "llm-average": 7.5
       },
       {
         "entity_name": "CTNNB1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -2117,15 +2117,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2137,11 +2137,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FIG4",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "PIKFYVE",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2153,11 +2153,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ISYNA1",
-        "llm-average": 14.01
+        "llm-average": 7.0
       },
       {
         "entity_name": "ADH1A",
-        "llm-average": 13.65
+        "llm-average": 6.8
       }
     ]
   },
@@ -2169,19 +2169,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RAB8A",
-        "llm-average": 6.93
+        "llm-average": 3.5
       },
       {
         "entity_name": "RAB10",
-        "llm-average": 5.1
+        "llm-average": 2.6
       },
       {
         "entity_name": "RAB11A",
-        "llm-average": 4.89
+        "llm-average": 2.4
       },
       {
         "entity_name": "RAB5A",
-        "llm-average": 1.98
+        "llm-average": 1.0
       }
     ]
   },
@@ -2193,27 +2193,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SIRT1",
-        "llm-average": 16.28
+        "llm-average": 8.1
       },
       {
         "entity_name": "ITGB4",
-        "llm-average": 12.39
+        "llm-average": 6.2
       },
       {
         "entity_name": "PSMD5",
-        "llm-average": 10.66
+        "llm-average": 5.3
       },
       {
         "entity_name": "MMP2",
-        "llm-average": 9.46
+        "llm-average": 4.7
       },
       {
         "entity_name": "CCND1",
-        "llm-average": 9.23
+        "llm-average": 4.6
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 7.66
+        "llm-average": 3.8
       }
     ]
   },
@@ -2225,27 +2225,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BMI1",
-        "llm-average": 13.13
+        "llm-average": 6.6
       },
       {
         "entity_name": "PCGF2",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "COPS5",
-        "llm-average": 11.93
+        "llm-average": 6.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "RNF2",
-        "llm-average": 10.56
+        "llm-average": 5.3
       },
       {
         "entity_name": "CUL3",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -2257,15 +2257,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Mycophenolic acid",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "Levofloxacin",
-        "llm-average": 8.89
+        "llm-average": 4.4
       },
       {
         "entity_name": "Ofloxacin",
-        "llm-average": 8.15
+        "llm-average": 4.1
       }
     ]
   },
@@ -2277,19 +2277,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PRKG1",
-        "llm-average": 18.85
+        "llm-average": 9.4
       },
       {
         "entity_name": "ATP2A1",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "BCL2L1",
-        "llm-average": 9.25
+        "llm-average": 4.6
       },
       {
         "entity_name": "GAPDH",
-        "llm-average": 7.0
+        "llm-average": 3.5
       }
     ]
   },
@@ -2301,23 +2301,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CLP1",
-        "llm-average": 17.35
+        "llm-average": 8.7
       },
       {
         "entity_name": "SIRT7",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "INTS11",
-        "llm-average": 9.68
+        "llm-average": 4.8
       },
       {
         "entity_name": "TOE1",
-        "llm-average": 9.46
+        "llm-average": 4.7
       },
       {
         "entity_name": "RBM5",
-        "llm-average": 9.25
+        "llm-average": 4.6
       }
     ]
   },
@@ -2329,11 +2329,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AGPAT5",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 15.07
+        "llm-average": 7.5
       }
     ]
   },
@@ -2345,15 +2345,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SKIL",
-        "llm-average": 14.68
+        "llm-average": 7.3
       },
       {
         "entity_name": "SMURF2",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "SMAD3",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2365,11 +2365,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATR",
-        "llm-average": 14.59
+        "llm-average": 7.3
       },
       {
         "entity_name": "HDAC2",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -2381,31 +2381,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 17.59
+        "llm-average": 8.8
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 16.02
+        "llm-average": 8.0
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 14.03
+        "llm-average": 7.0
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "AGPAT5",
-        "llm-average": 12.1
+        "llm-average": 6.1
       },
       {
         "entity_name": "PGS1",
-        "llm-average": 10.91
+        "llm-average": 5.5
       },
       {
         "entity_name": "CDS2",
-        "llm-average": 10.43
+        "llm-average": 5.2
       }
     ]
   },
@@ -2417,11 +2417,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MID1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "IRF6",
-        "llm-average": 8.39
+        "llm-average": 4.2
       }
     ]
   },
@@ -2433,19 +2433,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 16.83
+        "llm-average": 8.4
       },
       {
         "entity_name": "CRLS1",
-        "llm-average": 12.39
+        "llm-average": 6.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 12.13
+        "llm-average": 6.1
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.82
+        "llm-average": 5.4
       }
     ]
   },
@@ -2457,19 +2457,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Methotrexate",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "Saxagliptin",
-        "llm-average": 13.24
+        "llm-average": 6.6
       },
       {
         "entity_name": "Zonisamide",
-        "llm-average": 12.89
+        "llm-average": 6.4
       },
       {
         "entity_name": "Fluconazole",
-        "llm-average": 8.15
+        "llm-average": 4.1
       }
     ]
   },
@@ -2481,15 +2481,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CDS2",
-        "llm-average": 11.44
+        "llm-average": 5.7
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.39
+        "llm-average": 5.7
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.81
+        "llm-average": 5.4
       }
     ]
   },
@@ -2501,19 +2501,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CD40LG",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "CTLA4",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "CD28",
-        "llm-average": 8.4
+        "llm-average": 4.2
       },
       {
         "entity_name": "TNF",
-        "llm-average": 6.03
+        "llm-average": 3.0
       }
     ]
   },
@@ -2525,11 +2525,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "KRAS",
-        "llm-average": 12.6
+        "llm-average": 6.3
       },
       {
         "entity_name": "ERAS",
-        "llm-average": 12.42
+        "llm-average": 6.2
       }
     ]
   },
@@ -2541,11 +2541,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CD44",
-        "llm-average": 15.33
+        "llm-average": 7.7
       },
       {
         "entity_name": "MAPK3",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2557,11 +2557,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 16.89
+        "llm-average": 8.4
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 13.45
+        "llm-average": 6.7
       }
     ]
   },
@@ -2573,15 +2573,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 10.01
+        "llm-average": 5.0
       }
     ]
   },
@@ -2593,11 +2593,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PSMC3",
-        "llm-average": 10.44
+        "llm-average": 5.2
       },
       {
         "entity_name": "AZIN2",
-        "llm-average": 9.19
+        "llm-average": 4.6
       }
     ]
   },
@@ -2609,19 +2609,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NELFCD",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "TCEA1",
-        "llm-average": 13.71
+        "llm-average": 6.9
       },
       {
         "entity_name": "ELOA3P",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "POLR2A",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2633,15 +2633,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AGPAT1",
-        "llm-average": 13.71
+        "llm-average": 6.9
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -2653,19 +2653,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "FYN",
-        "llm-average": 15.11
+        "llm-average": 7.6
       },
       {
         "entity_name": "MS4A1",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "LYN",
-        "llm-average": 12.05
+        "llm-average": 6.0
       },
       {
         "entity_name": "LCK",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2677,11 +2677,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "C4A",
-        "llm-average": 7.77
+        "llm-average": 3.9
       },
       {
         "entity_name": "C3",
-        "llm-average": 7.03
+        "llm-average": 3.5
       }
     ]
   },
@@ -2693,11 +2693,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NHLRC1",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "KIF6",
-        "llm-average": 10.22
+        "llm-average": 5.1
       }
     ]
   },
@@ -2709,31 +2709,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 15.66
+        "llm-average": 7.8
       },
       {
         "entity_name": "TGFB2",
-        "llm-average": 12.0
+        "llm-average": 6.0
       },
       {
         "entity_name": "IL6",
-        "llm-average": 9.95
+        "llm-average": 5.0
       },
       {
         "entity_name": "VEGFA",
-        "llm-average": 9.52
+        "llm-average": 4.8
       },
       {
         "entity_name": "AKT1",
-        "llm-average": 8.55
+        "llm-average": 4.3
       },
       {
         "entity_name": "FGF2",
-        "llm-average": 7.04
+        "llm-average": 3.5
       },
       {
         "entity_name": "CTSL",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -2745,11 +2745,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SENP6",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "SUMO1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2761,15 +2761,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MMP2",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "DCN",
-        "llm-average": 13.06
+        "llm-average": 6.5
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -2781,15 +2781,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "EMILIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "ITGB1",
-        "llm-average": 6.63
+        "llm-average": 3.3
       },
       {
         "entity_name": "ITGA4",
-        "llm-average": 6.27
+        "llm-average": 3.1
       }
     ]
   },
@@ -2801,11 +2801,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ABL1",
-        "llm-average": 13.65
+        "llm-average": 6.8
       },
       {
         "entity_name": "BRCA1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -2817,11 +2817,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTDSS1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "CHKA",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2833,11 +2833,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ESR1",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "EP300",
-        "llm-average": 13.45
+        "llm-average": 6.7
       }
     ]
   },
@@ -2849,11 +2849,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CDK5R1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "CAD",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -2865,23 +2865,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RHOT2",
-        "llm-average": 11.71
+        "llm-average": 5.9
       },
       {
         "entity_name": "RHOT1",
-        "llm-average": 10.19
+        "llm-average": 5.1
       },
       {
         "entity_name": "BAG3",
-        "llm-average": 9.92
+        "llm-average": 5.0
       },
       {
         "entity_name": "DMPK",
-        "llm-average": 6.44
+        "llm-average": 3.2
       },
       {
         "entity_name": "RIPK3",
-        "llm-average": 5.18
+        "llm-average": 2.6
       }
     ]
   },
@@ -2893,19 +2893,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -2917,11 +2917,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NOTCH3",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "NOTCH2",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -2933,11 +2933,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ADSL",
-        "llm-average": 13.46
+        "llm-average": 6.7
       },
       {
         "entity_name": "ITPR1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       }
     ]
   },
@@ -2949,11 +2949,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 14.3
+        "llm-average": 7.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 12.89
+        "llm-average": 6.4
       }
     ]
   },
@@ -2965,19 +2965,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPAM",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 14.61
+        "llm-average": 7.3
       },
       {
         "entity_name": "LPIN1",
-        "llm-average": 12.71
+        "llm-average": 6.4
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -2989,15 +2989,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "AGPAT5",
-        "llm-average": 15.62
+        "llm-average": 7.8
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 10.73
+        "llm-average": 5.4
       }
     ]
   },
@@ -3009,19 +3009,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Triamcinolone",
-        "llm-average": 11.25
+        "llm-average": 5.6
       },
       {
         "entity_name": "Dexamethasone",
-        "llm-average": 7.26
+        "llm-average": 3.6
       },
       {
         "entity_name": "Betamethasone",
-        "llm-average": 7.04
+        "llm-average": 3.5
       },
       {
         "entity_name": "Methylprednisolone",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -3033,35 +3033,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SERPIND1",
-        "llm-average": 15.75
+        "llm-average": 7.9
       },
       {
         "entity_name": "PROC",
-        "llm-average": 14.24
+        "llm-average": 7.1
       },
       {
         "entity_name": "F12",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "F2",
-        "llm-average": 9.81
+        "llm-average": 4.9
       },
       {
         "entity_name": "SERPINC1",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "F8",
-        "llm-average": 9.04
+        "llm-average": 4.5
       },
       {
         "entity_name": "VWF",
-        "llm-average": 5.74
+        "llm-average": 2.9
       },
       {
         "entity_name": "KNG1",
-        "llm-average": 4.76
+        "llm-average": 2.4
       }
     ]
   },
@@ -3073,23 +3073,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 18.71
+        "llm-average": 9.4
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 12.98
+        "llm-average": 6.5
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 8.93
+        "llm-average": 4.5
       }
     ]
   },
@@ -3101,23 +3101,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "STAG1",
-        "llm-average": 10.69
+        "llm-average": 5.3
       },
       {
         "entity_name": "CD69",
-        "llm-average": 10.28
+        "llm-average": 5.1
       },
       {
         "entity_name": "STAG2",
-        "llm-average": 9.95
+        "llm-average": 5.0
       },
       {
         "entity_name": "H2AC20",
-        "llm-average": 7.16
+        "llm-average": 3.6
       },
       {
         "entity_name": "H2BC21",
-        "llm-average": 3.6
+        "llm-average": 1.8
       }
     ]
   },
@@ -3129,15 +3129,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HSPA8",
-        "llm-average": 7.66
+        "llm-average": 3.8
       },
       {
         "entity_name": "GAPDH",
-        "llm-average": 7.56
+        "llm-average": 3.8
       },
       {
         "entity_name": "ACTB",
-        "llm-average": 6.25
+        "llm-average": 3.1
       }
     ]
   },
@@ -3149,11 +3149,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PTPMT1",
-        "llm-average": 16.09
+        "llm-average": 8.0
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 10.3
+        "llm-average": 5.2
       }
     ]
   },
@@ -3165,23 +3165,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 15.3
+        "llm-average": 7.7
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 10.81
+        "llm-average": 5.4
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -3193,11 +3193,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hyoscyamine",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "Atropine",
-        "llm-average": 11.5
+        "llm-average": 5.7
       }
     ]
   },
@@ -3209,19 +3209,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 12.72
+        "llm-average": 6.4
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 7.09
+        "llm-average": 3.5
       }
     ]
   },
@@ -3233,11 +3233,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CDS2",
-        "llm-average": 15.27
+        "llm-average": 7.6
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 15.07
+        "llm-average": 7.5
       }
     ]
   },
@@ -3249,15 +3249,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LIFR",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "MAPK14",
-        "llm-average": 11.16
+        "llm-average": 5.6
       },
       {
         "entity_name": "MAPK1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -3269,15 +3269,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CIT",
-        "llm-average": 14.98
+        "llm-average": 7.5
       },
       {
         "entity_name": "DVL3",
-        "llm-average": 9.19
+        "llm-average": 4.6
       },
       {
         "entity_name": "DVL2",
-        "llm-average": 8.85
+        "llm-average": 4.4
       }
     ]
   },
@@ -3289,15 +3289,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "HTR7",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "CREB1",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "JUN",
-        "llm-average": 10.3
+        "llm-average": 5.2
       }
     ]
   },
@@ -3309,11 +3309,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PGS1",
-        "llm-average": 14.51
+        "llm-average": 7.3
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 10.3
+        "llm-average": 5.2
       }
     ]
   },
@@ -3325,27 +3325,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RAB8A",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "RHO",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "RAB11A",
-        "llm-average": 10.38
+        "llm-average": 5.2
       },
       {
         "entity_name": "EXOC7",
-        "llm-average": 8.86
+        "llm-average": 4.4
       },
       {
         "entity_name": "EXOC5",
-        "llm-average": 8.47
+        "llm-average": 4.2
       },
       {
         "entity_name": "EXOC4",
-        "llm-average": 7.64
+        "llm-average": 3.8
       }
     ]
   },
@@ -3357,15 +3357,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "YWHAH",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "MAPT",
-        "llm-average": 14.61
+        "llm-average": 7.3
       },
       {
         "entity_name": "PPP3CC",
-        "llm-average": 11.83
+        "llm-average": 5.9
       }
     ]
   },
@@ -3377,19 +3377,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 18.38
+        "llm-average": 9.2
       },
       {
         "entity_name": "DGAT1",
-        "llm-average": 17.27
+        "llm-average": 8.6
       },
       {
         "entity_name": "GPAM",
-        "llm-average": 11.83
+        "llm-average": 5.9
       },
       {
         "entity_name": "AGPAT1",
-        "llm-average": 7.85
+        "llm-average": 3.9
       }
     ]
   },
@@ -3401,19 +3401,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LAMA2",
-        "llm-average": 15.65
+        "llm-average": 7.8
       },
       {
         "entity_name": "DDR1",
-        "llm-average": 12.48
+        "llm-average": 6.2
       },
       {
         "entity_name": "FN1",
-        "llm-average": 9.94
+        "llm-average": 5.0
       },
       {
         "entity_name": "DMD",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -3425,11 +3425,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NOS3",
-        "llm-average": 17.24
+        "llm-average": 8.6
       },
       {
         "entity_name": "CAV1",
-        "llm-average": 9.68
+        "llm-average": 4.8
       }
     ]
   },
@@ -3441,11 +3441,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "LPIN1",
-        "llm-average": 13.45
+        "llm-average": 6.7
       },
       {
         "entity_name": "GPD1",
-        "llm-average": 9.38
+        "llm-average": 4.7
       }
     ]
   },
@@ -3457,15 +3457,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 11.88
+        "llm-average": 5.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -3477,11 +3477,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -3493,15 +3493,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 18.13
+        "llm-average": 9.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "MDM2",
-        "llm-average": 10.01
+        "llm-average": 5.0
       }
     ]
   },
@@ -3513,19 +3513,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 15.21
+        "llm-average": 7.6
       },
       {
         "entity_name": "BCL2L1",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 7.99
+        "llm-average": 4.0
       }
     ]
   },
@@ -3537,19 +3537,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "CBL",
-        "llm-average": 10.6
+        "llm-average": 5.3
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 10.27
+        "llm-average": 5.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 7.24
+        "llm-average": 3.6
       }
     ]
   },
@@ -3561,11 +3561,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GRB2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       }
     ]
   },
@@ -3577,19 +3577,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GAB2",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 7.09
+        "llm-average": 3.5
       }
     ]
   },
@@ -3601,11 +3601,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -3617,11 +3617,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 8.59
+        "llm-average": 4.3
       }
     ]
   },
@@ -3633,11 +3633,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "MYC",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -3649,19 +3649,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 14.18
+        "llm-average": 7.1
       },
       {
         "entity_name": "TP53",
-        "llm-average": 10.3
+        "llm-average": 5.1
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 9.08
+        "llm-average": 4.5
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -3673,11 +3673,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       }
     ]
   },
@@ -3689,11 +3689,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "MYC",
-        "llm-average": 9.86
+        "llm-average": 4.9
       }
     ]
   },
@@ -3705,19 +3705,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SKP2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "STAT5A",
-        "llm-average": 10.99
+        "llm-average": 5.5
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 10.72
+        "llm-average": 5.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -3729,11 +3729,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -3745,19 +3745,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 17.0
+        "llm-average": 8.5
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "CBL",
-        "llm-average": 9.44
+        "llm-average": 4.7
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       }
     ]
   },
@@ -3769,27 +3769,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 14.48
+        "llm-average": 7.2
       },
       {
         "entity_name": "CBL",
-        "llm-average": 11.39
+        "llm-average": 5.7
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 9.37
+        "llm-average": 4.7
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 8.87
+        "llm-average": 4.4
       }
     ]
   },
@@ -3801,15 +3801,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 13.75
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -3821,15 +3821,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.75
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -3841,19 +3841,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 16.55
+        "llm-average": 8.3
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 7.99
+        "llm-average": 4.0
       }
     ]
   },
@@ -3865,11 +3865,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.64
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -3881,15 +3881,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 14.14
+        "llm-average": 7.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "MYC",
-        "llm-average": 11.73
+        "llm-average": 5.9
       }
     ]
   },
@@ -3901,15 +3901,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 19.25
+        "llm-average": 9.6
       },
       {
         "entity_name": "STAT5A",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -3921,11 +3921,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 12.26
+        "llm-average": 6.1
       }
     ]
   },
@@ -3937,23 +3937,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 19.25
+        "llm-average": 9.6
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 17.72
+        "llm-average": 8.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 9.37
+        "llm-average": 4.7
       }
     ]
   },
@@ -3965,19 +3965,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2L1",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "TP53",
-        "llm-average": 9.14
+        "llm-average": 4.6
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 7.99
+        "llm-average": 4.0
       }
     ]
   },
@@ -3989,15 +3989,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.96
+        "llm-average": 7.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "MYC",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -4009,11 +4009,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 8.74
+        "llm-average": 4.4
       }
     ]
   },
@@ -4025,11 +4025,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.64
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4041,19 +4041,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -4065,35 +4065,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "MDM2",
-        "llm-average": 11.97
+        "llm-average": 6.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "MYC",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "CBL",
-        "llm-average": 9.85
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 6.1
+        "llm-average": 3.0
       }
     ]
   },
@@ -4105,31 +4105,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 16.7
+        "llm-average": 8.4
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 14.96
+        "llm-average": 7.5
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "CBL",
-        "llm-average": 10.75
+        "llm-average": 5.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 8.03
+        "llm-average": 4.0
       }
     ]
   },
@@ -4141,15 +4141,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 14.18
+        "llm-average": 7.1
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.74
+        "llm-average": 4.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.21
+        "llm-average": 4.1
       }
     ]
   },
@@ -4161,15 +4161,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 16.05
+        "llm-average": 8.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 8.74
+        "llm-average": 4.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.21
+        "llm-average": 4.1
       }
     ]
   },
@@ -4181,11 +4181,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -4197,11 +4197,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       }
     ]
   },
@@ -4213,19 +4213,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 12.21
+        "llm-average": 6.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -4237,11 +4237,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 13.43
+        "llm-average": 6.7
       }
     ]
   },
@@ -4253,11 +4253,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 8.59
+        "llm-average": 4.3
       }
     ]
   },
@@ -4269,11 +4269,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 14.76
+        "llm-average": 7.4
       },
       {
         "entity_name": "MYC",
-        "llm-average": 14.33
+        "llm-average": 7.2
       }
     ]
   },
@@ -4285,11 +4285,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GRB2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       }
     ]
   },
@@ -4301,15 +4301,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 8.29
+        "llm-average": 4.1
       }
     ]
   },
@@ -4321,15 +4321,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 13.75
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.97
+        "llm-average": 4.5
       }
     ]
   },
@@ -4341,19 +4341,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 15.86
+        "llm-average": 7.9
       },
       {
         "entity_name": "TP53",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "GAB2",
-        "llm-average": 10.76
+        "llm-average": 5.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -4365,11 +4365,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -4381,15 +4381,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 17.9
+        "llm-average": 9.0
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -4401,15 +4401,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "TP53",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4421,11 +4421,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -4437,23 +4437,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 12.36
+        "llm-average": 6.2
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 11.02
+        "llm-average": 5.5
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 10.14
+        "llm-average": 5.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.62
+        "llm-average": 3.8
       }
     ]
   },
@@ -4465,11 +4465,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 12.26
+        "llm-average": 6.1
       }
     ]
   },
@@ -4481,11 +4481,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 12.68
+        "llm-average": 6.3
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.49
+        "llm-average": 4.7
       }
     ]
   },
@@ -4497,11 +4497,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.64
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4513,19 +4513,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2L1",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 7.99
+        "llm-average": 4.0
       },
       {
         "entity_name": "TP53",
-        "llm-average": 6.22
+        "llm-average": 3.1
       }
     ]
   },
@@ -4537,31 +4537,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 10.78
+        "llm-average": 5.4
       },
       {
         "entity_name": "GAB2",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "CBL",
-        "llm-average": 10.19
+        "llm-average": 5.1
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 9.82
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 6.79
+        "llm-average": 3.4
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 4.36
+        "llm-average": 2.2
       }
     ]
   },
@@ -4573,19 +4573,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GRB2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 12.81
+        "llm-average": 6.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 7.99
+        "llm-average": 4.0
       }
     ]
   },
@@ -4597,19 +4597,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 13.72
+        "llm-average": 6.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "GAB2",
-        "llm-average": 7.99
+        "llm-average": 4.0
       }
     ]
   },
@@ -4621,11 +4621,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.11
+        "llm-average": 4.6
       }
     ]
   },
@@ -4637,11 +4637,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 14.33
+        "llm-average": 7.2
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4653,35 +4653,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MTOR",
-        "llm-average": 12.74
+        "llm-average": 6.4
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 12.7
+        "llm-average": 6.3
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 11.37
+        "llm-average": 5.7
       },
       {
         "entity_name": "GAB2",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "CBL",
-        "llm-average": 8.94
+        "llm-average": 4.5
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 7.17
+        "llm-average": 3.6
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 7.13
+        "llm-average": 3.6
       }
     ]
   },
@@ -4693,15 +4693,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TP53",
-        "llm-average": 13.98
+        "llm-average": 7.0
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "BCL2L1",
-        "llm-average": 8.74
+        "llm-average": 4.4
       }
     ]
   },
@@ -4713,11 +4713,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 12.26
+        "llm-average": 6.1
       }
     ]
   },
@@ -4729,11 +4729,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "MYC",
-        "llm-average": 12.26
+        "llm-average": 6.1
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -4745,27 +4745,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 14.91
+        "llm-average": 7.5
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 11.92
+        "llm-average": 6.0
       },
       {
         "entity_name": "CBL",
-        "llm-average": 11.39
+        "llm-average": 5.7
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 5.89
+        "llm-average": 2.9
       }
     ]
   },
@@ -4777,19 +4777,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "JAK2",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "STAT5A",
-        "llm-average": 15.83
+        "llm-average": 7.9
       },
       {
         "entity_name": "SKP2",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 6.94
+        "llm-average": 3.5
       }
     ]
   },
@@ -4801,31 +4801,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.64
+        "llm-average": 6.8
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 12.61
+        "llm-average": 6.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 11.73
+        "llm-average": 5.9
       },
       {
         "entity_name": "CBL",
-        "llm-average": 11.0
+        "llm-average": 5.5
       },
       {
         "entity_name": "PIK3R1",
-        "llm-average": 8.03
+        "llm-average": 4.0
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 5.0
+        "llm-average": 2.5
       }
     ]
   },
@@ -4837,35 +4837,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 15.86
+        "llm-average": 7.9
       },
       {
         "entity_name": "MTOR",
-        "llm-average": 14.99
+        "llm-average": 7.5
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 11.2
+        "llm-average": 5.6
       },
       {
         "entity_name": "GAB2",
-        "llm-average": 10.29
+        "llm-average": 5.1
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "CBL",
-        "llm-average": 8.94
+        "llm-average": 4.5
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -4877,15 +4877,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "BCL2L1",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "TP53",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.21
+        "llm-average": 4.1
       }
     ]
   },
@@ -4897,15 +4897,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "TP53",
-        "llm-average": 11.21
+        "llm-average": 5.6
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.11
+        "llm-average": 4.6
       }
     ]
   },
@@ -4917,15 +4917,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 19.25
+        "llm-average": 9.6
       },
       {
         "entity_name": "MDM2",
-        "llm-average": 12.63
+        "llm-average": 6.3
       },
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       }
     ]
   },
@@ -4937,11 +4937,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRKL",
-        "llm-average": 13.64
+        "llm-average": 6.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 10.61
+        "llm-average": 5.3
       }
     ]
   },
@@ -4953,15 +4953,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CBL",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "MDM2",
-        "llm-average": 14.7
+        "llm-average": 7.4
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -4973,11 +4973,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CRK",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 8.59
+        "llm-average": 4.3
       }
     ]
   },
@@ -4989,19 +4989,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SKP2",
-        "llm-average": 13.81
+        "llm-average": 6.9
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 11.77
+        "llm-average": 5.9
       },
       {
         "entity_name": "STAT5A",
-        "llm-average": 10.99
+        "llm-average": 5.5
       },
       {
         "entity_name": "CRK",
-        "llm-average": 9.71
+        "llm-average": 4.9
       }
     ]
   },
@@ -5013,27 +5013,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 13.58
+        "llm-average": 6.8
       },
       {
         "entity_name": "JAK2",
-        "llm-average": 12.12
+        "llm-average": 6.1
       },
       {
         "entity_name": "CBL",
-        "llm-average": 10.67
+        "llm-average": 5.3
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 9.93
+        "llm-average": 5.0
       },
       {
         "entity_name": "RPS6KB1",
-        "llm-average": 7.58
+        "llm-average": 3.8
       },
       {
         "entity_name": "CRK",
-        "llm-average": 5.59
+        "llm-average": 2.8
       }
     ]
   },
@@ -5045,31 +5045,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PIK3R1",
-        "llm-average": 14.24
+        "llm-average": 7.1
       },
       {
         "entity_name": "GAB2",
-        "llm-average": 12.12
+        "llm-average": 6.1
       },
       {
         "entity_name": "GRB2",
-        "llm-average": 11.63
+        "llm-average": 5.8
       },
       {
         "entity_name": "CRKL",
-        "llm-average": 9.82
+        "llm-average": 4.9
       },
       {
         "entity_name": "CRK",
-        "llm-average": 8.36
+        "llm-average": 4.2
       },
       {
         "entity_name": "CBL",
-        "llm-average": 8.12
+        "llm-average": 4.1
       },
       {
         "entity_name": "SOS1",
-        "llm-average": 5.74
+        "llm-average": 2.9
       }
     ]
   },
@@ -5081,19 +5081,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPHB5",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "ADCYAP1R1",
-        "llm-average": 12.61
+        "llm-average": 6.3
       },
       {
         "entity_name": "CGA",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "GNB1",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -5105,15 +5105,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "CYP2C9",
-        "llm-average": 14.84
+        "llm-average": 7.4
       },
       {
         "entity_name": "JUN",
-        "llm-average": 13.86
+        "llm-average": 6.9
       },
       {
         "entity_name": "NR1I2",
-        "llm-average": 7.71
+        "llm-average": 3.9
       }
     ]
   },
@@ -5125,15 +5125,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "NEU3",
-        "llm-average": 13.93
+        "llm-average": 7.0
       },
       {
         "entity_name": "NEU2",
-        "llm-average": 9.27
+        "llm-average": 4.6
       },
       {
         "entity_name": "NEU1",
-        "llm-average": 9.26
+        "llm-average": 4.6
       }
     ]
   },
@@ -5145,11 +5145,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TMEM192",
-        "llm-average": 15.08
+        "llm-average": 7.5
       },
       {
         "entity_name": "CTCF",
-        "llm-average": 14.04
+        "llm-average": 7.0
       }
     ]
   },
@@ -5161,11 +5161,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "negative regulation of cell population proliferation",
-        "llm-average": 11.53
+        "llm-average": 5.8
       },
       {
         "entity_name": "negative regulation of endopeptidase activity",
-        "llm-average": 10.94
+        "llm-average": 5.5
       }
     ]
   },
@@ -5177,11 +5177,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "SLCO1B3",
-        "llm-average": 10.94
+        "llm-average": 5.5
       },
       {
         "entity_name": "ALB",
-        "llm-average": 3.83
+        "llm-average": 1.9
       }
     ]
   },
@@ -5193,35 +5193,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Defective SLCO1B1 causes hyperbilirubinemia, Rotor type (HBLRR)",
-        "llm-average": 16.36
+        "llm-average": 8.2
       },
       {
         "entity_name": "Recycling of bile acids and salts",
-        "llm-average": 15.41
+        "llm-average": 7.7
       },
       {
         "entity_name": "Transport of organic anions",
-        "llm-average": 11.74
+        "llm-average": 5.9
       },
       {
         "entity_name": "Heme degradation",
-        "llm-average": 9.57
+        "llm-average": 4.8
       },
       {
         "entity_name": "Irinotecan Action Pathway",
-        "llm-average": 6.4
+        "llm-average": 3.2
       },
       {
         "entity_name": "Rosiglitazone Metabolism Pathway",
-        "llm-average": 4.33
+        "llm-average": 2.2
       },
       {
         "entity_name": "Irinotecan Metabolism Pathway",
-        "llm-average": 3.61
+        "llm-average": 1.8
       },
       {
         "entity_name": "Mycophenolic Acid Metabolism Pathway",
-        "llm-average": 3.11
+        "llm-average": 1.6
       }
     ]
   },
@@ -5233,19 +5233,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "TRAF6 mediated IRF7 activation",
-        "llm-average": 10.93
+        "llm-average": 5.5
       },
       {
         "entity_name": "Interferon alpha/beta signaling",
-        "llm-average": 8.95
+        "llm-average": 4.5
       },
       {
         "entity_name": "Factors involved in megakaryocyte development and platelet production",
-        "llm-average": 7.83
+        "llm-average": 3.9
       },
       {
         "entity_name": "Regulation of IFNA signaling",
-        "llm-average": 7.33
+        "llm-average": 3.7
       }
     ]
   },
@@ -5257,35 +5257,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "ATP binding cassette subfamily B member 1",
-        "llm-average": 14.2
+        "llm-average": 7.1
       },
       {
         "entity_name": "sphingosine-1-phosphate receptor 4",
-        "llm-average": 13.78
+        "llm-average": 6.9
       },
       {
         "entity_name": "interleukin 15",
-        "llm-average": 13.55
+        "llm-average": 6.8
       },
       {
         "entity_name": "sphingosine-1-phosphate receptor 1",
-        "llm-average": 11.86
+        "llm-average": 5.9
       },
       {
         "entity_name": "interleukin 2 receptor subunit alpha",
-        "llm-average": 8.63
+        "llm-average": 4.3
       },
       {
         "entity_name": "progesterone receptor",
-        "llm-average": 5.5
+        "llm-average": 2.8
       },
       {
         "entity_name": "kallikrein related peptidase 3",
-        "llm-average": 5.38
+        "llm-average": 2.7
       },
       {
         "entity_name": "estrogen receptor 1",
-        "llm-average": 4.34
+        "llm-average": 2.2
       }
     ]
   },
@@ -5297,11 +5297,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Signaling by Retinoic Acid",
-        "llm-average": 15.15
+        "llm-average": 7.6
       },
       {
         "entity_name": "Nuclear Receptor transcription pathway",
-        "llm-average": 7.97
+        "llm-average": 4.0
       }
     ]
   },
@@ -5313,35 +5313,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "solute carrier family 47 member 1",
-        "llm-average": 16.24
+        "llm-average": 8.1
       },
       {
         "entity_name": "solute carrier family 29 member 4",
-        "llm-average": 15.36
+        "llm-average": 7.7
       },
       {
         "entity_name": "leucine rich repeat containing G protein-coupled receptor 4",
-        "llm-average": 12.5
+        "llm-average": 6.2
       },
       {
         "entity_name": "leucine rich repeat containing G protein-coupled receptor 5",
-        "llm-average": 12.5
+        "llm-average": 6.2
       },
       {
         "entity_name": "Fc fragment of IgG receptor IIIa",
-        "llm-average": 12.11
+        "llm-average": 6.1
       },
       {
         "entity_name": "actin gamma 1 pseudogene 4",
-        "llm-average": 10.86
+        "llm-average": 5.4
       },
       {
         "entity_name": "nitric oxide synthase 1",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "histamine receptor H2",
-        "llm-average": 5.56
+        "llm-average": 2.8
       }
     ]
   },
@@ -5353,15 +5353,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "hepatic veno-occlusive disease",
-        "llm-average": 13.18
+        "llm-average": 6.6
       },
       {
         "entity_name": "alcohol dependence",
-        "llm-average": 11.94
+        "llm-average": 6.0
       },
       {
         "entity_name": "liver disease",
-        "llm-average": 8.22
+        "llm-average": 4.1
       }
     ]
   },
@@ -5373,31 +5373,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Autoimmune hemolytic anemia",
-        "llm-average": 17.11
+        "llm-average": 8.6
       },
       {
         "entity_name": "Chronic active hepatitis",
-        "llm-average": 16.77
+        "llm-average": 8.4
       },
       {
         "entity_name": "Crohn's disease",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "Systemic lupus erythematosus",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "Ulcerative colitis",
-        "llm-average": 11.44
+        "llm-average": 5.7
       },
       {
         "entity_name": "Rheumatoid arthritis",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Inflammation of the large intestine",
-        "llm-average": 5.9
+        "llm-average": 3.0
       }
     ]
   },
@@ -5409,15 +5409,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "hepatic veno-occlusive disease",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "alcohol dependence",
-        "llm-average": 10.73
+        "llm-average": 5.4
       },
       {
         "entity_name": "liver disease",
-        "llm-average": 9.14
+        "llm-average": 4.6
       }
     ]
   },
@@ -5429,11 +5429,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glomerulonephritis",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "genetic disease",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -5445,19 +5445,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Periodontitis",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "Gingival bleeding",
-        "llm-average": 7.5
+        "llm-average": 3.7
       },
       {
         "entity_name": "Carious teeth",
-        "llm-average": 7.11
+        "llm-average": 3.6
       },
       {
         "entity_name": "Gingivitis",
-        "llm-average": 6.26
+        "llm-average": 3.1
       }
     ]
   },
@@ -5469,11 +5469,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "pituitary gland disease",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "ovarian disease",
-        "llm-average": 7.86
+        "llm-average": 3.9
       }
     ]
   },
@@ -5485,15 +5485,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "infertility",
-        "llm-average": 16.25
+        "llm-average": 8.1
       },
       {
         "entity_name": "endocrine system disease",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "pituitary gland disease",
-        "llm-average": 8.55
+        "llm-average": 4.3
       }
     ]
   },
@@ -5505,19 +5505,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Chronic myelomonocytic leukemia",
-        "llm-average": 14.65
+        "llm-average": 7.3
       },
       {
         "entity_name": "Acute megakaryocytic leukemia",
-        "llm-average": 14.1
+        "llm-average": 7.0
       },
       {
         "entity_name": "Refractory anemia",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Elevated hepatic transaminase",
-        "llm-average": 5.01
+        "llm-average": 2.5
       }
     ]
   },
@@ -5529,15 +5529,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "alcohol dependence",
-        "llm-average": 13.22
+        "llm-average": 6.6
       },
       {
         "entity_name": "hepatic veno-occlusive disease",
-        "llm-average": 11.58
+        "llm-average": 5.8
       },
       {
         "entity_name": "liver disease",
-        "llm-average": 10.73
+        "llm-average": 5.4
       }
     ]
   },
@@ -5549,19 +5549,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vomiting",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "Nausea",
-        "llm-average": 9.64
+        "llm-average": 4.8
       },
       {
         "entity_name": "Iridocyclitis",
-        "llm-average": 5.35
+        "llm-average": 2.7
       },
       {
         "entity_name": "Mydriasis",
-        "llm-average": 4.83
+        "llm-average": 2.4
       }
     ]
   },
@@ -5573,11 +5573,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "hepatic veno-occlusive disease",
-        "llm-average": 11.78
+        "llm-average": 5.9
       },
       {
         "entity_name": "liver disease",
-        "llm-average": 5.55
+        "llm-average": 2.8
       }
     ]
   },
@@ -5589,31 +5589,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "cytochrome P450 family 19 subfamily A member 1",
-        "llm-average": 15.72
+        "llm-average": 7.9
       },
       {
         "entity_name": "cytochrome P450 family 11 subfamily A member 1",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "trefoil factor 3",
-        "llm-average": 13.88
+        "llm-average": 6.9
       },
       {
         "entity_name": "gamma-glutamyltransferase 1",
-        "llm-average": 12.46
+        "llm-average": 6.2
       },
       {
         "entity_name": "cytochrome P450 family 1 subfamily B member 1",
-        "llm-average": 11.06
+        "llm-average": 5.5
       },
       {
         "entity_name": "thyroglobulin",
-        "llm-average": 7.13
+        "llm-average": 3.6
       },
       {
         "entity_name": "gonadotropin releasing hormone 1",
-        "llm-average": 6.78
+        "llm-average": 3.4
       }
     ]
   },
@@ -5625,15 +5625,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "infertility",
-        "llm-average": 13.74
+        "llm-average": 6.9
       },
       {
         "entity_name": "endocrine system disease",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "pituitary gland disease",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -5645,15 +5645,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Emphysema",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 7.34
+        "llm-average": 3.7
       },
       {
         "entity_name": "Bronchitis",
-        "llm-average": 7.14
+        "llm-average": 3.6
       }
     ]
   },
@@ -5665,31 +5665,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Airway obstruction",
-        "llm-average": 9.08
+        "llm-average": 4.5
       },
       {
         "entity_name": "Respiratory distress",
-        "llm-average": 8.71
+        "llm-average": 4.4
       },
       {
         "entity_name": "Exercise-induced asthma",
-        "llm-average": 8.22
+        "llm-average": 4.1
       },
       {
         "entity_name": "Emphysema",
-        "llm-average": 8.19
+        "llm-average": 4.1
       },
       {
         "entity_name": "Chronic bronchitis",
-        "llm-average": 7.85
+        "llm-average": 3.9
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 7.34
+        "llm-average": 3.7
       },
       {
         "entity_name": "Chronic pulmonary obstruction",
-        "llm-average": 7.33
+        "llm-average": 3.7
       }
     ]
   },
@@ -5701,19 +5701,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Neoplasm",
-        "llm-average": 10.35
+        "llm-average": 5.2
       },
       {
         "entity_name": "Leukemia",
-        "llm-average": 10.01
+        "llm-average": 5.0
       },
       {
         "entity_name": "Lymphoma",
-        "llm-average": 6.97
+        "llm-average": 3.5
       },
       {
         "entity_name": "Nausea",
-        "llm-average": 0.53
+        "llm-average": 0.3
       },
       {
         "entity_name": "Fever",
@@ -5729,23 +5729,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Gingival bleeding",
-        "llm-average": 8.56
+        "llm-average": 4.3
       },
       {
         "entity_name": "Pneumonia",
-        "llm-average": 7.99
+        "llm-average": 4.0
       },
       {
         "entity_name": "Sinusitis",
-        "llm-average": 7.47
+        "llm-average": 3.7
       },
       {
         "entity_name": "Gingivitis",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Fever",
-        "llm-average": 2.67
+        "llm-average": 1.3
       }
     ]
   },
@@ -5757,11 +5757,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Reduced factor XI activity",
-        "llm-average": 17.85
+        "llm-average": 8.9
       },
       {
         "entity_name": "Immunodeficiency",
-        "llm-average": 11.06
+        "llm-average": 5.5
       }
     ]
   },
@@ -5773,31 +5773,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Emphysema",
-        "llm-average": 9.31
+        "llm-average": 4.7
       },
       {
         "entity_name": "Nasal obstruction",
-        "llm-average": 8.91
+        "llm-average": 4.5
       },
       {
         "entity_name": "Glaucoma",
-        "llm-average": 8.35
+        "llm-average": 4.2
       },
       {
         "entity_name": "Chronic pulmonary obstruction",
-        "llm-average": 8.07
+        "llm-average": 4.0
       },
       {
         "entity_name": "Chronic bronchitis",
-        "llm-average": 7.34
+        "llm-average": 3.7
       },
       {
         "entity_name": "Asthma",
-        "llm-average": 6.45
+        "llm-average": 3.2
       },
       {
         "entity_name": "Seasonal allergy",
-        "llm-average": 6.41
+        "llm-average": 3.2
       }
     ]
   },
@@ -5809,11 +5809,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "vasculitis",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "autoimmune disease",
-        "llm-average": 7.86
+        "llm-average": 3.9
       }
     ]
   },
@@ -5825,31 +5825,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Hyperhidrosis",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "Peptic ulcer",
-        "llm-average": 12.01
+        "llm-average": 6.0
       },
       {
         "entity_name": "Cholecystitis",
-        "llm-average": 7.31
+        "llm-average": 3.7
       },
       {
         "entity_name": "Diarrhea",
-        "llm-average": 6.09
+        "llm-average": 3.0
       },
       {
         "entity_name": "Gastritis",
-        "llm-average": 6.08
+        "llm-average": 3.0
       },
       {
         "entity_name": "Ulcerative colitis",
-        "llm-average": 4.63
+        "llm-average": 2.3
       },
       {
         "entity_name": "Pancreatitis",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5861,15 +5861,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "hereditary fructose intolerance syndrome",
-        "llm-average": 18.92
+        "llm-average": 9.5
       },
       {
         "entity_name": "disease of metabolism",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "gastrointestinal system disease",
-        "llm-average": 4.83
+        "llm-average": 2.4
       }
     ]
   },
@@ -5881,11 +5881,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glomerulonephritis",
-        "llm-average": 14.45
+        "llm-average": 7.2
       },
       {
         "entity_name": "genetic disease",
-        "llm-average": 7.86
+        "llm-average": 3.9
       }
     ]
   },
@@ -5897,11 +5897,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Psoriasiform dermatitis",
-        "llm-average": 11.06
+        "llm-average": 5.5
       },
       {
         "entity_name": "Abnormality of the skin",
-        "llm-average": 4.3
+        "llm-average": 2.1
       }
     ]
   },
@@ -5913,31 +5913,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Vitiligo",
-        "llm-average": 17.33
+        "llm-average": 8.7
       },
       {
         "entity_name": "Hyperpigmentation of the skin",
-        "llm-average": 8.92
+        "llm-average": 4.5
       },
       {
         "entity_name": "Cafe-au-lait spot",
-        "llm-average": 8.72
+        "llm-average": 4.4
       },
       {
         "entity_name": "Cutaneous melanoma",
-        "llm-average": 8.51
+        "llm-average": 4.3
       },
       {
         "entity_name": "Nevus",
-        "llm-average": 6.04
+        "llm-average": 3.0
       },
       {
         "entity_name": "Hypopigmentation of the skin",
-        "llm-average": 5.35
+        "llm-average": 2.7
       },
       {
         "entity_name": "Inflammatory abnormality of the skin",
-        "llm-average": 4.1
+        "llm-average": 2.0
       }
     ]
   },
@@ -5949,19 +5949,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Acute megakaryocytic leukemia",
-        "llm-average": 12.3
+        "llm-average": 6.2
       },
       {
         "entity_name": "Chronic myelomonocytic leukemia",
-        "llm-average": 12.14
+        "llm-average": 6.1
       },
       {
         "entity_name": "Refractory anemia",
-        "llm-average": 6.42
+        "llm-average": 3.2
       },
       {
         "entity_name": "Elevated hepatic transaminase",
-        "llm-average": 3.58
+        "llm-average": 1.8
       }
     ]
   },
@@ -5973,15 +5973,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Neoplasm",
-        "llm-average": 11.42
+        "llm-average": 5.7
       },
       {
         "entity_name": "Chronic pain",
-        "llm-average": 8.58
+        "llm-average": 4.3
       },
       {
         "entity_name": "Pain",
-        "llm-average": 5.55
+        "llm-average": 2.8
       }
     ]
   },
@@ -5993,11 +5993,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "glomerulonephritis",
-        "llm-average": 13.38
+        "llm-average": 6.7
       },
       {
         "entity_name": "genetic disease",
-        "llm-average": 6.42
+        "llm-average": 3.2
       }
     ]
   },
@@ -6009,27 +6009,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "transient receptor potential cation channel subfamily M member 8",
-        "llm-average": 16.42
+        "llm-average": 8.2
       },
       {
         "entity_name": "transient receptor potential cation channel subfamily M member 2",
-        "llm-average": 15.17
+        "llm-average": 7.6
       },
       {
         "entity_name": "transient receptor potential cation channel subfamily M member 4",
-        "llm-average": 13.92
+        "llm-average": 7.0
       },
       {
         "entity_name": "nuclear receptor subfamily 1 group I member 3",
-        "llm-average": 13.22
+        "llm-average": 6.6
       },
       {
         "entity_name": "potassium calcium-activated channel subfamily N member 4",
-        "llm-average": 9.65
+        "llm-average": 4.8
       },
       {
         "entity_name": "cytochrome P450 family 3 subfamily A member 4",
-        "llm-average": 6.98
+        "llm-average": 3.5
       }
     ]
   },
@@ -6041,35 +6041,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Moxifloxacin",
-        "llm-average": 9.46
+        "llm-average": 4.7
       },
       {
         "entity_name": "Doxycycline",
-        "llm-average": 8.64
+        "llm-average": 4.3
       },
       {
         "entity_name": "Clindamycin",
-        "llm-average": 8.01
+        "llm-average": 4.0
       },
       {
         "entity_name": "Azithromycin",
-        "llm-average": 7.91
+        "llm-average": 4.0
       },
       {
         "entity_name": "Erythromycin",
-        "llm-average": 7.75
+        "llm-average": 3.9
       },
       {
         "entity_name": "D-Levofloxacin",
-        "llm-average": 7.62
+        "llm-average": 3.8
       },
       {
         "entity_name": "Ofloxacin",
-        "llm-average": 7.39
+        "llm-average": 3.7
       },
       {
         "entity_name": "Levofloxacin",
-        "llm-average": 7.19
+        "llm-average": 3.6
       }
     ]
   },
@@ -6081,23 +6081,23 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GOT2",
-        "llm-average": 12.27
+        "llm-average": 6.1
       },
       {
         "entity_name": "GOT1",
-        "llm-average": 10.06
+        "llm-average": 5.0
       },
       {
         "entity_name": "GPT2",
-        "llm-average": 9.56
+        "llm-average": 4.8
       },
       {
         "entity_name": "ALPL",
-        "llm-average": 8.67
+        "llm-average": 4.3
       },
       {
         "entity_name": "GPT",
-        "llm-average": 7.36
+        "llm-average": 3.7
       }
     ]
   },
@@ -6109,35 +6109,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Clodronic acid",
-        "llm-average": 14.52
+        "llm-average": 7.3
       },
       {
         "entity_name": "Cyanocobalamin",
-        "llm-average": 13.31
+        "llm-average": 6.7
       },
       {
         "entity_name": "Metronidazole",
-        "llm-average": 13.29
+        "llm-average": 6.6
       },
       {
         "entity_name": "Azathioprine",
-        "llm-average": 12.6
+        "llm-average": 6.3
       },
       {
         "entity_name": "Mesalazine",
-        "llm-average": 11.49
+        "llm-average": 5.7
       },
       {
         "entity_name": "Budesonide",
-        "llm-average": 10.49
+        "llm-average": 5.2
       },
       {
         "entity_name": "Sulfasalazine",
-        "llm-average": 9.28
+        "llm-average": 4.6
       },
       {
         "entity_name": "Prednisone",
-        "llm-average": 9.15
+        "llm-average": 4.6
       }
     ]
   },
@@ -6149,15 +6149,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Ranolazine",
-        "llm-average": 12.41
+        "llm-average": 6.2
       },
       {
         "entity_name": "Ziprasidone",
-        "llm-average": 8.67
+        "llm-average": 4.3
       },
       {
         "entity_name": "Phenylephrine",
-        "llm-average": 3.79
+        "llm-average": 1.9
       }
     ]
   },
@@ -6169,11 +6169,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "GPT2",
-        "llm-average": 8.94
+        "llm-average": 4.5
       },
       {
         "entity_name": "GPT",
-        "llm-average": 7.1
+        "llm-average": 3.5
       }
     ]
   },
@@ -6185,15 +6185,15 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "PLA2G1B",
-        "llm-average": 16.86
+        "llm-average": 8.4
       },
       {
         "entity_name": "C1R",
-        "llm-average": 13.27
+        "llm-average": 6.6
       },
       {
         "entity_name": "C1S",
-        "llm-average": 12.34
+        "llm-average": 6.2
       }
     ]
   },
@@ -6205,19 +6205,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dopamine",
-        "llm-average": 13.24
+        "llm-average": 6.6
       },
       {
         "entity_name": "Buspirone",
-        "llm-average": 12.27
+        "llm-average": 6.1
       },
       {
         "entity_name": "Epinephrine",
-        "llm-average": 11.48
+        "llm-average": 5.7
       },
       {
         "entity_name": "Dihydroergotamine",
-        "llm-average": 8.94
+        "llm-average": 4.5
       }
     ]
   },
@@ -6229,11 +6229,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Arginine",
-        "llm-average": 12.34
+        "llm-average": 6.2
       },
       {
         "entity_name": "D-arginine",
-        "llm-average": 11.88
+        "llm-average": 5.9
       }
     ]
   },
@@ -6245,27 +6245,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Methylprednisolone",
-        "llm-average": 13.03
+        "llm-average": 6.5
       },
       {
         "entity_name": "Prednisone",
-        "llm-average": 9.7
+        "llm-average": 4.9
       },
       {
         "entity_name": "Dexamethasone",
-        "llm-average": 9.6
+        "llm-average": 4.8
       },
       {
         "entity_name": "Prednisolone",
-        "llm-average": 8.17
+        "llm-average": 4.1
       },
       {
         "entity_name": "Hydrocortisone",
-        "llm-average": 5.81
+        "llm-average": 2.9
       },
       {
         "entity_name": "Betamethasone",
-        "llm-average": 5.71
+        "llm-average": 2.9
       }
     ]
   },
@@ -6277,27 +6277,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Bosentan",
-        "llm-average": 17.52
+        "llm-average": 8.8
       },
       {
         "entity_name": "Epoprostenol",
-        "llm-average": 16.09
+        "llm-average": 8.0
       },
       {
         "entity_name": "Cimetidine",
-        "llm-average": 5.87
+        "llm-average": 2.9
       },
       {
         "entity_name": "Ranitidine",
-        "llm-average": 5.64
+        "llm-average": 2.8
       },
       {
         "entity_name": "Dexamethasone",
-        "llm-average": 5.29
+        "llm-average": 2.6
       },
       {
         "entity_name": "Betamethasone",
-        "llm-average": 4.33
+        "llm-average": 2.2
       }
     ]
   },
@@ -6309,19 +6309,19 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Dorsomorphin",
-        "llm-average": 14.96
+        "llm-average": 7.5
       },
       {
         "entity_name": "Regorafenib",
-        "llm-average": 11.31
+        "llm-average": 5.7
       },
       {
         "entity_name": "Dasatinib",
-        "llm-average": 9.2
+        "llm-average": 4.6
       },
       {
         "entity_name": "Vandetanib",
-        "llm-average": 9.03
+        "llm-average": 4.5
       }
     ]
   },
@@ -6333,31 +6333,31 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "complement activation, classical pathway",
-        "llm-average": 13.37
+        "llm-average": 6.7
       },
       {
         "entity_name": "positive regulation of B cell activation",
-        "llm-average": 11.45
+        "llm-average": 5.7
       },
       {
         "entity_name": "B cell receptor signaling pathway",
-        "llm-average": 11.09
+        "llm-average": 5.5
       },
       {
         "entity_name": "phagocytosis, engulfment",
-        "llm-average": 9.04
+        "llm-average": 4.5
       },
       {
         "entity_name": "defense response to bacterium",
-        "llm-average": 7.72
+        "llm-average": 3.9
       },
       {
         "entity_name": "innate immune response",
-        "llm-average": 4.32
+        "llm-average": 2.2
       },
       {
         "entity_name": "phagocytosis, recognition",
-        "llm-average": 3.7
+        "llm-average": 1.8
       }
     ]
   },
@@ -6369,11 +6369,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "gastrin releasing peptide receptor",
-        "llm-average": 6.44
+        "llm-average": 3.2
       },
       {
         "entity_name": "neuromedin B receptor",
-        "llm-average": 6.2
+        "llm-average": 3.1
       }
     ]
   },
@@ -6385,11 +6385,11 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "respiratory burst",
-        "llm-average": 15.74
+        "llm-average": 7.9
       },
       {
         "entity_name": "positive regulation of cytosolic calcium ion concentration",
-        "llm-average": 10.5
+        "llm-average": 5.2
       }
     ]
   },
@@ -6401,35 +6401,35 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "peroxisome proliferator activated receptor alpha",
-        "llm-average": 20.0
+        "llm-average": 10.0
       },
       {
         "entity_name": "stearoyl-CoA desaturase",
-        "llm-average": 14.82
+        "llm-average": 7.4
       },
       {
         "entity_name": "solute carrier organic anion transporter family member 1B1",
-        "llm-average": 10.63
+        "llm-average": 5.3
       },
       {
         "entity_name": "lipoprotein lipase",
-        "llm-average": 10.5
+        "llm-average": 5.2
       },
       {
         "entity_name": "solute carrier family 2 member 4",
-        "llm-average": 9.01
+        "llm-average": 4.5
       },
       {
         "entity_name": "fatty acid binding protein 1",
-        "llm-average": 8.12
+        "llm-average": 4.1
       },
       {
         "entity_name": "kinase insert domain receptor",
-        "llm-average": 7.79
+        "llm-average": 3.9
       },
       {
         "entity_name": "MET proto-oncogene, receptor tyrosine kinase",
-        "llm-average": 4.49
+        "llm-average": 2.2
       }
     ]
   },
@@ -6441,27 +6441,27 @@ export const batch5: Question[] = [
     "llm_ranking": [
       {
         "entity_name": "Tie signaling pathway",
-        "llm-average": 14.52
+        "llm-average": 7.3
       },
       {
         "entity_name": "lymph vessel morphogenesis",
-        "llm-average": 13.27
+        "llm-average": 6.6
       },
       {
         "entity_name": "lymph circulation",
-        "llm-average": 8.78
+        "llm-average": 4.4
       },
       {
         "entity_name": "epidermis development",
-        "llm-average": 6.96
+        "llm-average": 3.5
       },
       {
         "entity_name": "cell adhesion",
-        "llm-average": 5.31
+        "llm-average": 2.7
       },
       {
         "entity_name": "tight junction organization",
-        "llm-average": 4.32
+        "llm-average": 2.2
       },
       {
         "entity_name": "gene expression",


### PR DESCRIPTION
Adjusts the "llm-average" values for multiple entities across 
different batches to reflect more accurate data. This change 
improves the reliability of the dataset and ensures consistency 
in the information provided for each entity.