### PR TITLE
fix: handle undefined entity_link in BatchForm component

### DIFF
--- a/components/Batch.tsx
+++ b/components/Batch.tsx
@@ -257,7 +257,7 @@ const BatchForm = ({onComplete, batchId, questions}: {
                         name={`responses.${responseIndex}.entity_responses.${entity.entity_name}`}
                         render={({field}) => (
                           <FormItem className="flex flex-row items-center justify-between">
-                            <FormLabel><Link href={entity.entity_link.toString()} target="_blank" className="flex gap-x-2 items-center">
+                            <FormLabel><Link href={entity.entity_link ? entity.entity_link.toString() : ''} target="_blank" className="flex gap-x-2 items-center">
                               {entity.entity_name} <LinkIcon size={16}/>
                             </Link></FormLabel>
                             <FormControl className="w-1/2">


### PR DESCRIPTION
Update the BatchForm component to safely handle cases where 
entity_link may be undefined. This change prevents potential 
errors